### PR TITLE
Unified jacobian protocol

### DIFF
--- a/Sources/SwiftFusion/Core/Jacobian.swift
+++ b/Sources/SwiftFusion/Core/Jacobian.swift
@@ -1,7 +1,3 @@
-public protocol JacobianEvaluatable: Differentiable, KeyPathIterable where TangentVector: KeyPathIterable {
-  
-}
-
 // A jacobian can be calculated by applying the pullback (reverse mode) to the basis vectors of
 // the result tangent type, or by applying the differential (forward mode) to the basis vectors of
 // the input tangent type.
@@ -30,39 +26,11 @@ public protocol JacobianEvaluatable: Differentiable, KeyPathIterable where Tange
 /// [ [-1.0, 0.0, 1.0, 0.0, 0.0, 0.0]
 ///   [0.0, -1.0, 0.0, 1.0, 0.0, 0.0] ]
 /// ```
-func jacobian<A: Differentiable, B: JacobianEvaluatable>(
+func jacobian<A: Differentiable, B: TangentStandardBasis>(
   of f: @differentiable(A) -> B,
   at p: A,
-  basisVectors: [B.TangentVector] = B.TangentVector.basisVectors()) -> [A.TangentVector] {
+  basisVectors: [B.TangentVector] = B.tangentStandardBasis
+) -> [A.TangentVector] {
   let pb = pullback(at: p, in: f)
   return basisVectors.map { pb($0) }
-}
-
-
-func jacobian<A: Differentiable>(
-  of f: @differentiable(A) -> Double,
-  at p: A) -> [A.TangentVector] {
-  let pb = pullback(at: p, in: f)
-  return [1.0].map { pb($0) }
-}
-
-func jacobian<A: Differentiable>(
-  of f: @differentiable(A) -> Double,
-  at p: A,
-  basisVectors: [Double]) -> [A.TangentVector] {
-  let pb = pullback(at: p, in: f)
-  return basisVectors.map { pb($0) }
-}
-
-public extension KeyPathIterable where Self: AdditiveArithmetic {
-  // Note: Assumes that the scalars are Double.
-  static func basisVectors() -> [Self] {
-    var vectors: [Self] = []
-    for kp in zero.recursivelyAllWritableKeyPaths(to: Double.self) {
-      var vector = zero
-      vector[keyPath: kp] = 1.0
-      vectors.append(vector)
-    }
-    return vectors
-  }
 }

--- a/Sources/SwiftFusion/Core/StandardBasis.swift
+++ b/Sources/SwiftFusion/Core/StandardBasis.swift
@@ -1,0 +1,27 @@
+/// A differentiable type whose `TangentVector` type has an identified "standard" basis.
+// TODO(TF-1227): It would be simpler to have a `StandardBasis` protocol, and conform
+// `TangentVector` to that, so we should do that after TF-1227 is resolved.
+public protocol TangentStandardBasis: Differentiable {
+  /// The identified set of "standard" basis vectors.
+  static var tangentStandardBasis: [TangentVector] { get }
+}
+
+extension Double: TangentStandardBasis {
+  public static var tangentStandardBasis: [Double] { [1.0] }
+}
+
+/// Provides an implementation of `tangentStandardBasis` so that it is easy to conform types to
+/// `TangentStandardBasis`.
+///
+/// Note: Assumes that scalars are `Double`.
+extension Differentiable where TangentVector: KeyPathIterable {
+  public static var tangentStandardBasis: [TangentVector] {
+    var vectors: [TangentVector] = []
+    for kp in TangentVector.zero.recursivelyAllWritableKeyPaths(to: Double.self) {
+      var vector = TangentVector.zero
+      vector[keyPath: kp] = 1.0
+      vectors.append(vector)
+    }
+    return vectors
+  }
+}

--- a/Sources/SwiftFusion/Geometry/Point2.swift
+++ b/Sources/SwiftFusion/Geometry/Point2.swift
@@ -1,7 +1,7 @@
 import TensorFlow
 
 /// Point2 class is the new Swift type for the 2D vector space R^2
-public struct Point2: Equatable, Differentiable, JacobianEvaluatable {
+public struct Point2: Equatable, Differentiable, KeyPathIterable, TangentStandardBasis {
   public var x, y: Double
 
   @differentiable

--- a/Sources/SwiftFusion/Geometry/Pose2.swift
+++ b/Sources/SwiftFusion/Geometry/Pose2.swift
@@ -1,6 +1,6 @@
 /// Pose2 class is the new Swift type for the SE(2) manifold of 2D Euclidean
 /// Poses
-public struct Pose2: Equatable, Differentiable, JacobianEvaluatable {
+public struct Pose2: Equatable, Differentiable, KeyPathIterable, TangentStandardBasis {
   public var t_: Point2
   public var rot_: Rot2
 

--- a/Sources/SwiftFusion/Geometry/Rot2.swift
+++ b/Sources/SwiftFusion/Geometry/Rot2.swift
@@ -99,6 +99,10 @@ public struct Rot2: Equatable, Differentiable, KeyPathIterable {
   }
 }
 
+extension Rot2: TangentStandardBasis {
+  public static var tangentStandardBasis: [Double] { [1.0] }
+}
+
 infix operator *: MultiplicationPrecedence
 public extension Rot2 {
   static func == (lhs: Rot2, rhs: Rot2) -> Bool {

--- a/Tests/SwiftFusionTests/Core/JacobianTests.swift
+++ b/Tests/SwiftFusionTests/Core/JacobianTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import SwiftFusion
 
-class JacobianProtocolTests: XCTestCase {
+class JacobianTests: XCTestCase {
   static var allTests = [
     ("testJacobianPose2Identity", testJacobianPose2Identity),
     ("testJacobianPose2Trivial", testJacobianPose2Trivial),

--- a/Tests/SwiftFusionTests/XCTestManifests.swift
+++ b/Tests/SwiftFusionTests/XCTestManifests.swift
@@ -5,7 +5,7 @@ public func allTests() -> [XCTestCaseEntry] {
   [
     testCase(Rot2Tests.allTests),
     testCase(Pose2Tests.allTests),
-    testCase(JacobianProtocolTests.allTests),
+    testCase(JacobianTests.allTests),
   ]
 }
 #endif


### PR DESCRIPTION
This adds a `TangentStandardBasis` protocol that defines a basis for the tangent space of a type. This protocol allows us to unify all the `jacobian` functions into one function that works for all types.

It would be simpler to have a `StandardBasis` protocol that defines a basis for a vector space, and then conform `TangentVector` to `StandardBasis`. But we can't do that right now because of https://bugs.swift.org/browse/TF-1227. I think we should do that after https://bugs.swift.org/browse/TF-1227 gets fixed.

This resolves #13.