### PR TITLE
`TensorFactor` protocol

### DIFF
--- a/Sources/SwiftFusion/Core/TensorConvertible.swift
+++ b/Sources/SwiftFusion/Core/TensorConvertible.swift
@@ -1,0 +1,67 @@
+import TensorFlow
+
+/// A type that is convertible to/from a `Tensor`.
+public protocol TensorConvertible: Differentiable {
+  /// Create `Self` from a `Tensor` of shape `[dimension]`.
+  @differentiable init(_ tensor: Tensor<Double>)
+
+  /// A `Tensor` of shape `[dimension]`.
+  var tensor: Tensor<Double> { @differentiable get }
+
+  /// The dimension of this type.
+  static var dimension: Int { get }
+}
+
+/// A pair of `TensorConvertible` types.
+///
+/// Useful for defining factors that take two values.
+public struct TensorConvertiblePair<A: TensorConvertible, B: TensorConvertible>: TensorConvertible {
+  public var a: A
+  public var b: B
+
+  public init(_ a: A, _ b: B) {
+    self.a = a
+    self.b = b
+  }
+
+  @differentiable
+  public init(_ tensor: Tensor<Double>) {
+    self.a = A(tensor.slice(lowerBounds: [0], upperBounds: [A.dimension]))
+    self.b = B(tensor.slice(lowerBounds: [A.dimension], upperBounds: [Self.dimension]))
+  }
+
+  @differentiable
+  public var tensor: Tensor<Double> {
+    Tensor(concatenating: [a.tensor, b.tensor])
+  }
+
+  public static var dimension: Int { A.dimension + B.dimension }
+
+  public struct TangentVector: AdditiveArithmetic, Differentiable {
+    public var a: A.TangentVector
+    public var b: B.TangentVector
+
+    public init(_ a: A.TangentVector, _ b: B.TangentVector) {
+      self.a = a
+      self.b = b
+    }
+  }
+  public mutating func move(along direction: TangentVector) { fatalError() }
+}
+
+extension TensorConvertiblePair.TangentVector: TensorConvertible
+  where A.TangentVector: TensorConvertible, B.TangentVector: TensorConvertible
+{
+  @differentiable
+  public init(_ tensor: Tensor<Double>) {
+    self.a = A.TangentVector(tensor.slice(lowerBounds: [0], upperBounds: [A.dimension]))
+    self.b = B.TangentVector(tensor.slice(lowerBounds: [A.dimension], upperBounds: [Self.dimension]))
+  }
+
+  @differentiable
+  public var tensor: Tensor<Double> {
+    Tensor(concatenating: [a.tensor, b.tensor])
+  }
+
+  public static var dimension: Int { A.dimension + B.dimension }
+}

--- a/Sources/SwiftFusion/Core/Vector.swift
+++ b/Sources/SwiftFusion/Core/Vector.swift
@@ -83,7 +83,7 @@ extension Vector1: ElementaryFunctions {
 }
 
 /// Conversion to/from tensor.
-extension Vector1 {
+extension Vector1: TensorConvertible {
   /// A `Tensor` with shape `[1]` whose elements are the elements of `self`.
   @differentiable
   public var tensor: Tensor<Double> {
@@ -100,6 +100,8 @@ extension Vector1 {
     self.x = tensor[0].scalarized()
 // ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 100)
   }
+
+  public static var dimension: Int { 1 }
 }
 
 // ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 6)
@@ -195,7 +197,7 @@ extension Vector2: ElementaryFunctions {
 }
 
 /// Conversion to/from tensor.
-extension Vector2 {
+extension Vector2: TensorConvertible {
   /// A `Tensor` with shape `[2]` whose elements are the elements of `self`.
   @differentiable
   public var tensor: Tensor<Double> {
@@ -214,6 +216,8 @@ extension Vector2 {
     self.y = tensor[1].scalarized()
 // ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 100)
   }
+
+  public static var dimension: Int { 2 }
 }
 
 // ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 6)
@@ -323,7 +327,7 @@ extension Vector3: ElementaryFunctions {
 }
 
 /// Conversion to/from tensor.
-extension Vector3 {
+extension Vector3: TensorConvertible {
   /// A `Tensor` with shape `[3]` whose elements are the elements of `self`.
   @differentiable
   public var tensor: Tensor<Double> {
@@ -344,5 +348,7 @@ extension Vector3 {
     self.z = tensor[2].scalarized()
 // ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 100)
   }
+
+  public static var dimension: Int { 3 }
 }
 

--- a/Sources/SwiftFusion/Core/Vector.swift.gyb
+++ b/Sources/SwiftFusion/Core/Vector.swift.gyb
@@ -81,7 +81,7 @@ extension Vector${dim}: ElementaryFunctions {
 }
 
 /// Conversion to/from tensor.
-extension Vector${dim} {
+extension Vector${dim}: TensorConvertible {
   /// A `Tensor` with shape `[${dim}]` whose elements are the elements of `self`.
   @differentiable
   public var tensor: Tensor<Double> {
@@ -98,6 +98,8 @@ extension Vector${dim} {
     self.${coordinate} = tensor[${index}].scalarized()
     % end
   }
+
+  public static var dimension: Int { ${dim} }
 }
 
 % end

--- a/Sources/SwiftFusion/FactorGraph/Factor.swift
+++ b/Sources/SwiftFusion/FactorGraph/Factor.swift
@@ -1,0 +1,36 @@
+import TensorFlow
+
+/// Computes measurement errors.
+public protocol Factor {
+  associatedtype Input: TensorConvertible where Input.TangentVector: TensorConvertible
+  associatedtype Output: TensorConvertible where Output.TangentVector: TensorConvertible
+
+  /// Returns the `error` of the factor.
+  @differentiable
+  func error(_ input: Input) -> Output
+}
+
+/// A `Factor` whose input and output types are `Tensor`s.
+public protocol TensorFactor {
+  /// Returns the `error` of the factor.
+  @differentiable
+  func error(tensorValues: Tensor<Double>) -> Tensor<Double>
+}
+
+extension Factor {
+  @differentiable
+  public func error(tensorValues: Tensor<Double>) -> Tensor<Double> {
+    return error(Input(tensorValues)).tensor
+  }
+
+  // TODO(TF-1234): This custom derivative should not be necessary.
+  @derivative(of: error(tensorValues:))
+  @usableFromInline
+  func errorWithPullback(tensorValues: Tensor<Double>) -> (
+    value: Tensor<Double>,
+    pullback: (Tensor<Double>) -> Tensor<Double>
+  ) {
+    let (err, pb) = valueWithPullback(at: Input(tensorValues), in: error)
+    return (value: err.tensor, pullback: { pb(Output.TangentVector($0)).tensor })
+  }
+}

--- a/Tests/SwiftFusionTests/FactorGraph/FactorTests.swift
+++ b/Tests/SwiftFusionTests/FactorGraph/FactorTests.swift
@@ -1,0 +1,55 @@
+import TensorFlow
+import XCTest
+
+import SwiftFusion
+
+final class FactorTests: XCTestCase {
+  /// Test that `Factor` computes the correct error and jacobian for a simple "identity" factor.
+  func testFactorIdentity() {
+    struct IdentityFactor: Factor, TensorFactor {
+      @differentiable func error(_ input: Vector2) -> Vector2 {
+        input
+      }
+    }
+    for _ in 0..<10 {
+      let value = Vector2(Tensor<Double>(randomNormal: [2]))
+      assertFactor(
+        IdentityFactor(),
+        at: value.tensor,
+        expectedError: value.tensor,
+        expectedJacobian: eye(rowCount: 2),
+        accuracy: 1e-10
+      )
+    }
+  }
+
+  /// Test that `Factor` computes the correct error and jacobian for a simple "difference" factor.
+  func testFactorDifference() {
+    struct DifferenceFactor: Factor, TensorFactor {
+      typealias Input = TensorConvertiblePair<Vector2, Vector2>
+      typealias Output = Vector2
+      @differentiable func error(_ input: TensorConvertiblePair<Vector2, Vector2>) -> Vector2 {
+        input.a - input.b
+      }
+    }
+    for _ in 0..<10 {
+      let value = DifferenceFactor.Input(
+        Vector2(Tensor<Double>(randomNormal: [2])),
+        Vector2(Tensor<Double>(randomNormal: [2]))
+      )
+      assertFactor(
+        DifferenceFactor(),
+        at: value.tensor,
+        expectedError: (value.a - value.b).tensor,
+        expectedJacobian: Tensor(concatenating: [eye(rowCount: 2), -eye(rowCount: 2)], alongAxis: 1),
+        accuracy: 1e-10
+      )
+    }
+  }
+
+
+  static var allTests = [
+    ("testFactorIdentity", testFactorIdentity),
+    ("testFactorDifference", testFactorDifference)
+  ]
+}

--- a/Tests/SwiftFusionTests/TestUtilities.swift
+++ b/Tests/SwiftFusionTests/TestUtilities.swift
@@ -1,14 +1,20 @@
+import SwiftFusion
 import TensorFlow
 import XCTest
 
 /// Asserts that `x` and `y` have the same shape and that their values have absolute difference
 /// less than `accuracy`.
 func assertEqual<T: TensorFlowFloatingPoint>(
-  _ x: Tensor<T>, _ y: Tensor<T>, accuracy: T, file: StaticString = #file, line: UInt = #line
+  _ x: Tensor<T>,
+  _ y: Tensor<T>,
+  accuracy: T,
+  message: String = "",
+  file: StaticString = #file,
+  line: UInt = #line
 ) {
   guard x.shape == y.shape else {
     XCTFail(
-      "shape mismatch: \(x.shape) is not equal to \(y.shape)",
+      "\(message)shape mismatch: \(x.shape) is not equal to \(y.shape)",
       file: file,
       line: line
     )
@@ -16,7 +22,53 @@ func assertEqual<T: TensorFlowFloatingPoint>(
   }
   XCTAssert(
     abs(x - y).max().scalarized() < accuracy,
-    "value mismatch:\n\(x)\nis not equal to\n\(y)\nwith accuracy \(accuracy)",
+    "\(message)value mismatch:\n\(x)\nis not equal to\n\(y)\nwith accuracy \(accuracy)",
+    file: file,
+    line: line
+  )
+}
+
+/// TODO(document)
+func assertFactor<F: TensorFactor>(
+  _ factor: F,
+  at value: Tensor<Double>,
+  expectedError: Tensor<Double>,
+  expectedJacobian: Tensor<Double>,
+  accuracy: Double,
+  file: StaticString = #file,
+  line: UInt = #line
+) {
+  let actualError = factor.error(tensorValues: value)
+  assertEqual(
+    actualError,
+    expectedError,
+    accuracy: accuracy,
+    message: "unexpected `error`: ",
+    file: file,
+    line: line
+  )
+
+  let (actualError2, actualPullback) = valueWithPullback(at: value, in: factor.error)
+  assertEqual(
+    actualError2,
+    expectedError,
+    accuracy: accuracy,
+    message: "unexpected `error` from `errorWithPullback`: ",
+    file: file,
+    line: line
+  )
+  let expectedJacobianRowCount = expectedJacobian.shape[0]
+  let actualJacobianRows = (0..<expectedJacobianRowCount).map { rowIndex -> Tensor<Double> in
+    var basisVector = Tensor<Double>(zeros: [expectedJacobianRowCount])
+    basisVector[rowIndex] = Tensor(1)
+    return actualPullback(basisVector)
+  }
+  let actualJacobian = Tensor(stacking: actualJacobianRows)
+  assertEqual(
+    actualJacobian,
+    expectedJacobian,
+    accuracy: accuracy,
+    message: "unexpected jacobian: ",
     file: file,
     line: line
   )

--- a/Tests/SwiftFusionTests/XCTestManifests.swift
+++ b/Tests/SwiftFusionTests/XCTestManifests.swift
@@ -3,6 +3,7 @@ import XCTest
 #if !canImport(ObjectiveC)
 public func allTests() -> [XCTestCaseEntry] {
   [
+    testCase(FactorTests.allTests),
     testCase(Rot2Tests.allTests),
     testCase(Pose2Tests.allTests),
     testCase(JacobianTests.allTests),


### PR DESCRIPTION
The main point of this PR is the `TensorFactor` protocol, which is very simple:

```
/// Computes measurement errors.
public protocol TensorFactor {
  /// Returns the `error` of the factor.
  @differentiable
  func error(tensorValues: Tensor<Double>) -> Tensor<Double>
}
```

This should be easy to store in a factor graph, and easy to use to compute errors and derivatives.

The rest of this PR is a bunch of boilerplate making it "easier" to define factors whose input and output types are non-tensor types. But I'm not sure if it's worth it. Maybe everyone can just convert to/from `Tensor` within the factor implementaitons so that we don't need any of the other parts of this PR.