### PR TITLE
import AnyDifferentiable

### DIFF
--- a/Sources/SwiftFusion/Core/AnyDifferentiable.swift
+++ b/Sources/SwiftFusion/Core/AnyDifferentiable.swift
@@ -1,0 +1,397 @@
+// NOTE: This will be available in S4TF v0.9, so we should delete this as soon as we switch to
+// that version.
+
+//===----------------------------------------------------------------------===//
+// `AnyDifferentiable`
+//===----------------------------------------------------------------------===//
+
+internal protocol _AnyDifferentiableBox {
+  // `Differentiable` requirements.
+  mutating func _move(along direction: AnyDerivative)
+
+  /// The underlying base value, type-erased to `Any`.
+  var _typeErasedBase: Any { get }
+
+  /// Returns the underlying value unboxed to the given type, if possible.
+  func _unboxed<U: Differentiable>(to type: U.Type) -> U?
+}
+
+internal struct _ConcreteDifferentiableBox<T: Differentiable>: _AnyDifferentiableBox
+{
+  /// The underlying base value.
+  var _base: T
+
+  init(_ base: T) {
+    self._base = base
+  }
+
+  /// The underlying base value, type-erased to `Any`.
+  var _typeErasedBase: Any {
+    return _base
+  }
+
+  func _unboxed<U: Differentiable>(to type: U.Type) -> U? {
+    return (self as? _ConcreteDifferentiableBox<U>)?._base
+  }
+
+  mutating func _move(along direction: AnyDerivative) {
+    guard
+      let directionBase =
+        direction.base as? T.TangentVector
+    else {
+      _derivativeTypeMismatch(T.self, type(of: direction.base))
+    }
+    _base.move(along: directionBase)
+  }
+}
+
+public struct AnyDifferentiable: Differentiable {
+  internal var _box: _AnyDifferentiableBox
+
+  internal init(_box: _AnyDifferentiableBox) {
+    self._box = _box
+  }
+
+  /// The underlying base value.
+  public var base: Any {
+    return _box._typeErasedBase
+  }
+
+  /// Creates a type-erased derivative from the given derivative.
+  @differentiable
+  public init<T: Differentiable>(_ base: T) {
+    self._box = _ConcreteDifferentiableBox<T>(base)
+  }
+
+  @inlinable
+  @derivative(of: init)
+  internal static func _vjpInit<T: Differentiable>(
+    _ base: T
+  ) -> (value: AnyDifferentiable, pullback: (AnyDerivative) -> T.TangentVector)
+  {
+    return (AnyDifferentiable(base), { v in v.base as! T.TangentVector })
+  }
+
+  @inlinable
+  @derivative(of: init)
+  internal static func _jvpInit<T: Differentiable>(
+    _ base: T
+  ) -> (
+    value: AnyDifferentiable, differential: (T.TangentVector) -> AnyDerivative
+  ) {
+    return (AnyDifferentiable(base), { dbase in AnyDerivative(dbase) })
+  }
+
+  public typealias TangentVector = AnyDerivative
+
+  public mutating func move(along direction: TangentVector) {
+    _box._move(along: direction)
+  }
+}
+
+extension AnyDifferentiable {
+  @differentiable
+  public func baseAs<T: Differentiable>(_ t: T.Type) -> T {
+    base as! T
+  }
+
+  @derivative(of: baseAs)
+  @usableFromInline
+  func jvpBaseAs<T: Differentiable>(_ t: T.Type) -> (
+    value: T,
+    differential: (AnyDerivative) -> T.TangentVector
+  ) {
+    (baseAs(t), { $0.base as! T.TangentVector })
+  }
+
+  @derivative(of: baseAs)
+  @usableFromInline
+  func vjpBaseAs<T: Differentiable>(_ t: T.Type) -> (
+    value: T,
+    pullback: (T.TangentVector) -> AnyDerivative
+  ) {
+    (baseAs(t), { AnyDerivative($0) })
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// `AnyDerivative`
+//===----------------------------------------------------------------------===//
+
+@usableFromInline
+internal protocol _AnyDerivativeBox {
+  // `Equatable` requirements (implied by `AdditiveArithmetic`).
+  func _isEqual(to other: _AnyDerivativeBox) -> Bool
+  func _isNotEqual(to other: _AnyDerivativeBox) -> Bool
+
+  // `AdditiveArithmetic` requirements.
+  static var _zero: _AnyDerivativeBox { get }
+  func _adding(_ x: _AnyDerivativeBox) -> _AnyDerivativeBox
+  func _subtracting(_ x: _AnyDerivativeBox) -> _AnyDerivativeBox
+
+  // `Differentiable` requirements.
+  mutating func _move(along direction: _AnyDerivativeBox)
+
+  /// The underlying base value, type-erased to `Any`.
+  var _typeErasedBase: Any { get }
+
+  /// Returns the underlying value unboxed to the given type, if possible.
+  func _unboxed<U>(to type: U.Type) -> U?
+  where U: Differentiable, U.TangentVector == U
+}
+
+extension _AnyDerivativeBox {
+  /// Returns true if the underlying value has type `AnyDerivative.OpaqueZero`.
+  @inlinable
+  func _isOpaqueZero() -> Bool {
+    return _unboxed(to: AnyDerivative.OpaqueZero.self) != nil
+  }
+}
+
+@frozen
+@usableFromInline
+internal struct _ConcreteDerivativeBox<T>: _AnyDerivativeBox
+where T: Differentiable, T.TangentVector == T {
+  /// The underlying base value.
+  @usableFromInline
+  var _base: T
+
+  @inlinable
+  internal init(_ base: T) {
+    self._base = base
+  }
+
+  /// The underlying base value, type-erased to `Any`.
+  @inlinable
+  var _typeErasedBase: Any {
+    return _base
+  }
+
+  @inlinable
+  func _unboxed<U>(to type: U.Type) -> U?
+  where U: Differentiable, U.TangentVector == U {
+    return (self as? _ConcreteDerivativeBox<U>)?._base
+  }
+
+  // `Equatable` requirements (implied by `AdditiveArithmetic`).
+  @inlinable
+  func _isEqual(to other: _AnyDerivativeBox) -> Bool {
+    return _base == other._unboxed(to: T.self)
+  }
+  @inlinable
+  func _isNotEqual(to other: _AnyDerivativeBox) -> Bool {
+    return _base != other._unboxed(to: T.self)
+  }
+
+  // `AdditiveArithmetic` requirements.
+
+  @inlinable
+  static var _zero: _AnyDerivativeBox {
+    return _ConcreteDerivativeBox(T.zero)
+  }
+
+  @inlinable
+  func _adding(_ x: _AnyDerivativeBox) -> _AnyDerivativeBox {
+    // 0 + x = x
+    if _isOpaqueZero() {
+      return x
+    }
+    // y + 0 = y
+    if x._isOpaqueZero() {
+      return self
+    }
+    guard let xBase = x._unboxed(to: T.self) else {
+      _derivativeTypeMismatch(T.self, type(of: x._typeErasedBase))
+    }
+    return _ConcreteDerivativeBox(_base + xBase)
+  }
+
+  @inlinable
+  func _subtracting(_ x: _AnyDerivativeBox) -> _AnyDerivativeBox {
+    // y - 0 = y
+    if x._isOpaqueZero() {
+      return self
+    }
+    // 0 - x = -x
+    if _isOpaqueZero() {
+      return type(of: x)._zero._subtracting(x)
+    }
+    guard let xBase = x._unboxed(to: T.self) else {
+      _derivativeTypeMismatch(T.self, type(of: x._typeErasedBase))
+    }
+    return _ConcreteDerivativeBox(_base - xBase)
+  }
+
+  // `Differentiable` requirements.
+  @inlinable
+  mutating func _move(along direction: _AnyDerivativeBox) {
+    if direction._isOpaqueZero() {
+      return
+    }
+    // The case where `self._isOpaqueZero()` returns true is handled in
+    // `AnyDerivative.move(along:)`.
+    guard
+      let directionBase =
+        direction._unboxed(to: T.TangentVector.self)
+    else {
+      _derivativeTypeMismatch(T.self, type(of: direction._typeErasedBase))
+    }
+    _base.move(along: directionBase)
+  }
+}
+
+/// A type-erased derivative value.
+///
+/// The `AnyDerivative` type forwards its operations to an arbitrary underlying
+/// base derivative value conforming to `Differentiable` and
+/// `AdditiveArithmetic`, hiding the specifics of the underlying value.
+@frozen
+public struct AnyDerivative: Differentiable & AdditiveArithmetic {
+  @usableFromInline
+  internal var _box: _AnyDerivativeBox
+
+  @inlinable
+  internal init(_box: _AnyDerivativeBox) {
+    self._box = _box
+  }
+
+  /// The underlying base value.
+  @inlinable
+  public var base: Any {
+    return _box._typeErasedBase
+  }
+
+  /// Creates a type-erased derivative from the given derivative.
+  @inlinable
+  @differentiable
+  public init<T>(_ base: T) where T: Differentiable, T.TangentVector == T {
+    self._box = _ConcreteDerivativeBox<T>(base)
+  }
+
+  @inlinable
+  @derivative(of: init)
+  internal static func _vjpInit<T>(
+    _ base: T
+  ) -> (value: AnyDerivative, pullback: (AnyDerivative) -> T.TangentVector)
+  where T: Differentiable, T.TangentVector == T {
+    return (AnyDerivative(base), { v in v.base as! T.TangentVector })
+  }
+
+  @inlinable
+  @derivative(of: init)
+  internal static func _jvpInit<T>(
+    _ base: T
+  ) -> (value: AnyDerivative, differential: (T.TangentVector) -> AnyDerivative)
+  where T: Differentiable, T.TangentVector == T {
+    return (AnyDerivative(base), { dbase in AnyDerivative(dbase) })
+  }
+
+  public typealias TangentVector = AnyDerivative
+
+  // `Equatable` requirements (implied by `AdditiveArithmetic`).
+  @inlinable
+  public static func == (lhs: AnyDerivative, rhs: AnyDerivative) -> Bool {
+    return lhs._box._isEqual(to: rhs._box)
+  }
+  @inlinable
+  public static func != (lhs: AnyDerivative, rhs: AnyDerivative) -> Bool {
+    return lhs._box._isNotEqual(to: rhs._box)
+  }
+
+  // `AdditiveArithmetic` requirements.
+
+  /// Internal struct representing an opaque zero value.
+  @frozen
+  @usableFromInline
+  internal struct OpaqueZero: Differentiable & AdditiveArithmetic {}
+
+  @inlinable
+  public static var zero: AnyDerivative {
+    return AnyDerivative(
+      _box: _ConcreteDerivativeBox<OpaqueZero>(OpaqueZero.zero))
+  }
+
+  @inlinable
+  public static func + (
+    lhs: AnyDerivative, rhs: AnyDerivative
+  ) -> AnyDerivative {
+    return AnyDerivative(_box: lhs._box._adding(rhs._box))
+  }
+
+  @derivative(of: +)
+  @inlinable
+  internal static func _vjpAdd(
+    lhs: AnyDerivative, rhs: AnyDerivative
+  ) -> (
+    value: AnyDerivative,
+    pullback: (AnyDerivative) -> (AnyDerivative, AnyDerivative)
+  ) {
+    return (lhs + rhs, { v in (v, v) })
+  }
+
+  @derivative(of: +)
+  @inlinable
+  internal static func _jvpAdd(
+    lhs: AnyDerivative, rhs: AnyDerivative
+  ) -> (
+    value: AnyDerivative,
+    differential: (AnyDerivative, AnyDerivative) -> (AnyDerivative)
+  ) {
+    return (lhs + rhs, { (dlhs, drhs) in dlhs + drhs })
+  }
+
+  @inlinable
+  public static func - (
+    lhs: AnyDerivative, rhs: AnyDerivative
+  ) -> AnyDerivative {
+    return AnyDerivative(_box: lhs._box._subtracting(rhs._box))
+  }
+
+  @derivative(of: -)
+  @inlinable
+  internal static func _vjpSubtract(
+    lhs: AnyDerivative, rhs: AnyDerivative
+  ) -> (
+    value: AnyDerivative,
+    pullback: (AnyDerivative) -> (AnyDerivative, AnyDerivative)
+  ) {
+    return (lhs - rhs, { v in (v, .zero - v) })
+  }
+
+  @derivative(of: -)
+  @inlinable
+  internal static func _jvpSubtract(
+    lhs: AnyDerivative, rhs: AnyDerivative
+  ) -> (
+    value: AnyDerivative,
+    differential: (AnyDerivative, AnyDerivative) -> AnyDerivative
+  ) {
+    return (lhs - rhs, { (dlhs, drhs) in dlhs - drhs })
+  }
+
+  // `Differentiable` requirements.
+  @inlinable
+  public mutating func move(along direction: TangentVector) {
+    if _box._isOpaqueZero() {
+      _box = direction._box
+      return
+    }
+    _box._move(along: direction._box)
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Helpers
+//===----------------------------------------------------------------------===//
+
+@inline(never)
+@usableFromInline
+internal func _derivativeTypeMismatch(
+  _ x: Any.Type, _ y: Any.Type, file: StaticString = #file, line: UInt = #line
+) -> Never {
+  preconditionFailure(
+    """
+    Derivative type mismatch: \
+    \(String(reflecting: x)) and \(String(reflecting: y))
+    """, file: file, line: line)
+}

--- a/Tests/SwiftFusionTests/Core/AnyDifferentiableTests.swift
+++ b/Tests/SwiftFusionTests/Core/AnyDifferentiableTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+
+import TensorFlow
+
+import SwiftFusion
+
+class AnyDifferentiableTests: XCTestCase {
+  /// Tests that we can take derivatives with respect to an array of type-erased elements with
+  /// different runtime types.
+  func testAnyDifferentiableArray() {
+    func f(_ poses: [Pose2], _ vectors: [Vector2]) -> Double {
+      var loss: Double = 0
+      for i in withoutDerivative(at: 0..<poses.count-1) {
+        let b = between(poses[i], poses[i + 1])
+        loss += b.t.norm
+        loss += b.rot.theta * b.rot.theta
+      }
+      for i in withoutDerivative(at: 0..<vectors.count-1) {
+        let b = vectors[i + 1] - vectors[i]
+        loss += b.norm
+      }
+      return loss
+    }
+
+    func fErased(_ erased: [AnyDifferentiable]) -> Double {
+      let poses = [erased[0], erased[1], erased[2]].differentiableMap { $0.baseAs(Pose2.self) }
+      let vectors = [erased[3], erased[4], erased[5]].differentiableMap { $0.baseAs(Vector2.self) }
+      return f(poses, vectors)
+    }
+
+    let initialPoses = (0..<3).map { _ in Pose2(randomWithCovariance: eye(rowCount: 3)) }
+    let initialVectors = (0..<3).map { _ in Vector2(Tensor(randomNormal: [2])) }
+    let elementsErased =
+      initialPoses.map { AnyDifferentiable($0) } + initialVectors.map { AnyDifferentiable($0) }
+
+    let (expectedPosesGrad, expectedVectorsGrad) = gradient(at: initialPoses, initialVectors, in: f)
+    let erasedActualGrad = gradient(at: elementsErased, in: fErased)
+    let actualPosesGrad = erasedActualGrad[0..<3].map { $0.base as! Pose2.TangentVector }
+    let actualVectorsGrad = erasedActualGrad[3..<6].map { $0.base as! Vector2.TangentVector }
+    XCTAssertEqual(actualPosesGrad, expectedPosesGrad.base)
+    XCTAssertEqual(actualVectorsGrad, expectedVectorsGrad.base)
+  }
+
+  static var allTests = [
+    ("testAnyDifferentiableArray", testAnyDifferentiableArray)
+  ]
+}

--- a/Tests/SwiftFusionTests/XCTestManifests.swift
+++ b/Tests/SwiftFusionTests/XCTestManifests.swift
@@ -3,6 +3,7 @@ import XCTest
 #if !canImport(ObjectiveC)
 public func allTests() -> [XCTestCaseEntry] {
   [
+    testCase(AnyDifferentiableTests.allTests),
     testCase(DictionaryDifferentiableTests.allTests),
     testCase(Rot2Tests.allTests),
     testCase(Pose2Tests.allTests),


### PR DESCRIPTION
Adds an `AnyDifferentiable` type that allows us to take derivatives with respect to type-erased differentiable types.

Includes a test that demonstrates how to take the derivative with respect to an array that contains `Pose2` and `Vector2` elements.

NOTE: This will be available in S4TF v0.9, so we should delete this as soon as we switch to that version.

Resolves #30 