### PR TITLE
Simplified interface for Double jacobians

### DIFF
--- a/Sources/DiffSwiftTest/Core/JacobianProtocol.swift
+++ b/Sources/DiffSwiftTest/Core/JacobianProtocol.swift
@@ -1,11 +1,5 @@
-public protocol JacobianEvaluatable {
-  associatedtype ValueType = Double
-
-  var jacobianDim: Int {
-    get
-  }
-
-  func jacobianAt(n: Int, m: Int) -> ValueType
+public protocol JacobianEvaluatable: Differentiable, KeyPathIterable where TangentVector: KeyPathIterable {
+  
 }
 
 // A jacobian can be calculated by applying the pullback (reverse mode) to the basis vectors of
@@ -15,15 +9,44 @@ public protocol JacobianEvaluatable {
 // Swift doesn't yet completely support forward mode, so we'll only do the reverse mode version.
 
 /// Returns the jacobian matrix at the given point, represented as an array of columns.
-// Note: We could make this a bit fancier by defining a protocol for "has basis vectors",
-//       constraining B.TangentVector to have that protocol, and then automatically getting the
-//       basis vectors from that instead of taking them as an argument.
-func jacobian<A: Differentiable, B: Differentiable>(
+/// Note: We could make this a bit fancier by defining a protocol for "has basis vectors",
+///      constraining B.TangentVector to have that protocol, and then automatically getting the
+///      basis vectors from that instead of taking them as an argument.
+///
+/// Additional Notes
+/// ===================
+/// For example, if we have an array of `Point2` `map = [p1, p2, p3]` with an operation of `map[1] - map[0]`,
+/// the result will be
+/// ```
+/// J(ef) = [
+///  [ [-1.0, 0.0],
+///    [1.0, 0.0],
+///    [0.0, 0.0] ]
+///  [ [0.0, -1.0],
+///    [0.0, 1.0],
+///    [0.0, 0.0] ]
+///  ]
+///  ```
+/// So this is 2x3 but the data type is Point2.TangentVector.
+/// In "normal" Jacobian notation, we should have a 2x6.
+/// ```
+/// [ [-1.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+///   [0.0, -1.0, 0.0, 1.0, 0.0, 0.0] ]
+/// ```
+func jacobian<A: Differentiable, B: JacobianEvaluatable>(
   of f: @differentiable(A) -> B,
   at p: A,
-  basisVectors: [B.TangentVector]) -> [A.TangentVector] {
+  basisVectors: [B.TangentVector] = B.TangentVector.basisVectors()) -> [A.TangentVector] {
   let pb = pullback(at: p, in: f)
   return basisVectors.map { pb($0) }
+}
+
+
+func jacobian<A: Differentiable>(
+  of f: @differentiable(A) -> Double,
+  at p: A) -> [A.TangentVector] {
+  let pb = pullback(at: p, in: f)
+  return [1.0].map { pb($0) }
 }
 
 func jacobian<A: Differentiable>(

--- a/Sources/DiffSwiftTest/Core/JacobianProtocol.swift
+++ b/Sources/DiffSwiftTest/Core/JacobianProtocol.swift
@@ -9,16 +9,13 @@ public protocol JacobianEvaluatable: Differentiable, KeyPathIterable where Tange
 // Swift doesn't yet completely support forward mode, so we'll only do the reverse mode version.
 
 /// Returns the jacobian matrix at the given point, represented as an array of columns.
-/// Note: We could make this a bit fancier by defining a protocol for "has basis vectors",
-///      constraining B.TangentVector to have that protocol, and then automatically getting the
-///      basis vectors from that instead of taking them as an argument.
 ///
 /// Additional Notes
 /// ===================
-/// For example, if we have an array of `Point2` `map = [p1, p2, p3]` with an operation of `map[1] - map[0]`,
-/// the result will be
+/// For example, if we have an array of `Point2` `pts = [p1, p2, p3]` with an operation of `pts[1] - pts[0]`,
+/// the result should be
 /// ```
-/// J(ef) = [
+/// J_f(pts) = [
 ///  [ [-1.0, 0.0],
 ///    [1.0, 0.0],
 ///    [0.0, 0.0] ]
@@ -28,7 +25,7 @@ public protocol JacobianEvaluatable: Differentiable, KeyPathIterable where Tange
 ///  ]
 ///  ```
 /// So this is 2x3 but the data type is Point2.TangentVector.
-/// In "normal" Jacobian notation, we should have a 2x6.
+/// In "flattened" Jacobian notation, we should have a 2x6.
 /// ```
 /// [ [-1.0, 0.0, 1.0, 0.0, 0.0, 0.0]
 ///   [0.0, -1.0, 0.0, 1.0, 0.0, 0.0] ]

--- a/Sources/DiffSwiftTest/Geometry/Point2.swift
+++ b/Sources/DiffSwiftTest/Geometry/Point2.swift
@@ -1,7 +1,7 @@
 import TensorFlow
 
 /// Point2 class is the new Swift type for the 2D vector space R^2
-public struct Point2: Equatable, Differentiable, KeyPathIterable {
+public struct Point2: Equatable, Differentiable, JacobianEvaluatable {
   public var x, y: Double
 
   @differentiable
@@ -14,7 +14,7 @@ public struct Point2: Equatable, Differentiable, KeyPathIterable {
   public var magnitude: Double {
     (x * x + y * y).squareRoot()
   }
-
+  
   public static func == (lhs: Point2, rhs: Point2) -> Bool {
     (lhs.x, lhs.y) == (rhs.x, rhs.y)
   }
@@ -27,5 +27,10 @@ public struct Point2: Equatable, Differentiable, KeyPathIterable {
   @differentiable
   public static prefix func - (a: Point2) -> Point2 {
     Point2(-a.x, -a.y)
+  }
+  
+  @differentiable
+  public static func - (a: Point2, b: Point2) -> Point2 {
+    Point2(a.x - b.x, a.y - b.y)
   }
 }

--- a/Sources/DiffSwiftTest/Geometry/Pose2.swift
+++ b/Sources/DiffSwiftTest/Geometry/Pose2.swift
@@ -1,6 +1,6 @@
 /// Pose2 class is the new Swift type for the SE(2) manifold of 2D Euclidean
 /// Poses
-public struct Pose2: Equatable, Differentiable, KeyPathIterable {
+public struct Pose2: Equatable, Differentiable, JacobianEvaluatable {
   public var t_: Point2
   public var rot_: Rot2
 

--- a/Tests/DiffSwiftTestTests/Core/JacobianProtocolTests.swift
+++ b/Tests/DiffSwiftTestTests/Core/JacobianProtocolTests.swift
@@ -21,7 +21,7 @@ class JacobianProtocolTests: XCTestCase {
       return d.rot_.theta * d.rot_.theta + d.t_.x * d.t_.x + d.t_.y * d.t_.y
     }
 
-    let j = jacobian(of: ef, at: map, basisVectors: Array(repeating: 1.0, count: 1))
+    let j = jacobian(of: ef, at: map)
     print("J(ef) = \(j[0].base as AnyObject)")
     for item in j[0] {
       XCTAssertEqual(item, Pose2.TangentVector.zero)
@@ -38,7 +38,8 @@ class JacobianProtocolTests: XCTestCase {
       return d.rot_.theta * d.rot_.theta + d.t_.x * d.t_.x + d.t_.y * d.t_.y
     }
 
-    let j = jacobian(of: ef, at: map, basisVectors: Array(repeating: 1.0, count: 1))
+    let j = jacobian(of: ef, at: map)
+    
     print("j(ef) = \(j[0].base as AnyObject)")
 
     print("Pose2.TangentVector.basisVectors() = \(Pose2.TangentVector.basisVectors() as AnyObject)")
@@ -46,6 +47,48 @@ class JacobianProtocolTests: XCTestCase {
     print("J(ef) = [")
     for r in j[0] {
       print(r.recursivelyAllKeyPaths(to:Double.self).map {r[keyPath: $0]})
+    }
+    print("]")
+  }
+    
+  func testJacobian2D() {
+    let p1 = Point2(0, 1), p2 = Point2(0,0), p3 = Point2(0,0);
+    let map: [Point2] = [p1, p2, p3]
+
+    let ef: @differentiable(_ map: [Point2]) -> Point2 = { (_ map: [Point2]) -> Point2 in
+      let d = map[1] - map[0]
+
+      return d
+    }
+
+    let j = jacobian(of: ef, at: map)
+    
+    print("j(ef) = \(j as AnyObject)")
+
+    print("Point2.TangentVector.basisVectors() = \(Point2.TangentVector.basisVectors() as AnyObject)")
+    
+    /* Example output:
+      J(ef) = [
+      [ [-1.0, 0.0],
+        [1.0, 0.0],
+        [0.0, 0.0] ]
+      [ [0.0, -1.0],
+        [0.0, 1.0],
+        [0.0, 0.0] ]
+      ]
+     So this is 2x3 but the data type is Point2.TangentVector.
+     In "normal" Jacobian notation, we should have a 2x6.
+     [ [-1.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+       [0.0, -1.0, 0.0, 1.0, 0.0, 0.0] ]
+    */
+    print("J(ef) = [")
+    for c in j {
+      print("[")
+      for r in c {
+        print(r.recursivelyAllKeyPaths(to:Double.self).map {r[keyPath: $0]})
+        print(",")
+      }
+      print("]")
     }
     print("]")
   }

--- a/Tests/DiffSwiftTestTests/Core/JacobianProtocolTests.swift
+++ b/Tests/DiffSwiftTestTests/Core/JacobianProtocolTests.swift
@@ -9,66 +9,74 @@ class JacobianProtocolTests: XCTestCase {
     ("testJacobianPose2Trivial", testJacobianPose2Trivial),
   ]
 
-  // --------------------------------------------------------------------------
-  // testConcat
+  /// tests a simple identity Jacobian for Pose2
   func testJacobianPose2Identity() {
     let wT1 = Pose2(1, 0, 3.1415926 / 2.0), wT2 = Pose2(1, 0, 3.1415926 / 2.0)
-    let map: [Pose2] = [wT1, wT2]
+    let pts: [Pose2] = [wT1, wT2]
 
-    let ef: @differentiable(_ map: [Pose2]) -> Double = { (_ map: [Pose2]) -> Double in
-      let d = between(map[0], map[1])
+    let f: @differentiable(_ pts: [Pose2]) -> Double = { (_ pts: [Pose2]) -> Double in
+      let d = between(pts[0], pts[1])
 
       return d.rot_.theta * d.rot_.theta + d.t_.x * d.t_.x + d.t_.y * d.t_.y
     }
 
-    let j = jacobian(of: ef, at: map)
-    print("J(ef) = \(j[0].base as AnyObject)")
+    let j = jacobian(of: f, at: pts)
+    // print("J(f) = \(j[0].base as AnyObject)")
     for item in j[0] {
       XCTAssertEqual(item, Pose2.TangentVector.zero)
     }
   }
 
   func testJacobianPose2Trivial() {
-    let wT1 = Pose2(1, 0, 3.1415926 / 2.0), wT2 = Pose2(1, 1, -3.1415926 / 2.0)
-    let map: [Pose2] = [wT1, wT2]
+    // Values taken from GTSAM `testPose2.cpp`
+    let wT1 = Pose2(1, 2, .pi/2.0), wT2 = Pose2(-1, 4, .pi)
+    let pts: [Pose2] = [wT1, wT2]
 
-    let ef: @differentiable(_ map: [Pose2]) -> Double = { (_ map: [Pose2]) -> Double in
-      let d = between(map[0], map[1])
-
-      return d.rot_.theta * d.rot_.theta + d.t_.x * d.t_.x + d.t_.y * d.t_.y
-    }
-
-    let j = jacobian(of: ef, at: map)
-    
-    print("j(ef) = \(j[0].base as AnyObject)")
-
-    print("Pose2.TangentVector.basisVectors() = \(Pose2.TangentVector.basisVectors() as AnyObject)")
-
-    print("J(ef) = [")
-    for r in j[0] {
-      print(r.recursivelyAllKeyPaths(to:Double.self).map {r[keyPath: $0]})
-    }
-    print("]")
-  }
-    
-  func testJacobian2D() {
-    let p1 = Point2(0, 1), p2 = Point2(0,0), p3 = Point2(0,0);
-    let map: [Point2] = [p1, p2, p3]
-
-    let ef: @differentiable(_ map: [Point2]) -> Point2 = { (_ map: [Point2]) -> Point2 in
-      let d = map[1] - map[0]
+    let f: @differentiable(_ pts: [Pose2]) -> Pose2 = { (_ pts: [Pose2]) -> Pose2 in
+      let d = between(pts[0], pts[1])
 
       return d
     }
 
-    let j = jacobian(of: ef, at: map)
+    let j = jacobian(of: f, at: pts)
     
-    print("j(ef) = \(j as AnyObject)")
+    let expected: [Array<Pose2>.TangentVector] = [
+      [Pose2.TangentVector(t_: Point2.TangentVector(x: 0, y: -1.0), rot_: 2.0), Pose2.TangentVector(t_: Point2.TangentVector(x: 0, y: 1.0), rot_: 0.0)],
+      [Pose2.TangentVector(t_: Point2.TangentVector(x: 1.0, y: 0), rot_: -2.0), Pose2.TangentVector(t_: Point2.TangentVector(x: -1.0, y: 0), rot_: 0.0)],
+      [Pose2.TangentVector(t_: Point2.TangentVector(x: 0.0, y: 0.0), rot_: -1.0), Pose2.TangentVector(t_: Point2.TangentVector(x: 0.0, y: 0.0), rot_: 1.0)]
+    ]
+    
+    // TODO(fan): Find a better way to do approximate comparison
+    XCTAssert(
+      expected.recursivelyAllKeyPaths(to:Double.self)
+        .map {j[keyPath: $0] - expected[keyPath: $0]}
+        .reduce(0.0, {$0 + abs($1)}) < 1e-10
+    )
+  }
+  
+  /// tests the Jacobian of a 2D function
+  func testJacobian2D() {
+    let p1 = Point2(0, 1), p2 = Point2(0,0), p3 = Point2(0,0);
+    let pts: [Point2] = [p1, p2, p3]
 
-    print("Point2.TangentVector.basisVectors() = \(Point2.TangentVector.basisVectors() as AnyObject)")
+    // TODO(fan): Find a better way to do this
+    // If we remove the type we will have:
+    // a '@differentiable' function can only be formed from
+    // a reference to a 'func' or a literal closure
+    let f: @differentiable(_ pts: [Point2]) -> Point2 = { (_ pts: [Point2]) -> Point2 in
+      let d = pts[1] - pts[0]
+
+      return d
+    }
+
+    let j = jacobian(of: f, at: pts)
+    
+    // print("j(f) = \(j as AnyObject)")
+
+    // print("Point2.TangentVector.basisVectors() = \(Point2.TangentVector.basisVectors() as AnyObject)")
     
     /* Example output:
-      J(ef) = [
+      J(f) = [
       [ [-1.0, 0.0],
         [1.0, 0.0],
         [0.0, 0.0] ]
@@ -81,7 +89,13 @@ class JacobianProtocolTests: XCTestCase {
      [ [-1.0, 0.0, 1.0, 0.0, 0.0, 0.0]
        [0.0, -1.0, 0.0, 1.0, 0.0, 0.0] ]
     */
-    print("J(ef) = [")
+    
+    let expected: [Array<Point2>.TangentVector] = [
+        [Point2.TangentVector(x: -1.0, y: 0.0), Point2.TangentVector(x: 1.0, y: 0.0), Point2.TangentVector(x: 0.0, y: 0.0)],
+        [Point2.TangentVector(x: 0.0, y: -1.0), Point2.TangentVector(x: 0.0, y: 1.0), Point2.TangentVector(x: 0.0, y: 0.0)]
+    ]
+    /*
+    print("J_f(p) = [")
     for c in j {
       print("[")
       for r in c {
@@ -91,5 +105,7 @@ class JacobianProtocolTests: XCTestCase {
       print("]")
     }
     print("]")
+    */
+    XCTAssertEqual(expected, j)
   }
 }


### PR DESCRIPTION
This PR added simple inference for `basisVectors` so you can just write `jacobian(of: at:)` instead of `jacobian(of: at: basisVectors:)`.