### PR TITLE
Revert TF-1234 workarounds.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
         uses: actions/checkout@master
       - name: Install toolchain
         run: |
-          wget https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.8/rc1/swift-tensorflow-RELEASE-0.8-osx.pkg
-          sudo installer -pkg swift-tensorflow-RELEASE-0.8-osx.pkg -target /
+          wget https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2020-05-09-a-osx.pkg
+          sudo installer -pkg swift-tensorflow-DEVELOPMENT-2020-05-09-a-osx.pkg -target /
           echo "::set-env name=PATH::/Library/Developer/Toolchains/swift-latest/usr/bin:${PATH}"
       - name: Build
         run: swift build -v

--- a/Sources/SwiftFusion/Core/LieGroup.swift
+++ b/Sources/SwiftFusion/Core/LieGroup.swift
@@ -12,27 +12,6 @@ public protocol LieGroup: Manifold {
   func local(_ global: Self) -> Self.Coordinate.LocalCoordinate
 }
 
-// TODO(TF-1234): Remove this extension. It is a workaround.
-extension LieGroup {
-  /// Use this instead of "*" to worok around TF-1234.
-  @differentiable
-  static func differentiableMultiply(_ lhs: Self, _ rhs: Self) -> Self {
-    return lhs * rhs
-  }
-
-  /// Use this instead of "inverse" to worok around TF-1234.
-  @differentiable
-  func differentiableInverse() -> Self {
-    return inverse()
-  }
-
-  /// Use this instead of "local" to worok around TF-1234.
-  @differentiable(wrt: global)
-  func differentiableLocal(_ global: Self) -> Self.Coordinate.LocalCoordinate {
-    return local(global)
-  }
-}
-
 /// Calculate relative pose 1T2 between two poses wT1 and wT2
 @differentiable(wrt: (wT1, wT2))
 public func between<T: LieGroup & Differentiable>(_ wT1: T, _ wT2: T) -> T {

--- a/Sources/SwiftFusion/Core/TensorConvertible.swift
+++ b/Sources/SwiftFusion/Core/TensorConvertible.swift
@@ -7,14 +7,6 @@ public protocol TensorConvertible: Differentiable {
   }
 }
 
-// TODO(TF-1234): Remove this extension. It is a workaround.
-extension TensorConvertible {
-  /// Use this instead of "tensor" to worok around TF-1234.
-  @differentiable var differentiableTensor: Tensor<Double> {
-    return tensor
-  }
-}
-
 extension Vector1: TensorConvertible {
   
 }

--- a/Sources/SwiftFusion/Inference/BetweenFactor.swift
+++ b/Sources/SwiftFusion/Inference/BetweenFactor.swift
@@ -67,16 +67,16 @@ public struct BetweenFactor<T: LieGroup>: NonlinearFactor {
   /// Returns the `error` of the factor.
   @differentiable(wrt: values)
   public func error(_ values: Values) -> Double {
-    let actual = T.differentiableMultiply(values[key1].baseAs(T.self).differentiableInverse(), values[key2].baseAs(T.self))
-    let error = difference.differentiableLocal(actual)
+    let actual = values[key1].baseAs(T.self).inverse() * values[key2].baseAs(T.self)
+    let error = difference.local(actual)
     
-    return error.differentiableTensor.squared().sum().scalars[0]
+    return error.tensor.squared().sum().scalars[0]
   }
   
   @differentiable(wrt: values)
   public func errorVector(_ values: Values) -> T.Coordinate.LocalCoordinate {
-    let error = difference.differentiableLocal(
-      T.differentiableMultiply(values[key1].baseAs(T.self).differentiableInverse(), values[key2].baseAs(T.self))
+    let error = difference.local(
+      values[key1].baseAs(T.self).inverse() * values[key2].baseAs(T.self)
     )
     
     return error


### PR DESCRIPTION
This partially reverts commit 87e759809160228e98f93da0c406ba76b5d97b65.
[TF-1234](https://bugs.swift.org/browse/TF-1234) is fixed, so we can revert workarounds and restore idiomatic code.

---

*Please do not merge until the [TF-1234](https://bugs.swift.org/browse/TF-1234) fix (https://github.com/apple/swift/pull/31670) is merged and new toolchains are released.* This patch won't build with current toolchains missing the fix.

I'm building a macOS toolchain with the fix right now, to be shared asap.

---

Aside: could I please have edit access to borglab/SwiftFusion? We agreed to develop on borglab/SwiftFusion branches instead of using forks.