### PR TITLE
make Dictionary Differentiable

### DIFF
--- a/Sources/SwiftFusion/Core/Dictionary+Differentiable.swift
+++ b/Sources/SwiftFusion/Core/Dictionary+Differentiable.swift
@@ -1,0 +1,52 @@
+/// This file makes `Dictionary` differentiable.
+///
+/// Note: This will eventually be moved into the Swift standard library. Once it is in the
+/// standard library, we can delete it from this repository.
+
+/// Implements the `Differentiable` requirements.
+extension Dictionary: Differentiable where Value: Differentiable {
+  public typealias TangentVector = Dictionary<Key, Value.TangentVector>
+  public mutating func move(along direction: TangentVector) {
+    for (componentKey, componentDirection) in direction {
+      func fatalMissingComponent() -> Value {
+        fatalError("missing component \(componentKey) in moved Dictionary")
+      }
+      self[componentKey, default: fatalMissingComponent()].move(along: componentDirection)
+    }
+  }
+  public var zeroTangentVector: TangentVector { mapValues { _ in .zero } }
+}
+
+/// Implements the `AdditiveArithmetic` requirements.
+extension Dictionary: AdditiveArithmetic where Value: AdditiveArithmetic {
+  public static func + (_ lhs: Self, _ rhs: Self) -> Self {
+    lhs.merging(rhs, uniquingKeysWith: +)
+  }
+  public static func - (_ lhs: Self, _ rhs: Self) -> Self {
+    lhs.merging(rhs.mapValues { .zero - $0 }, uniquingKeysWith: +)
+  }
+  public static var zero: Self { [:] }
+}
+
+/// Provides some differentiable methods for manipulating `Dictionary`.
+///
+/// Note: Once the differentiable `Dictionary` is moved into the standard library, the standard
+/// `Dictionary` methods will be differentiable and you won't have to use special differentiable
+/// methods to manipulate `Dictionary`.
+extension Dictionary where Value: Differentiable {
+  /// Returns the value with `key`.
+  ///
+  /// Precondition: `self` contains an entry with key `key`.
+  @differentiable
+  public func differentiableSubscript(_ key: Key) -> Value {
+    self[key]!
+  }
+
+  @derivative(of: differentiableSubscript)
+  @usableFromInline
+  func vjpDifferentiableSubscript(_ key: Key)
+    -> (value: Value, pullback: (Value.TangentVector) -> TangentVector)
+  {
+    (differentiableSubscript(key), { [key: $0] })
+  }
+}

--- a/Tests/SwiftFusionTests/Core/Dictionary+DifferentiableTests.swift
+++ b/Tests/SwiftFusionTests/Core/Dictionary+DifferentiableTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import XCTest
+
+import SwiftFusion
+
+class DictionaryDifferentiableTests: XCTestCase {
+  /// Test the `AdditiveArithmetic` `zero` requirement.
+  func testAdditiveArithmeticZero() {
+    XCTAssertEqual(Dictionary<String, Float>.zero, [:])
+  }
+
+  /// Test the `AdditiveArithmetic` `+` requirement.
+  func testAdditiveArithmeticPlus() {
+    XCTAssertEqual(
+      ([:] as [String: Int]) + [:],
+      [:]
+    )
+    XCTAssertEqual(
+      ["a": 1] + [:],
+      ["a": 1]
+    )
+    XCTAssertEqual(
+      [:] + ["b": 1],
+      ["b": 1]
+    )
+    XCTAssertEqual(
+      ["a": 1] + ["b": 1],
+      ["a": 1, "b": 1]
+    )
+    XCTAssertEqual(
+      ["a": 1, "b": 1] + ["b": 1],
+      ["a": 1, "b": 2]
+    )
+  }
+
+  /// Test the `AdditiveArithmetic` `-` requirement.
+  func testAdditiveArithmeticMinus() {
+    XCTAssertEqual(
+      ([:] as [String: Int]) - [:],
+      [:]
+    )
+    XCTAssertEqual(
+      ["a": 1] - [:],
+      ["a": 1]
+    )
+    XCTAssertEqual(
+      [:] - ["b": 1],
+      ["b": -1]
+    )
+    XCTAssertEqual(
+      ["a": 1] - ["b": 1],
+      ["a": 1, "b": -1]
+    )
+    XCTAssertEqual(
+      ["a": 1, "b": 1] - ["b": 1],
+      ["a": 1, "b": 0]
+    )
+  }
+
+  /// Test the `Differentiable` `move` requirement.
+  func testMove() {
+    var foo: [String: Double] = ["a": 0, "b": 0]
+    foo.move(along: ["a": 1])
+    XCTAssertEqual(foo, ["a": 1, "b": 0])
+    foo.move(along: ["b": 1])
+    XCTAssertEqual(foo, ["a": 1, "b": 1])
+    foo.move(along: ["a": 1, "b": 2])
+    XCTAssertEqual(foo, ["a": 2, "b": 3])
+  }
+
+  /// Test the `Differentiable` `zeroTangentVector` requirement.
+  func testZeroTangentVector() {
+    XCTAssertEqual(
+      ([:] as [String: Double]).zeroTangentVector,
+      [:]
+    )
+    XCTAssertEqual(
+      (["a": 1] as [String: Double]).zeroTangentVector,
+      ["a":  0]
+    )
+  }
+
+  /// Test the value and derivative of `differentiableSubscript`.
+  func testDifferentiableSubscript() {
+    let point: [String: Double] = ["a": 1, "b": 2]
+    XCTAssertEqual(point.differentiableSubscript("a"), 1)
+    XCTAssertEqual(point.differentiableSubscript("b"), 2)
+    XCTAssertEqual(
+      gradient(at: point) { $0.differentiableSubscript("a") },
+      ["a": 1]
+    )
+    XCTAssertEqual(
+      gradient(at: point) { $0.differentiableSubscript("a") + $0.differentiableSubscript("b") },
+      ["a": 1, "b": 1]
+    )
+  }
+
+  static var allTests = [
+    ("testAdditiveArithmeticZero", testAdditiveArithmeticZero),
+    ("testAdditiveArithmeticPlus", testAdditiveArithmeticPlus),
+    ("testAdditiveArithmeticMinus", testAdditiveArithmeticMinus),
+    ("testMove", testMove),
+    ("testZeroTangentVector", testZeroTangentVector),
+    ("testDifferentiableSubscript", testDifferentiableSubscript)
+  ]
+}

--- a/Tests/SwiftFusionTests/XCTestManifests.swift
+++ b/Tests/SwiftFusionTests/XCTestManifests.swift
@@ -3,6 +3,7 @@ import XCTest
 #if !canImport(ObjectiveC)
 public func allTests() -> [XCTestCaseEntry] {
   [
+    testCase(DictionaryDifferentiableTests.allTests),
     testCase(Rot2Tests.allTests),
     testCase(Pose2Tests.allTests),
     testCase(JacobianTests.allTests),


### PR DESCRIPTION
As discussed in https://github.com/borglab/SwiftFusion/pull/23/files/eea06d0b6c3fca7c6bba2ebe6588097f0096dc36#r405894624, it would be nice for `Dictionary` to be `Differentiable`.

I will work on getting this included in the standard library so that it does not need to exist in this repo, but it will take weeks-months for that to make it into a release toolchain, so in the meantime you probably want it in this repo so that you can use it sooner.

This PR only defines a derivative for the "subscript" operation. We'll need to define derivatives for any other primitive dictionary operations that you need. But it looks like "subscript" is all you need in the short term.