### PR TITLE
small fixes to public interface

### DIFF
--- a/Sources/SwiftFusion/Core/Jacobian.swift
+++ b/Sources/SwiftFusion/Core/Jacobian.swift
@@ -26,7 +26,7 @@
 /// [ [-1.0, 0.0, 1.0, 0.0, 0.0, 0.0]
 ///   [0.0, -1.0, 0.0, 1.0, 0.0, 0.0] ]
 /// ```
-func jacobian<A: Differentiable, B: TangentStandardBasis>(
+public func jacobian<A: Differentiable, B: TangentStandardBasis>(
   of f: @differentiable(A) -> B,
   at p: A,
   basisVectors: [B.TangentVector] = B.tangentStandardBasis

--- a/Sources/SwiftFusion/Geometry/Pose2.swift
+++ b/Sources/SwiftFusion/Geometry/Pose2.swift
@@ -20,13 +20,14 @@ public struct Pose2: Equatable, Differentiable, KeyPathIterable, TangentStandard
     (lhs.t_, lhs.rot_) == (rhs.t_, rhs.rot_)
   }
 
+  @differentiable
   public static func * (a: Pose2, b: Pose2) -> Pose2 {
     Pose2(a.rot_ * b.rot_, a.t_ + a.rot_ * b.t_)
   }
 }
 
 @differentiable
-func inverse(_ p: Pose2) -> Pose2 {
+public func inverse(_ p: Pose2) -> Pose2 {
   Pose2(inverse(p.rot_), p.rot_.unrotate(-p.t_))
 }
 

--- a/Sources/SwiftFusion/Geometry/Rot2.swift
+++ b/Sources/SwiftFusion/Geometry/Rot2.swift
@@ -33,7 +33,7 @@ public struct Rot2: Equatable, Differentiable, KeyPathIterable {
   private var c_, s_: Double
 
   @differentiable
-  var c: Double {
+  public var c: Double {
     c_
   }
 
@@ -44,7 +44,7 @@ public struct Rot2: Equatable, Differentiable, KeyPathIterable {
   }
 
   @differentiable
-  var s: Double {
+  public var s: Double {
     s_
   }
 
@@ -145,7 +145,7 @@ public extension Rot2 {
 
 extension Rot2: CustomDebugStringConvertible {
   public var debugDescription: String {
-    "Rot2(theta: \(theta)"
+    "Rot2(theta: \(theta))"
   }
 }
 

--- a/Tests/SwiftFusionTests/Core/JacobianTests.swift
+++ b/Tests/SwiftFusionTests/Core/JacobianTests.swift
@@ -1,7 +1,7 @@
 import Foundation
 import XCTest
 
-@testable import SwiftFusion
+import SwiftFusion
 
 class JacobianTests: XCTestCase {
   static var allTests = [

--- a/Tests/SwiftFusionTests/Geometry/Pose2Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Pose2Tests.swift
@@ -1,4 +1,4 @@
-@testable import SwiftFusion
+import SwiftFusion
 import XCTest
 
 final class Pose2Tests: XCTestCase {

--- a/Tests/SwiftFusionTests/Geometry/Rot2Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Rot2Tests.swift
@@ -1,7 +1,6 @@
 // This file tests for the various identities in Rot2
 
-@testable import SwiftFusion
-// @testable import SwiftFusion.Geometry.Rot2
+import SwiftFusion
 
 import XCTest
 


### PR DESCRIPTION
* Adds `public` to some properties and functions that clients (e.g. some example colab notebooks that I am writing) might want to use.
* Removes `@testable import` from the tests, so that the tests test the public interface. If there's ever a case where we really do want to test a private function we could put that test in a separate file.
* Adds `@differentiable` to `Pose2.*`.
* Adds missing closing paren to `Rot2.debugDescription`.