### PR TITLE
replace Tensor with array-backed Vector and Matrix

### DIFF
--- a/Examples/Pose2SLAMG2O/main.swift
+++ b/Examples/Pose2SLAMG2O/main.swift
@@ -66,15 +66,15 @@ func main() {
   print("Initial error: \(problem.graph.error(val))")
   for _ in 0..<10 {
     let gfg = problem.graph.linearize(val)
-    let optimizer = CGLS(precision: 1e-6, max_iteration: 20)
+    let optimizer = CGLS(precision: 1e-6, max_iteration: 200)
     var dx = VectorValues()
     for i in 0..<val.count {
-      dx.insert(i, Tensor<Double>(shape: [3, 1], scalars: [0, 0, 0]))
+      dx.insert(i, Vector(zeros: 3))
     }
     optimizer.optimize(gfg: gfg, initial: &dx)
     for i in 0..<val.count {
       var p = val[i].baseAs(Pose2.self)
-      p.move(along: Vector3(dx[i].reshaped(toShape: [3])))
+      p.move(along: Vector3(dx[i]))
       val[i] = AnyDifferentiable(p)
     }
     print("Current error: \(problem.graph.error(val))")

--- a/Sources/SwiftFusion/Core/Matrix.swift
+++ b/Sources/SwiftFusion/Core/Matrix.swift
@@ -1,0 +1,103 @@
+import TensorFlow
+
+/// A dynamically sized matrix.
+public struct Matrix: Equatable {
+  /// The scalars in the matrix, in row major order.
+  public fileprivate(set) var scalars: [Double]
+
+  /// The number of rows and columns in the matrix.
+  public fileprivate(set) var rowCount, columnCount: Int
+}
+
+/// Initializers.
+extension Matrix {
+  /// Creates a matrix with `scalars` in row major order with shape `rowCount` x `columnCount`.
+  public init(_ scalars: [Double], rowCount: Int, columnCount: Int) {
+    precondition(scalars.count == rowCount * columnCount)
+    self.scalars = scalars
+    self.rowCount = rowCount
+    self.columnCount = columnCount
+  }
+
+  /// Creates a matrix stacking `rows`.
+  public init(stacking rows: [Vector]) {
+    guard rows.count > 0 else {
+      self.init([], rowCount: 0, columnCount: 0)
+      return
+    }
+    self.init([], rowCount: 0, columnCount: rows[0].dimension)
+    for row in rows {
+      self.append(row: row)
+    }
+  }
+
+  /// Creates an identity matrix with the given `dimension`.
+  public init(eye dimension: Int) {
+    self.init([], rowCount: 0, columnCount: dimension)
+    self.reserveCapacity(dimension * dimension)
+    for i in 0..<dimension {
+      var scalars = Array(repeating: Double(0), count: dimension)
+      scalars[i] = 1
+      self.append(row: Vector(scalars))
+    }
+  }
+}
+
+/// Subscripts.
+extension Matrix {
+  // Returns the `(row, column)` entry of the matrix.
+  public subscript(row: Int, column: Int) -> Double {
+    return scalars[row * columnCount + column]
+  }
+}
+
+/// Elementwise operations.
+extension Matrix {
+  public static func *= (_ lhs: inout Matrix, _ rhs: Double) {
+    for index in lhs.scalars.indices {
+      lhs.scalars[index] *= rhs
+    }
+  }
+
+  public static func * (_ lhs: Double, _ rhs: Matrix) -> Matrix {
+    var result = rhs
+    result *= lhs
+    return result
+  }
+
+  public static func * (_ lhs: Matrix, _ rhs: Double) -> Matrix {
+    var result = lhs
+    result *= rhs
+    return result
+  }
+}
+
+/// Mutations.
+extension Matrix {
+  /// Appends `row` at the bottom of the matrix.
+  ///
+  /// Precondition `row.dimension == self.columnCount`.
+  public mutating func append(row: Vector) {
+    precondition(row.dimension == self.columnCount)
+    scalars.append(contentsOf: row.scalars)
+    rowCount += 1
+  }
+
+  /// Allocates space for `n` scalars in the scalar storage, so that no reallocations are
+  /// necessary while adding up to that many elements.
+  public mutating func reserveCapacity(_ n: Int) {
+    scalars.reserveCapacity(n)
+  }
+}
+
+/// Returns the matrix-vector product of `lhs` and `rhs`.
+public func matvec(_ lhs: Matrix, transposed: Bool = false, _ rhs: Vector) -> Vector {
+  precondition(rhs.dimension == (transposed ? lhs.rowCount : lhs.columnCount))
+  var result = Vector(zeros: transposed ? lhs.columnCount : lhs.rowCount)
+  for i in 0..<lhs.rowCount {
+    for j in 0..<lhs.columnCount {
+      result.scalars[transposed ? j : i] += lhs[i, j] * rhs.scalars[transposed ? i : j]
+    }
+  }
+  return result
+}

--- a/Sources/SwiftFusion/Core/Vector.swift
+++ b/Sources/SwiftFusion/Core/Vector.swift
@@ -1,348 +1,158 @@
-// WARNING: This is a generated file. Do not edit it. Instead, edit the corresponding ".gyb" file.
-// See "generate.sh" in the root of this repository for instructions how to regenerate files.
-
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 1)
 import TensorFlow
 
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 6)
+/// A dynamically sized vector.
+public struct Vector: Equatable, Differentiable {
+  /// The scalars in the vector.
+  public var scalars: [Double]
 
-/// An element of R^1, with Euclidean norm.
-public struct Vector1: Differentiable, KeyPathIterable, TangentStandardBasis
-{
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 11)
-  @differentiable public var x: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 13)
+  public typealias TangentVector = Self
+}
 
-  @differentiable
-  public init(_ x: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 17)
-    self.x = x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 19)
+/// Can be losslessly converted to and from a `Vector`.
+public protocol VectorConvertible {
+  init(_ vector: Vector)
+  var vector: Vector { get }
+}
+
+/// Initializers.
+extension Vector {
+  /// Creates a vector with the given `scalars`.
+  public init(_ scalars: [Double]) {
+    self.scalars = scalars
+  }
+
+  /// Creates a zero vector of the given `dimension`.
+  public init(zeros dimension: Int) {
+    self.init(Array(repeating: 0, count: dimension))
   }
 }
 
-/// Normed vector space methods.
-extension Vector1: AdditiveArithmetic, VectorProtocol {
-  public typealias VectorSpaceScalar = Double
-
-  /// Euclidean norm of `self`.
-  @differentiable
-  public var norm: Double { squaredNorm.squareRoot() }
-
-  /// Square of the Euclidean norm of `self`.
-  @differentiable
-  public var squaredNorm: Double { self.squared().sum() }
-
-  @differentiable
-  public static func + (_ lhs: Self, _ rhs: Self) -> Self {
-    var result = Self.zero
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 38)
-    result.x = lhs.x + rhs.x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 40)
-    return result
-  }
-
-  @differentiable
-  public static func - (_ lhs: Self, _ rhs: Self) -> Self {
-    var result = Self.zero
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 47)
-    result.x = lhs.x - rhs.x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 49)
-    return result
-  }
-
-  @differentiable
-  public static prefix func - (_ v: Self) -> Self {
-    var result = Self.zero
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 56)
-    result.x = -v.x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 58)
-    return result
+/// Miscellaneous computed properties.
+extension Vector {
+  public var dimension: Int {
+    return scalars.count
   }
 }
 
-/// Other arithmetic on the vector elements.
-extension Vector1: ElementaryFunctions {
+/// Arithmetic on elements.
+extension Vector {
   /// Sum of the elements of `self`.
   public func sum() -> Double {
-    var result: Double = 0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 68)
-    result = result + x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 70)
-    return result
+    return scalars.reduce(0, +)
   }
 
   /// Vector whose elements are squares of the elements of `self`.
   public func squared() -> Self {
-    var result = Self.zero
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 77)
-    result.x = x * x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 79)
-    return result
+    return Vector(scalars.map { $0 * $0 })
   }
 }
 
-/// Conversion to/from tensor.
-extension Vector1 {
-  /// A `Tensor` with shape `[1]` whose elements are the elements of `self`.
-  @differentiable
-  public var tensor: Tensor<Double> {
-    Tensor([x])
-  }
-
-  /// Creates a `Vector1` with the same elements as `tensor`.
-  ///
-  /// Precondition: `tensor` must have shape `[1]`.
-  @differentiable
-  public init(_ tensor: Tensor<Double>) {
-    precondition(tensor.shape == [1])
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 98)
-    self.x = tensor[0].scalarized()
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 100)
-  }
-}
-
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 6)
-
-/// An element of R^2, with Euclidean norm.
-public struct Vector2: Differentiable, KeyPathIterable, TangentStandardBasis
-{
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 11)
-  @differentiable public var x: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 11)
-  @differentiable public var y: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 13)
-
-  @differentiable
-  public init(_ x: Double, _ y: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 17)
-    self.x = x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 17)
-    self.y = y
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 19)
-  }
-}
-
-/// Normed vector space methods.
-extension Vector2: AdditiveArithmetic, VectorProtocol {
-  public typealias VectorSpaceScalar = Double
-
+/// Euclidean norms.
+extension Vector {
   /// Euclidean norm of `self`.
-  @differentiable
   public var norm: Double { squaredNorm.squareRoot() }
 
   /// Square of the Euclidean norm of `self`.
-  @differentiable
   public var squaredNorm: Double { self.squared().sum() }
-
-  @differentiable
-  public static func + (_ lhs: Self, _ rhs: Self) -> Self {
-    var result = Self.zero
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 38)
-    result.x = lhs.x + rhs.x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 38)
-    result.y = lhs.y + rhs.y
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 40)
-    return result
-  }
-
-  @differentiable
-  public static func - (_ lhs: Self, _ rhs: Self) -> Self {
-    var result = Self.zero
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 47)
-    result.x = lhs.x - rhs.x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 47)
-    result.y = lhs.y - rhs.y
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 49)
-    return result
-  }
-
-  @differentiable
-  public static prefix func - (_ v: Self) -> Self {
-    var result = Self.zero
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 56)
-    result.x = -v.x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 56)
-    result.y = -v.y
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 58)
-    return result
-  }
 }
 
-/// Other arithmetic on the vector elements.
-extension Vector2: ElementaryFunctions {
-  /// Sum of the elements of `self`.
-  public func sum() -> Double {
-    var result: Double = 0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 68)
-    result = result + x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 68)
-    result = result + y
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 70)
+/// AdditiveArithmetic conformance.
+extension Vector: AdditiveArithmetic {
+  public static func += (_ lhs: inout Vector, _ rhs: Vector) {
+    for index in lhs.scalars.indices {
+      lhs.scalars[index] += rhs.scalars[index]
+    }
+  }
+
+  public static func + (_ lhs: Vector, _ rhs: Vector) -> Vector {
+    var result = lhs
+    result += rhs
     return result
   }
 
-  /// Vector whose elements are squares of the elements of `self`.
-  public func squared() -> Self {
-    var result = Self.zero
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 77)
-    result.x = x * x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 77)
-    result.y = y * y
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 79)
+  public static func -= (_ lhs: inout Vector, _ rhs: Vector) {
+    for index in lhs.scalars.indices {
+      lhs.scalars[index] -= rhs.scalars[index]
+    }
+  }
+
+  public static func - (_ lhs: Vector, _ rhs: Vector) -> Vector {
+    var result = lhs
+    result -= rhs
     return result
   }
-}
 
-/// Conversion to/from tensor.
-extension Vector2 {
-  /// A `Tensor` with shape `[2]` whose elements are the elements of `self`.
-  @differentiable
-  public var tensor: Tensor<Double> {
-    Tensor([x, y])
-  }
-
-  /// Creates a `Vector2` with the same elements as `tensor`.
+  /// The zero vector.
   ///
-  /// Precondition: `tensor` must have shape `[2]`.
-  @differentiable
-  public init(_ tensor: Tensor<Double>) {
-    precondition(tensor.shape == [2])
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 98)
-    self.x = tensor[0].scalarized()
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 98)
-    self.y = tensor[1].scalarized()
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 100)
+  /// Note: "Zero" doesn't make very much sense as a static property on a dynamically sized vector
+  /// because we don't known the dimension of the zero. However, `AdditiveArithmetic` requires it,
+  /// so we implement it as reasonably as possible.
+  public static var zero: Vector {
+    return Vector([])
   }
 }
 
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 6)
-
-/// An element of R^3, with Euclidean norm.
-public struct Vector3: Differentiable, KeyPathIterable, TangentStandardBasis
-{
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 11)
-  @differentiable public var x: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 11)
-  @differentiable public var y: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 11)
-  @differentiable public var z: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 13)
-
-  @differentiable
-  public init(_ x: Double, _ y: Double, _ z: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 17)
-    self.x = x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 17)
-    self.y = y
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 17)
-    self.z = z
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 19)
-  }
-}
-
-/// Normed vector space methods.
-extension Vector3: AdditiveArithmetic, VectorProtocol {
+/// VectorProtocol conformance.
+extension Vector: VectorProtocol {
   public typealias VectorSpaceScalar = Double
 
-  /// Euclidean norm of `self`.
-  @differentiable
-  public var norm: Double { squaredNorm.squareRoot() }
+  public mutating func add(_ x: Double) {
+    for index in scalars.indices {
+      scalars[index] += x
+    }
+  }
 
-  /// Square of the Euclidean norm of `self`.
-  @differentiable
-  public var squaredNorm: Double { self.squared().sum() }
-
-  @differentiable
-  public static func + (_ lhs: Self, _ rhs: Self) -> Self {
-    var result = Self.zero
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 38)
-    result.x = lhs.x + rhs.x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 38)
-    result.y = lhs.y + rhs.y
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 38)
-    result.z = lhs.z + rhs.z
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 40)
+  public func adding(_ x: Double) -> Vector {
+    var result = self
+    result.add(x)
     return result
   }
 
-  @differentiable
-  public static func - (_ lhs: Self, _ rhs: Self) -> Self {
-    var result = Self.zero
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 47)
-    result.x = lhs.x - rhs.x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 47)
-    result.y = lhs.y - rhs.y
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 47)
-    result.z = lhs.z - rhs.z
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 49)
+  public static func += (_ lhs: inout Vector, _ rhs: Double) {
+    lhs.add(rhs)
+  }
+
+  public mutating func subtract(_ x: Double) {
+    for index in scalars.indices {
+      scalars[index] -= x
+    }
+  }
+
+  public func subtracting(_ x: Double) -> Vector {
+    var result = self
+    result.subtract(x)
     return result
   }
 
-  @differentiable
-  public static prefix func - (_ v: Self) -> Self {
-    var result = Self.zero
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 56)
-    result.x = -v.x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 56)
-    result.y = -v.y
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 56)
-    result.z = -v.z
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 58)
-    return result
+  public static func -= (_ lhs: inout Vector, _ rhs: Double) {
+    lhs.subtract(rhs)
   }
-}
 
-/// Other arithmetic on the vector elements.
-extension Vector3: ElementaryFunctions {
-  /// Sum of the elements of `self`.
-  public func sum() -> Double {
-    var result: Double = 0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 68)
-    result = result + x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 68)
-    result = result + y
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 68)
-    result = result + z
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 70)
+  public mutating func scale(by scalar: Double) {
+    for index in scalars.indices {
+      scalars[index] *= scalar
+    }
+  }
+
+  public func scaled(by scalar: Double) -> Vector {
+    var result = self
+    result.scale(by: scalar)
     return result
   }
 
-  /// Vector whose elements are squares of the elements of `self`.
-  public func squared() -> Self {
-    var result = Self.zero
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 77)
-    result.x = x * x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 77)
-    result.y = y * y
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 77)
-    result.z = z * z
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 79)
-    return result
+  public static func *= (_ lhs: inout Vector, _ rhs: Double) {
+    lhs.scale(by: rhs)
+  }
+
+  public static func * (_ lhs: Double, _ rhs: Vector) -> Vector {
+    return rhs.scaled(by: lhs)
   }
 }
 
-/// Conversion to/from tensor.
-extension Vector3 {
-  /// A `Tensor` with shape `[3]` whose elements are the elements of `self`.
-  @differentiable
+/// Conversion to tensor.
+extension Vector {
+  /// Returns this vector as a `Tensor<Double>`.
   public var tensor: Tensor<Double> {
-    Tensor([x, y, z])
-  }
-
-  /// Creates a `Vector3` with the same elements as `tensor`.
-  ///
-  /// Precondition: `tensor` must have shape `[3]`.
-  @differentiable
-  public init(_ tensor: Tensor<Double>) {
-    precondition(tensor.shape == [3])
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 98)
-    self.x = tensor[0].scalarized()
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 98)
-    self.y = tensor[1].scalarized()
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 98)
-    self.z = tensor[2].scalarized()
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/Vector.swift.gyb", line: 100)
+    return Tensor(shape: [scalars.count], scalars: scalars)
   }
 }
-

--- a/Sources/SwiftFusion/Core/VectorN.swift
+++ b/Sources/SwiftFusion/Core/VectorN.swift
@@ -1,0 +1,402 @@
+// WARNING: This is a generated file. Do not edit it. Instead, edit the corresponding ".gyb" file.
+// See "generate.sh" in the root of this repository for instructions how to regenerate files.
+
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 1)
+import TensorFlow
+
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 6)
+
+/// An element of R^1, with Euclidean norm.
+public struct Vector1: Differentiable, KeyPathIterable, TangentStandardBasis
+{
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 11)
+  @differentiable public var x: Double
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 13)
+
+  @differentiable
+  public init(_ x: Double) {
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 17)
+    self.x = x
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 19)
+  }
+}
+
+/// Normed vector space methods.
+extension Vector1: AdditiveArithmetic, VectorProtocol {
+  public typealias VectorSpaceScalar = Double
+
+  /// Euclidean norm of `self`.
+  @differentiable
+  public var norm: Double { squaredNorm.squareRoot() }
+
+  /// Square of the Euclidean norm of `self`.
+  @differentiable
+  public var squaredNorm: Double { self.squared().sum() }
+
+  @differentiable
+  public static func + (_ lhs: Self, _ rhs: Self) -> Self {
+    var result = Self.zero
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 38)
+    result.x = lhs.x + rhs.x
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 40)
+    return result
+  }
+
+  @differentiable
+  public static func - (_ lhs: Self, _ rhs: Self) -> Self {
+    var result = Self.zero
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 47)
+    result.x = lhs.x - rhs.x
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 49)
+    return result
+  }
+
+  @differentiable
+  public static prefix func - (_ v: Self) -> Self {
+    var result = Self.zero
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 56)
+    result.x = -v.x
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 58)
+    return result
+  }
+}
+
+/// Other arithmetic on the vector elements.
+extension Vector1: ElementaryFunctions {
+  /// Sum of the elements of `self`.
+  public func sum() -> Double {
+    var result: Double = 0
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 68)
+    result = result + x
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+    return result
+  }
+
+  /// Vector whose elements are squares of the elements of `self`.
+  public func squared() -> Self {
+    var result = Self.zero
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 77)
+    result.x = x * x
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 79)
+    return result
+  }
+}
+
+/// Conformance to `VectorConvertible`.
+extension Vector1: VectorConvertible {
+  public init(_ vector: Vector) {
+    var index = vector.scalars.startIndex
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 88)
+    self.x = vector.scalars[index]
+    index = vector.scalars.index(after: index)
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 91)
+  }
+
+  public var vector: Vector {
+    return Vector([x])
+  }
+}
+
+/// Conversion to/from tensor.
+extension Vector1 {
+  /// A `Tensor` with shape `[1]` whose elements are the elements of `self`.
+  @differentiable
+  public var tensor: Tensor<Double> {
+    Tensor([x])
+  }
+
+  /// Creates a `Vector1` with the same elements as `tensor`.
+  ///
+  /// Precondition: `tensor` must have shape `[1]`.
+  @differentiable
+  public init(_ tensor: Tensor<Double>) {
+    precondition(tensor.shape == [1])
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 113)
+    self.x = tensor[0].scalarized()
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 115)
+  }
+}
+
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 6)
+
+/// An element of R^2, with Euclidean norm.
+public struct Vector2: Differentiable, KeyPathIterable, TangentStandardBasis
+{
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 11)
+  @differentiable public var x: Double
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 11)
+  @differentiable public var y: Double
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 13)
+
+  @differentiable
+  public init(_ x: Double, _ y: Double) {
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 17)
+    self.x = x
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 17)
+    self.y = y
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 19)
+  }
+}
+
+/// Normed vector space methods.
+extension Vector2: AdditiveArithmetic, VectorProtocol {
+  public typealias VectorSpaceScalar = Double
+
+  /// Euclidean norm of `self`.
+  @differentiable
+  public var norm: Double { squaredNorm.squareRoot() }
+
+  /// Square of the Euclidean norm of `self`.
+  @differentiable
+  public var squaredNorm: Double { self.squared().sum() }
+
+  @differentiable
+  public static func + (_ lhs: Self, _ rhs: Self) -> Self {
+    var result = Self.zero
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 38)
+    result.x = lhs.x + rhs.x
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 38)
+    result.y = lhs.y + rhs.y
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 40)
+    return result
+  }
+
+  @differentiable
+  public static func - (_ lhs: Self, _ rhs: Self) -> Self {
+    var result = Self.zero
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 47)
+    result.x = lhs.x - rhs.x
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 47)
+    result.y = lhs.y - rhs.y
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 49)
+    return result
+  }
+
+  @differentiable
+  public static prefix func - (_ v: Self) -> Self {
+    var result = Self.zero
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 56)
+    result.x = -v.x
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 56)
+    result.y = -v.y
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 58)
+    return result
+  }
+}
+
+/// Other arithmetic on the vector elements.
+extension Vector2: ElementaryFunctions {
+  /// Sum of the elements of `self`.
+  public func sum() -> Double {
+    var result: Double = 0
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 68)
+    result = result + x
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 68)
+    result = result + y
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+    return result
+  }
+
+  /// Vector whose elements are squares of the elements of `self`.
+  public func squared() -> Self {
+    var result = Self.zero
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 77)
+    result.x = x * x
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 77)
+    result.y = y * y
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 79)
+    return result
+  }
+}
+
+/// Conformance to `VectorConvertible`.
+extension Vector2: VectorConvertible {
+  public init(_ vector: Vector) {
+    var index = vector.scalars.startIndex
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 88)
+    self.x = vector.scalars[index]
+    index = vector.scalars.index(after: index)
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 88)
+    self.y = vector.scalars[index]
+    index = vector.scalars.index(after: index)
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 91)
+  }
+
+  public var vector: Vector {
+    return Vector([x, y])
+  }
+}
+
+/// Conversion to/from tensor.
+extension Vector2 {
+  /// A `Tensor` with shape `[2]` whose elements are the elements of `self`.
+  @differentiable
+  public var tensor: Tensor<Double> {
+    Tensor([x, y])
+  }
+
+  /// Creates a `Vector2` with the same elements as `tensor`.
+  ///
+  /// Precondition: `tensor` must have shape `[2]`.
+  @differentiable
+  public init(_ tensor: Tensor<Double>) {
+    precondition(tensor.shape == [2])
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 113)
+    self.x = tensor[0].scalarized()
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 113)
+    self.y = tensor[1].scalarized()
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 115)
+  }
+}
+
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 6)
+
+/// An element of R^3, with Euclidean norm.
+public struct Vector3: Differentiable, KeyPathIterable, TangentStandardBasis
+{
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 11)
+  @differentiable public var x: Double
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 11)
+  @differentiable public var y: Double
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 11)
+  @differentiable public var z: Double
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 13)
+
+  @differentiable
+  public init(_ x: Double, _ y: Double, _ z: Double) {
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 17)
+    self.x = x
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 17)
+    self.y = y
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 17)
+    self.z = z
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 19)
+  }
+}
+
+/// Normed vector space methods.
+extension Vector3: AdditiveArithmetic, VectorProtocol {
+  public typealias VectorSpaceScalar = Double
+
+  /// Euclidean norm of `self`.
+  @differentiable
+  public var norm: Double { squaredNorm.squareRoot() }
+
+  /// Square of the Euclidean norm of `self`.
+  @differentiable
+  public var squaredNorm: Double { self.squared().sum() }
+
+  @differentiable
+  public static func + (_ lhs: Self, _ rhs: Self) -> Self {
+    var result = Self.zero
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 38)
+    result.x = lhs.x + rhs.x
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 38)
+    result.y = lhs.y + rhs.y
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 38)
+    result.z = lhs.z + rhs.z
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 40)
+    return result
+  }
+
+  @differentiable
+  public static func - (_ lhs: Self, _ rhs: Self) -> Self {
+    var result = Self.zero
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 47)
+    result.x = lhs.x - rhs.x
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 47)
+    result.y = lhs.y - rhs.y
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 47)
+    result.z = lhs.z - rhs.z
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 49)
+    return result
+  }
+
+  @differentiable
+  public static prefix func - (_ v: Self) -> Self {
+    var result = Self.zero
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 56)
+    result.x = -v.x
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 56)
+    result.y = -v.y
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 56)
+    result.z = -v.z
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 58)
+    return result
+  }
+}
+
+/// Other arithmetic on the vector elements.
+extension Vector3: ElementaryFunctions {
+  /// Sum of the elements of `self`.
+  public func sum() -> Double {
+    var result: Double = 0
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 68)
+    result = result + x
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 68)
+    result = result + y
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 68)
+    result = result + z
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+    return result
+  }
+
+  /// Vector whose elements are squares of the elements of `self`.
+  public func squared() -> Self {
+    var result = Self.zero
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 77)
+    result.x = x * x
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 77)
+    result.y = y * y
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 77)
+    result.z = z * z
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 79)
+    return result
+  }
+}
+
+/// Conformance to `VectorConvertible`.
+extension Vector3: VectorConvertible {
+  public init(_ vector: Vector) {
+    var index = vector.scalars.startIndex
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 88)
+    self.x = vector.scalars[index]
+    index = vector.scalars.index(after: index)
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 88)
+    self.y = vector.scalars[index]
+    index = vector.scalars.index(after: index)
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 88)
+    self.z = vector.scalars[index]
+    index = vector.scalars.index(after: index)
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 91)
+  }
+
+  public var vector: Vector {
+    return Vector([x, y, z])
+  }
+}
+
+/// Conversion to/from tensor.
+extension Vector3 {
+  /// A `Tensor` with shape `[3]` whose elements are the elements of `self`.
+  @differentiable
+  public var tensor: Tensor<Double> {
+    Tensor([x, y, z])
+  }
+
+  /// Creates a `Vector3` with the same elements as `tensor`.
+  ///
+  /// Precondition: `tensor` must have shape `[3]`.
+  @differentiable
+  public init(_ tensor: Tensor<Double>) {
+    precondition(tensor.shape == [3])
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 113)
+    self.x = tensor[0].scalarized()
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 113)
+    self.y = tensor[1].scalarized()
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 113)
+    self.z = tensor[2].scalarized()
+// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 115)
+  }
+}
+

--- a/Sources/SwiftFusion/Core/VectorN.swift.gyb
+++ b/Sources/SwiftFusion/Core/VectorN.swift.gyb
@@ -1,0 +1,118 @@
+import TensorFlow
+
+% dims = [1, 2, 3]
+% for dim in dims:
+% coordinates = ['x', 'y', 'z'][0:dim]
+
+/// An element of R^${dim}, with Euclidean norm.
+public struct Vector${dim}: Differentiable, KeyPathIterable, TangentStandardBasis
+{
+  % for coordinate in coordinates:
+  @differentiable public var ${coordinate}: Double
+  % end
+
+  @differentiable
+  public init(${', '.join(['_ %s: Double' % c for c in coordinates])}) {
+    % for (index, coordinate) in enumerate(coordinates):
+    self.${coordinate} = ${coordinate}
+    % end
+  }
+}
+
+/// Normed vector space methods.
+extension Vector${dim}: AdditiveArithmetic, VectorProtocol {
+  public typealias VectorSpaceScalar = Double
+
+  /// Euclidean norm of `self`.
+  @differentiable
+  public var norm: Double { squaredNorm.squareRoot() }
+
+  /// Square of the Euclidean norm of `self`.
+  @differentiable
+  public var squaredNorm: Double { self.squared().sum() }
+
+  @differentiable
+  public static func + (_ lhs: Self, _ rhs: Self) -> Self {
+    var result = Self.zero
+    % for coordinate in coordinates:
+    result.${coordinate} = lhs.${coordinate} + rhs.${coordinate}
+    % end
+    return result
+  }
+
+  @differentiable
+  public static func - (_ lhs: Self, _ rhs: Self) -> Self {
+    var result = Self.zero
+    % for coordinate in coordinates:
+    result.${coordinate} = lhs.${coordinate} - rhs.${coordinate}
+    % end
+    return result
+  }
+
+  @differentiable
+  public static prefix func - (_ v: Self) -> Self {
+    var result = Self.zero
+    % for coordinate in coordinates:
+    result.${coordinate} = -v.${coordinate}
+    % end
+    return result
+  }
+}
+
+/// Other arithmetic on the vector elements.
+extension Vector${dim}: ElementaryFunctions {
+  /// Sum of the elements of `self`.
+  public func sum() -> Double {
+    var result: Double = 0
+    % for coordinate in coordinates:
+    result = result + ${coordinate}
+    % end
+    return result
+  }
+
+  /// Vector whose elements are squares of the elements of `self`.
+  public func squared() -> Self {
+    var result = Self.zero
+    % for coordinate in coordinates:
+    result.${coordinate} = ${coordinate} * ${coordinate}
+    % end
+    return result
+  }
+}
+
+/// Conformance to `VectorConvertible`.
+extension Vector${dim}: VectorConvertible {
+  public init(_ vector: Vector) {
+    var index = vector.scalars.startIndex
+    % for coordinate in coordinates:
+    self.${coordinate} = vector.scalars[index]
+    index = vector.scalars.index(after: index)
+    % end
+  }
+
+  public var vector: Vector {
+    return Vector([${', '.join(coordinates)}])
+  }
+}
+
+/// Conversion to/from tensor.
+extension Vector${dim} {
+  /// A `Tensor` with shape `[${dim}]` whose elements are the elements of `self`.
+  @differentiable
+  public var tensor: Tensor<Double> {
+    Tensor([${', '.join(coordinates)}])
+  }
+
+  /// Creates a `Vector${dim}` with the same elements as `tensor`.
+  ///
+  /// Precondition: `tensor` must have shape `[${dim}]`.
+  @differentiable
+  public init(_ tensor: Tensor<Double>) {
+    precondition(tensor.shape == [${dim}])
+    % for (index, coordinate) in enumerate(coordinates):
+    self.${coordinate} = tensor[${index}].scalarized()
+    % end
+  }
+}
+
+% end

--- a/Sources/SwiftFusion/Inference/BetweenFactor.swift
+++ b/Sources/SwiftFusion/Inference/BetweenFactor.swift
@@ -87,11 +87,11 @@ public struct BetweenFactor: NonlinearFactor {
   
   public func linearize(_ values: Values) -> JacobianFactor {
     let j = jacobian(of: self.errorVector, at: values)
-    
-    let j1 = Tensor<Double>(stacking: (0..<3).map { i in (j[i]._values[values._indices[key1]!].base as! Pose2.TangentVector).tensor.reshaped(to: TensorShape([3])) })
-    let j2 = Tensor<Double>(stacking: (0..<3).map { i in (j[i]._values[values._indices[key2]!].base as! Pose2.TangentVector).tensor.reshaped(to: TensorShape([3])) })
-    
+
+    let j1 = Matrix(stacking: (0..<3).map { i in (j[i]._values[values._indices[key1]!].base as! Pose2.TangentVector).vector } )
+    let j2 = Matrix(stacking: (0..<3).map { i in (j[i]._values[values._indices[key2]!].base as! Pose2.TangentVector).vector } )
+
     // TODO: remove this negative sign
-    return JacobianFactor(keys, [j1, j2], -errorVector(values).tensor.reshaped(to: [3, 1]))
+    return JacobianFactor(keys, [j1, j2], errorVector(values).vector.scaled(by: -1))
   }
 }

--- a/Sources/SwiftFusion/Inference/Errors.swift
+++ b/Sources/SwiftFusion/Inference/Errors.swift
@@ -15,7 +15,7 @@ import TensorFlow
 
 /// The type of error vector returned by the Factor
 /// Should be VectorN, but now just tensor as we do not have fixed size Tensors
-public typealias Error = Tensor<Double>
+public typealias Error = Vector
 
 /// Collection of all errors returned by a Factor Graph
 public typealias Errors = Array<Error>
@@ -33,7 +33,7 @@ extension Array where Element == Error {
   /// Calculates the L2 norm
   public var norm: Double {
     get {
-      self.map { $0.squared().sum().scalar! }.reduce(0.0, { $0 + $1 })
+      self.map { $0.squared().sum() }.reduce(0.0, { $0 + $1 })
     }
   }
   

--- a/Sources/SwiftFusion/Inference/JacobianFactor.swift
+++ b/Sources/SwiftFusion/Inference/JacobianFactor.swift
@@ -11,12 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import TensorFlow
-
 /// A `LinearFactor` that operates like `JacobianFactor` in GTSAM.
 ///
 /// Input is a dictionary of `Key` to `Tensor` pairs, and the output is the paired
-/// error vector. Note here that the Tensor shapes are not checked.
+/// error vector. Note here that the shapes are not checked.
 ///
 /// Interpretation
 /// ================
@@ -46,15 +44,15 @@ public struct JacobianFactor: LinearFactor {
   
   public var dimension: Int {
     get {
-      jacobians[0].shape.dimensions[0]
+      jacobians[0].rowCount
     }
   }
-  public var keys: Array<Int> = []
-  public var jacobians: Array<Tensor<Double>> = []
-  public var b: Tensor<Double> = eye(rowCount: 0)
+  public var keys: Array<Int>
+  public var jacobians: Array<Matrix>
+  public var b: Vector
   public typealias Output = Error
   
-  public init (_ key: [Int], _ A: [Tensor<Double>], _ b: Tensor<Double>) {
+  public init (_ key: [Int], _ A: [Matrix], _ b: Vector) {
     keys = key
     jacobians = A
     self.b = b
@@ -69,11 +67,11 @@ public struct JacobianFactor: LinearFactor {
   ///                 x3
   /// ```
   static func * (lhs: JacobianFactor, rhs: VectorValues) -> Self.Output {
-    var arr: Array<Tensor<Double>> = []
+    var result = Vector(zeros: lhs.dimension)
     for i in lhs.keys.indices {
-      arr.append(matmul(lhs.jacobians[i], rhs[lhs.keys[i]]))
+      result += matvec(lhs.jacobians[i], rhs[lhs.keys[i]])
     }
-    return arr.reduce(Tensor<Double>(repeating: 0.0, shape: TensorShape([lhs.dimension, 1])), { $0 + $1 })
+    return result
   }
   
   /// Calculate `J^T * e`
@@ -98,9 +96,9 @@ public struct JacobianFactor: LinearFactor {
       
       // TODO(fan): add a proper method for searching key
       if let ind = result._indices[k] {
-        result._values[ind] += matmul(jacobians[pos].transposed(), r)
+        result._values[ind] += matvec(jacobians[pos], transposed: true, r)
       } else {
-        result.insert(k, matmul(jacobians[pos].transposed(), r))
+        result.insert(k, matvec(jacobians[pos], transposed: true, r))
       }
     }
     return result

--- a/Sources/SwiftFusion/Inference/NonlinearFactorGraph.swift
+++ b/Sources/SwiftFusion/Inference/NonlinearFactorGraph.swift
@@ -34,16 +34,9 @@ public struct NonlinearFactorGraph {
   /// linearize the nonlinear factor graph to a linear factor graph
   public func linearize(_ values: Values) -> GaussianFactorGraph {
     var gfg = GaussianFactorGraph()
-    
     for i in factors {
-      let linearized = i.linearize(values)
-      
-      // Assertion for the shape of Jacobian
-      assert(linearized.jacobians.map { $0.shape.count == 2 }.reduce(true, { $0 && $1 }))
-      
-      gfg += linearized
+      gfg += i.linearize(values)
     }
-    
     return gfg
   }
 

--- a/Sources/SwiftFusion/Inference/PriorFactor.swift
+++ b/Sources/SwiftFusion/Inference/PriorFactor.swift
@@ -61,9 +61,7 @@ public struct PriorFactor: NonlinearFactor {
   
   public func linearize(_ values: Values) -> JacobianFactor {
     let j = jacobian(of: self.errorVector, at: values)
-    
-    let j1 = Tensor<Double>(stacking: (0..<3).map { i in (j[i]._values[0].base as! Pose2.TangentVector).tensor.reshaped(to: TensorShape([3])) })
-    
-    return JacobianFactor(keys, [j1], -errorVector(values).tensor.reshaped(to: [3, 1]))
+    let j1 = Matrix(stacking: (0..<3).map { i in (j[i]._values[values._indices[keys[0]]!].base as! Pose2.TangentVector).vector } )
+    return JacobianFactor(keys, [j1], errorVector(values).vector.scaled(by: -1))
   }
 }

--- a/Tests/SwiftFusionTests/Core/MatrixTests.swift
+++ b/Tests/SwiftFusionTests/Core/MatrixTests.swift
@@ -1,76 +1,75 @@
+import Foundation
+import TensorFlow
 import XCTest
 
-import TensorFlow
 import SwiftFusion
 
 class MatrixTests: XCTestCase {
-    static var allTests = [
-        ("test_concat", testConcat),
-        ("test_log", test_log),
-        ("test_neg", test_neg),
-        ("test_squared", test_squared),
-    ]
+  static var allTests = [
+    ("testInitializers", testInitializers),
+    ("testSubscripts", testSubscripts),
+    ("testElementArithmetic", testElementArithmetic),
+    ("testMutations", testMutations),
+    ("testMatVec", testMatVec),
+  ]
 
-    //--------------------------------------------------------------------------
-    // testConcat
-    func testConcat() {
-        let t1 = Tensor(shape: [2, 3], scalars: (1...6).map { Double($0) })
-        let t2 = Tensor(shape: [2, 3], scalars: (7...12).map { Double($0) })
-        let c1 = t1.concatenated(with: t2)
-        let c1Expected = Tensor([
-            1,  2,  3,
-            4,  5,  6,
-            7,  8,  9,
-            10, 11, 12,
-        ])
-        
-        XCTAssert(c1.flattened() == c1Expected)
-        
-        let c2 = t1.concatenated(with: t2, alongAxis: 1)
-        let c2Expected = Tensor([
-            1, 2, 3,  7,  8,  9,
-            4, 5, 6, 10, 11, 12
-        ])
-        
-        XCTAssert(c2.flattened() == c2Expected)
-    }
+  /// Tests that the initializers work.
+  func testInitializers() {
+    let matrix1 = Matrix([1, 2, 3, 4, 5, 6], rowCount: 2, columnCount: 3)
+    XCTAssertEqual(matrix1.scalars, [1, 2, 3, 4, 5, 6])
+    XCTAssertEqual(matrix1.rowCount, 2)
+    XCTAssertEqual(matrix1.columnCount, 3)
 
-    //--------------------------------------------------------------------------
-    // test_log
-    func test_log() {
-        let range = 0..<6
-        let matrix = Tensor(shape: [3, 2], scalars: (range).map { Double($0) })
-        let values = log(matrix).flattened()
-        let expected = Tensor(range.map { Foundation.log(Double($0)) })
-        assertEqual(values, expected, accuracy: 1e-8)
-    }
-    
-    //--------------------------------------------------------------------------
-    // test_neg
-    func test_neg() {
-        let range = 0..<6
-        let matrix = Tensor(shape: [3, 2], scalars: (range).map { Double($0) })
-        let expected = Tensor(range.map { -Double($0) })
+    let matrix2 = Matrix(eye: 3)
+    XCTAssertEqual(matrix2.scalars, [1, 0, 0, 0, 1, 0, 0, 0, 1])
+    XCTAssertEqual(matrix2.rowCount, 3)
+    XCTAssertEqual(matrix2.columnCount, 3)
 
-        let values = (-matrix).flattened()
-        assertEqual(values, expected, accuracy: 1e-8)
-    }
-    
-    //--------------------------------------------------------------------------
-    // test_squared
-    func test_squared() {
-        let matrix = Tensor(shape: [3, 2], scalars: ([0, -1, 2, -3, 4, 5]).map { Double($0) })
-        let values = matrix.squared().flattened()
-        let expected = Tensor((0...5).map { Double ($0 * $0) })
-        assertEqual(values, expected, accuracy: 1e-8)
-    }
-        
-    //--------------------------------------------------------------------------
-    // test_multiplication
-    func test_multiplication() {
-        let matrix = Tensor(shape: [3, 2], scalars: ([0, -1, 2, -3, 4, 5]).map { Double($0) })
-        let values = (matrix * matrix).flattened()
-        let expected = Tensor((0...5).map { Double($0 * $0) })
-        assertEqual(values, expected, accuracy: 1e-8)
-    }
+    let matrix3 = Matrix(stacking: [Vector([1, 2, 3]), Vector([4, 5, 6])])
+    XCTAssertEqual(matrix3.scalars, [1, 2, 3, 4, 5, 6])
+    XCTAssertEqual(matrix3.rowCount, 2)
+    XCTAssertEqual(matrix3.columnCount, 3)
+  }
+
+  /// Tests that the subscripts work.
+  func testSubscripts() {
+    let matrix1 = Matrix([1, 2, 3, 4, 5, 6], rowCount: 2, columnCount: 3)
+    XCTAssertEqual(matrix1[0, 0], 1)
+    XCTAssertEqual(matrix1[0, 1], 2)
+    XCTAssertEqual(matrix1[0, 2], 3)
+    XCTAssertEqual(matrix1[1, 0], 4)
+    XCTAssertEqual(matrix1[1, 1], 5)
+    XCTAssertEqual(matrix1[1, 2], 6)
+  }
+
+  /// Tests that the element arithmetic methods work.
+  func testElementArithmetic() {
+    let matrix1 = Matrix([1, 2, 3, 4, 5, 6], rowCount: 2, columnCount: 3)
+    XCTAssertEqual(2 * matrix1, Matrix([2, 4, 6, 8, 10, 12], rowCount: 2, columnCount: 3))
+    XCTAssertEqual(matrix1 * 2, Matrix([2, 4, 6, 8, 10, 12], rowCount: 2, columnCount: 3))
+  }
+
+  /// Test that the mutation methods work.
+  func testMutations() {
+    var matrix1 = Matrix([], rowCount: 0, columnCount: 2)
+    matrix1.append(row: Vector([1, 2]))
+    XCTAssertEqual(matrix1, Matrix([1, 2], rowCount: 1, columnCount: 2))
+    matrix1.append(row: Vector([3, 4]))
+    XCTAssertEqual(matrix1, Matrix([1, 2, 3, 4], rowCount: 2, columnCount: 2))
+  }
+
+  /// Test matrix-vector multiplication.
+  func testMatVec() {
+    let matrix1 = Matrix([1, 2, 3, 4, 5, 6], rowCount: 2, columnCount: 3)
+    let vector1 = Vector([10, 20, 30])
+    let vector2 = Vector([40, 50])
+    XCTAssertEqual(
+      matvec(matrix1, vector1),
+      Vector([140, 320])
+    )
+    XCTAssertEqual(
+      matvec(matrix1, transposed: true, vector2),
+      Vector([240, 330, 420])
+    )
+  }
 }

--- a/Tests/SwiftFusionTests/Core/TensorFlowMatrixTests.swift
+++ b/Tests/SwiftFusionTests/Core/TensorFlowMatrixTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+
+import TensorFlow
+import SwiftFusion
+
+class TensorFlowMatrixTests: XCTestCase {
+    static var allTests = [
+        ("test_concat", testConcat),
+        ("test_log", test_log),
+        ("test_neg", test_neg),
+        ("test_squared", test_squared),
+    ]
+
+    //--------------------------------------------------------------------------
+    // testConcat
+    func testConcat() {
+        let t1 = Tensor(shape: [2, 3], scalars: (1...6).map { Double($0) })
+        let t2 = Tensor(shape: [2, 3], scalars: (7...12).map { Double($0) })
+        let c1 = t1.concatenated(with: t2)
+        let c1Expected = Tensor([
+            1,  2,  3,
+            4,  5,  6,
+            7,  8,  9,
+            10, 11, 12,
+        ])
+        
+        XCTAssert(c1.flattened() == c1Expected)
+        
+        let c2 = t1.concatenated(with: t2, alongAxis: 1)
+        let c2Expected = Tensor([
+            1, 2, 3,  7,  8,  9,
+            4, 5, 6, 10, 11, 12
+        ])
+        
+        XCTAssert(c2.flattened() == c2Expected)
+    }
+
+    //--------------------------------------------------------------------------
+    // test_log
+    func test_log() {
+        let range = 0..<6
+        let matrix = Tensor(shape: [3, 2], scalars: (range).map { Double($0) })
+        let values = log(matrix).flattened()
+        let expected = Tensor(range.map { Foundation.log(Double($0)) })
+        assertEqual(values, expected, accuracy: 1e-8)
+    }
+    
+    //--------------------------------------------------------------------------
+    // test_neg
+    func test_neg() {
+        let range = 0..<6
+        let matrix = Tensor(shape: [3, 2], scalars: (range).map { Double($0) })
+        let expected = Tensor(range.map { -Double($0) })
+
+        let values = (-matrix).flattened()
+        assertEqual(values, expected, accuracy: 1e-8)
+    }
+    
+    //--------------------------------------------------------------------------
+    // test_squared
+    func test_squared() {
+        let matrix = Tensor(shape: [3, 2], scalars: ([0, -1, 2, -3, 4, 5]).map { Double($0) })
+        let values = matrix.squared().flattened()
+        let expected = Tensor((0...5).map { Double ($0 * $0) })
+        assertEqual(values, expected, accuracy: 1e-8)
+    }
+        
+    //--------------------------------------------------------------------------
+    // test_multiplication
+    func test_multiplication() {
+        let matrix = Tensor(shape: [3, 2], scalars: ([0, -1, 2, -3, 4, 5]).map { Double($0) })
+        let values = (matrix * matrix).flattened()
+        let expected = Tensor((0...5).map { Double($0 * $0) })
+        assertEqual(values, expected, accuracy: 1e-8)
+    }
+}

--- a/Tests/SwiftFusionTests/Core/VectorNTests.swift
+++ b/Tests/SwiftFusionTests/Core/VectorNTests.swift
@@ -1,0 +1,502 @@
+// WARNING: This is a generated file. Do not edit it. Instead, edit the corresponding ".gyb" file.
+// See "generate.sh" in the root of this repository for instructions how to regenerate files.
+
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 1)
+import Foundation
+import TensorFlow
+import XCTest
+
+import SwiftFusion
+
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 9)
+
+class VectorNTests: XCTestCase {
+  static var allTests = [
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 13)
+    ("testVector1Init", testVector1Init),
+    ("testVector1Equality", testVector1Equality),
+    ("testVector1Norm", testVector1Norm),
+    ("testVector1SquaredNorm", testVector1SquaredNorm),
+    ("testVector1Add", testVector1Add),
+    ("testVector1Subtract", testVector1Subtract),
+    ("testVector1ScalarMultiply", testVector1ScalarMultiply),
+    ("testVector1Negate", testVector1Negate),
+    ("testVector1Squared", testVector1Squared),
+    ("testVector1Sum", testVector1Sum),
+    ("testVector1TangentVector", testVector1TangentVector),
+    ("testVector1Move", testVector1Move),
+    ("testVector1ConvertToVector", testVector1ConvertToVector),
+    ("testVector1ConvertFromVector", testVector1ConvertFromVector),
+    ("testVector1TensorInit", testVector1TensorInit),
+    ("testVector1TensorExtract", testVector1TensorExtract),
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 13)
+    ("testVector2Init", testVector2Init),
+    ("testVector2Equality", testVector2Equality),
+    ("testVector2Norm", testVector2Norm),
+    ("testVector2SquaredNorm", testVector2SquaredNorm),
+    ("testVector2Add", testVector2Add),
+    ("testVector2Subtract", testVector2Subtract),
+    ("testVector2ScalarMultiply", testVector2ScalarMultiply),
+    ("testVector2Negate", testVector2Negate),
+    ("testVector2Squared", testVector2Squared),
+    ("testVector2Sum", testVector2Sum),
+    ("testVector2TangentVector", testVector2TangentVector),
+    ("testVector2Move", testVector2Move),
+    ("testVector2ConvertToVector", testVector2ConvertToVector),
+    ("testVector2ConvertFromVector", testVector2ConvertFromVector),
+    ("testVector2TensorInit", testVector2TensorInit),
+    ("testVector2TensorExtract", testVector2TensorExtract),
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 13)
+    ("testVector3Init", testVector3Init),
+    ("testVector3Equality", testVector3Equality),
+    ("testVector3Norm", testVector3Norm),
+    ("testVector3SquaredNorm", testVector3SquaredNorm),
+    ("testVector3Add", testVector3Add),
+    ("testVector3Subtract", testVector3Subtract),
+    ("testVector3ScalarMultiply", testVector3ScalarMultiply),
+    ("testVector3Negate", testVector3Negate),
+    ("testVector3Squared", testVector3Squared),
+    ("testVector3Sum", testVector3Sum),
+    ("testVector3TangentVector", testVector3TangentVector),
+    ("testVector3Move", testVector3Move),
+    ("testVector3ConvertToVector", testVector3ConvertToVector),
+    ("testVector3ConvertFromVector", testVector3ConvertFromVector),
+    ("testVector3TensorInit", testVector3TensorInit),
+    ("testVector3TensorExtract", testVector3TensorExtract)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 30)
+  ]
+
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 36)
+
+  /// Test that initializing a vector from coordinate values works.
+  func testVector1Init() {
+    let vector1 = Vector1(1)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 41)
+    XCTAssertEqual(vector1.x, 1)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 43)
+  }
+
+  /// Test that vector norm works.
+  func testVector1Norm() {
+    let vector1 = Vector1(1)
+    XCTAssertEqual(vector1.norm, 1.0, accuracy: 1e-6)
+  }
+
+  /// Test that vector squared norm works.
+  func testVector1SquaredNorm() {
+    let vector1 = Vector1(1)
+    XCTAssertEqual(vector1.squaredNorm, 1, accuracy: 1e-6)
+  }
+
+  /// Test that vector `==` works.
+  func testVector1Equality() {
+    let vector1 = Vector1(1)
+    let vector2 = Vector1(2)
+    XCTAssertTrue(vector1 == vector1)
+    XCTAssertFalse(vector1 == vector2)
+  }
+
+  /// Test that vector addition works.
+  func testVector1Add() {
+    let vector1 = Vector1(1)
+    let vector2 = Vector1(2)
+    let sum = vector1 + vector2
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 71)
+    XCTAssertEqual(sum.x, 3)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 73)
+  }
+
+  /// Test that vector subtraction works.
+  func testVector1Subtract() {
+    let vector1 = Vector1(1)
+    let vector2 = Vector1(2)
+    let difference = vector1 - vector2
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 81)
+    XCTAssertEqual(difference.x, -1)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 83)
+  }
+
+  /// Test that vector scalar multiplication works.
+  func testVector1ScalarMultiply() {
+    let vector1 = Vector1(1)
+    let scaled = vector1.scaled(by: 2)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 90)
+    XCTAssertEqual(scaled.x, 2)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 92)
+  }
+
+  /// Test that vector negation works.
+  func testVector1Negate() {
+    let vector1 = Vector1(1)
+    let negated = -vector1
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 99)
+    XCTAssertEqual(negated.x, -1)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 101)
+  }
+
+  /// Test that vector squaring works.
+  func testVector1Squared() {
+    let vector1 = Vector1(1)
+    let squared = vector1.squared()
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 108)
+    XCTAssertEqual(squared.x, 1)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 110)
+  }
+
+  /// Test that vector sum works.
+  func testVector1Sum() {
+    let vector1 = Vector1(1)
+    XCTAssertEqual(vector1.sum(), 1)
+  }
+
+  /// Tests that `Vector1.TangentVector == Vector1`.
+  func testVector1TangentVector() {
+    let vector1 = Vector1(1)
+    let _: Vector1.TangentVector = vector1
+  }
+
+  /// Tests that the move (exponential map) operation works on vectors.
+  func testVector1Move() {
+    let vector1 = Vector1(1)
+    let vector2 = Vector1(2)
+    var moved = vector1
+    moved.move(along: vector2)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 131)
+    XCTAssertEqual(moved.x, 3)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 133)
+  }
+
+  /// Tests that conversion to `Vector` works.
+  func testVector1ConvertToVector() {
+    XCTAssertEqual(
+      Vector1(1).vector,
+      Vector([1])
+    )
+  }
+
+  /// Tests that conversion from `Vector` works.
+  func testVector1ConvertFromVector() {
+    XCTAssertEqual(
+      Vector1(Vector([1])),
+      Vector1(1)
+    )
+  }
+
+  /// Tests that we can initialize a vector from a tensor.
+  func testVector1TensorInit() {
+    let vector1 = Vector1(1)
+    let tensor1 = Tensor<Double>([1])
+    XCTAssertEqual(Vector1(tensor1), vector1)
+  }
+
+  /// Tests that we can extract a tensor from a vector.
+  func testVector1TensorExtract() {
+    let vector1 = Vector1(1)
+    let tensor1 = Tensor<Double>([1])
+    XCTAssertEqual(vector1.tensor, tensor1)
+  }
+
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 36)
+
+  /// Test that initializing a vector from coordinate values works.
+  func testVector2Init() {
+    let vector1 = Vector2(1, 2)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 41)
+    XCTAssertEqual(vector1.x, 1)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 41)
+    XCTAssertEqual(vector1.y, 2)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 43)
+  }
+
+  /// Test that vector norm works.
+  func testVector2Norm() {
+    let vector1 = Vector2(1, 2)
+    XCTAssertEqual(vector1.norm, 2.23606797749979, accuracy: 1e-6)
+  }
+
+  /// Test that vector squared norm works.
+  func testVector2SquaredNorm() {
+    let vector1 = Vector2(1, 2)
+    XCTAssertEqual(vector1.squaredNorm, 5, accuracy: 1e-6)
+  }
+
+  /// Test that vector `==` works.
+  func testVector2Equality() {
+    let vector1 = Vector2(1, 2)
+    let vector2 = Vector2(3, 4)
+    XCTAssertTrue(vector1 == vector1)
+    XCTAssertFalse(vector1 == vector2)
+  }
+
+  /// Test that vector addition works.
+  func testVector2Add() {
+    let vector1 = Vector2(1, 2)
+    let vector2 = Vector2(3, 4)
+    let sum = vector1 + vector2
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 71)
+    XCTAssertEqual(sum.x, 4)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 71)
+    XCTAssertEqual(sum.y, 6)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 73)
+  }
+
+  /// Test that vector subtraction works.
+  func testVector2Subtract() {
+    let vector1 = Vector2(1, 2)
+    let vector2 = Vector2(3, 4)
+    let difference = vector1 - vector2
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 81)
+    XCTAssertEqual(difference.x, -2)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 81)
+    XCTAssertEqual(difference.y, -2)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 83)
+  }
+
+  /// Test that vector scalar multiplication works.
+  func testVector2ScalarMultiply() {
+    let vector1 = Vector2(1, 2)
+    let scaled = vector1.scaled(by: 2)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 90)
+    XCTAssertEqual(scaled.x, 2)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 90)
+    XCTAssertEqual(scaled.y, 4)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 92)
+  }
+
+  /// Test that vector negation works.
+  func testVector2Negate() {
+    let vector1 = Vector2(1, 2)
+    let negated = -vector1
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 99)
+    XCTAssertEqual(negated.x, -1)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 99)
+    XCTAssertEqual(negated.y, -2)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 101)
+  }
+
+  /// Test that vector squaring works.
+  func testVector2Squared() {
+    let vector1 = Vector2(1, 2)
+    let squared = vector1.squared()
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 108)
+    XCTAssertEqual(squared.x, 1)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 108)
+    XCTAssertEqual(squared.y, 4)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 110)
+  }
+
+  /// Test that vector sum works.
+  func testVector2Sum() {
+    let vector1 = Vector2(1, 2)
+    XCTAssertEqual(vector1.sum(), 3)
+  }
+
+  /// Tests that `Vector2.TangentVector == Vector2`.
+  func testVector2TangentVector() {
+    let vector1 = Vector2(1, 2)
+    let _: Vector2.TangentVector = vector1
+  }
+
+  /// Tests that the move (exponential map) operation works on vectors.
+  func testVector2Move() {
+    let vector1 = Vector2(1, 2)
+    let vector2 = Vector2(3, 4)
+    var moved = vector1
+    moved.move(along: vector2)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 131)
+    XCTAssertEqual(moved.x, 4)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 131)
+    XCTAssertEqual(moved.y, 6)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 133)
+  }
+
+  /// Tests that conversion to `Vector` works.
+  func testVector2ConvertToVector() {
+    XCTAssertEqual(
+      Vector2(1, 2).vector,
+      Vector([1, 2])
+    )
+  }
+
+  /// Tests that conversion from `Vector` works.
+  func testVector2ConvertFromVector() {
+    XCTAssertEqual(
+      Vector2(Vector([1, 2])),
+      Vector2(1, 2)
+    )
+  }
+
+  /// Tests that we can initialize a vector from a tensor.
+  func testVector2TensorInit() {
+    let vector1 = Vector2(1, 2)
+    let tensor1 = Tensor<Double>([1, 2])
+    XCTAssertEqual(Vector2(tensor1), vector1)
+  }
+
+  /// Tests that we can extract a tensor from a vector.
+  func testVector2TensorExtract() {
+    let vector1 = Vector2(1, 2)
+    let tensor1 = Tensor<Double>([1, 2])
+    XCTAssertEqual(vector1.tensor, tensor1)
+  }
+
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 36)
+
+  /// Test that initializing a vector from coordinate values works.
+  func testVector3Init() {
+    let vector1 = Vector3(1, 2, 3)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 41)
+    XCTAssertEqual(vector1.x, 1)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 41)
+    XCTAssertEqual(vector1.y, 2)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 41)
+    XCTAssertEqual(vector1.z, 3)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 43)
+  }
+
+  /// Test that vector norm works.
+  func testVector3Norm() {
+    let vector1 = Vector3(1, 2, 3)
+    XCTAssertEqual(vector1.norm, 3.7416573867739413, accuracy: 1e-6)
+  }
+
+  /// Test that vector squared norm works.
+  func testVector3SquaredNorm() {
+    let vector1 = Vector3(1, 2, 3)
+    XCTAssertEqual(vector1.squaredNorm, 14, accuracy: 1e-6)
+  }
+
+  /// Test that vector `==` works.
+  func testVector3Equality() {
+    let vector1 = Vector3(1, 2, 3)
+    let vector2 = Vector3(4, 5, 6)
+    XCTAssertTrue(vector1 == vector1)
+    XCTAssertFalse(vector1 == vector2)
+  }
+
+  /// Test that vector addition works.
+  func testVector3Add() {
+    let vector1 = Vector3(1, 2, 3)
+    let vector2 = Vector3(4, 5, 6)
+    let sum = vector1 + vector2
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 71)
+    XCTAssertEqual(sum.x, 5)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 71)
+    XCTAssertEqual(sum.y, 7)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 71)
+    XCTAssertEqual(sum.z, 9)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 73)
+  }
+
+  /// Test that vector subtraction works.
+  func testVector3Subtract() {
+    let vector1 = Vector3(1, 2, 3)
+    let vector2 = Vector3(4, 5, 6)
+    let difference = vector1 - vector2
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 81)
+    XCTAssertEqual(difference.x, -3)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 81)
+    XCTAssertEqual(difference.y, -3)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 81)
+    XCTAssertEqual(difference.z, -3)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 83)
+  }
+
+  /// Test that vector scalar multiplication works.
+  func testVector3ScalarMultiply() {
+    let vector1 = Vector3(1, 2, 3)
+    let scaled = vector1.scaled(by: 2)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 90)
+    XCTAssertEqual(scaled.x, 2)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 90)
+    XCTAssertEqual(scaled.y, 4)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 90)
+    XCTAssertEqual(scaled.z, 6)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 92)
+  }
+
+  /// Test that vector negation works.
+  func testVector3Negate() {
+    let vector1 = Vector3(1, 2, 3)
+    let negated = -vector1
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 99)
+    XCTAssertEqual(negated.x, -1)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 99)
+    XCTAssertEqual(negated.y, -2)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 99)
+    XCTAssertEqual(negated.z, -3)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 101)
+  }
+
+  /// Test that vector squaring works.
+  func testVector3Squared() {
+    let vector1 = Vector3(1, 2, 3)
+    let squared = vector1.squared()
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 108)
+    XCTAssertEqual(squared.x, 1)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 108)
+    XCTAssertEqual(squared.y, 4)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 108)
+    XCTAssertEqual(squared.z, 9)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 110)
+  }
+
+  /// Test that vector sum works.
+  func testVector3Sum() {
+    let vector1 = Vector3(1, 2, 3)
+    XCTAssertEqual(vector1.sum(), 6)
+  }
+
+  /// Tests that `Vector3.TangentVector == Vector3`.
+  func testVector3TangentVector() {
+    let vector1 = Vector3(1, 2, 3)
+    let _: Vector3.TangentVector = vector1
+  }
+
+  /// Tests that the move (exponential map) operation works on vectors.
+  func testVector3Move() {
+    let vector1 = Vector3(1, 2, 3)
+    let vector2 = Vector3(4, 5, 6)
+    var moved = vector1
+    moved.move(along: vector2)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 131)
+    XCTAssertEqual(moved.x, 5)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 131)
+    XCTAssertEqual(moved.y, 7)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 131)
+    XCTAssertEqual(moved.z, 9)
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 133)
+  }
+
+  /// Tests that conversion to `Vector` works.
+  func testVector3ConvertToVector() {
+    XCTAssertEqual(
+      Vector3(1, 2, 3).vector,
+      Vector([1, 2, 3])
+    )
+  }
+
+  /// Tests that conversion from `Vector` works.
+  func testVector3ConvertFromVector() {
+    XCTAssertEqual(
+      Vector3(Vector([1, 2, 3])),
+      Vector3(1, 2, 3)
+    )
+  }
+
+  /// Tests that we can initialize a vector from a tensor.
+  func testVector3TensorInit() {
+    let vector1 = Vector3(1, 2, 3)
+    let tensor1 = Tensor<Double>([1, 2, 3])
+    XCTAssertEqual(Vector3(tensor1), vector1)
+  }
+
+  /// Tests that we can extract a tensor from a vector.
+  func testVector3TensorExtract() {
+    let vector1 = Vector3(1, 2, 3)
+    let tensor1 = Tensor<Double>([1, 2, 3])
+    XCTAssertEqual(vector1.tensor, tensor1)
+  }
+
+// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb", line: 166)
+}

--- a/Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb
+++ b/Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb
@@ -7,7 +7,7 @@ import SwiftFusion
 % import math
 % dims = [1, 2, 3]
 
-class VectorTests: XCTestCase {
+class VectorNTests: XCTestCase {
   static var allTests = [
     % for dim in dims:
     ("testVector${dim}Init", testVector${dim}Init),
@@ -22,6 +22,8 @@ class VectorTests: XCTestCase {
     ("testVector${dim}Sum", testVector${dim}Sum),
     ("testVector${dim}TangentVector", testVector${dim}TangentVector),
     ("testVector${dim}Move", testVector${dim}Move),
+    ("testVector${dim}ConvertToVector", testVector${dim}ConvertToVector),
+    ("testVector${dim}ConvertFromVector", testVector${dim}ConvertFromVector),
     ("testVector${dim}TensorInit", testVector${dim}TensorInit),
     ("testVector${dim}TensorExtract", testVector${dim}TensorExtract)${',' if dim < dims[-1] else ''}
     % end
@@ -128,6 +130,22 @@ class VectorTests: XCTestCase {
     % for (index, coordinate) in enumerate(coordinates):
     XCTAssertEqual(moved.${coordinate}, ${values1[index] + values2[index]})
     % end
+  }
+
+  /// Tests that conversion to `Vector` works.
+  func testVector${dim}ConvertToVector() {
+    XCTAssertEqual(
+      Vector${dim}(${', '.join([str(v) for v in values1])}).vector,
+      Vector([${', '.join([str(v) for v in values1])}])
+    )
+  }
+
+  /// Tests that conversion from `Vector` works.
+  func testVector${dim}ConvertFromVector() {
+    XCTAssertEqual(
+      Vector${dim}(Vector([${', '.join([str(v) for v in values1])}])),
+      Vector${dim}(${', '.join([str(v) for v in values1])})
+    )
   }
 
   /// Tests that we can initialize a vector from a tensor.

--- a/Tests/SwiftFusionTests/Core/VectorTests.swift
+++ b/Tests/SwiftFusionTests/Core/VectorTests.swift
@@ -1,448 +1,74 @@
-// WARNING: This is a generated file. Do not edit it. Instead, edit the corresponding ".gyb" file.
-// See "generate.sh" in the root of this repository for instructions how to regenerate files.
-
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 1)
 import Foundation
 import TensorFlow
 import XCTest
 
 import SwiftFusion
 
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 9)
-
 class VectorTests: XCTestCase {
   static var allTests = [
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 13)
-    ("testVector1Init", testVector1Init),
-    ("testVector1Equality", testVector1Equality),
-    ("testVector1Norm", testVector1Norm),
-    ("testVector1SquaredNorm", testVector1SquaredNorm),
-    ("testVector1Add", testVector1Add),
-    ("testVector1Subtract", testVector1Subtract),
-    ("testVector1ScalarMultiply", testVector1ScalarMultiply),
-    ("testVector1Negate", testVector1Negate),
-    ("testVector1Squared", testVector1Squared),
-    ("testVector1Sum", testVector1Sum),
-    ("testVector1TangentVector", testVector1TangentVector),
-    ("testVector1Move", testVector1Move),
-    ("testVector1TensorInit", testVector1TensorInit),
-    ("testVector1TensorExtract", testVector1TensorExtract),
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 13)
-    ("testVector2Init", testVector2Init),
-    ("testVector2Equality", testVector2Equality),
-    ("testVector2Norm", testVector2Norm),
-    ("testVector2SquaredNorm", testVector2SquaredNorm),
-    ("testVector2Add", testVector2Add),
-    ("testVector2Subtract", testVector2Subtract),
-    ("testVector2ScalarMultiply", testVector2ScalarMultiply),
-    ("testVector2Negate", testVector2Negate),
-    ("testVector2Squared", testVector2Squared),
-    ("testVector2Sum", testVector2Sum),
-    ("testVector2TangentVector", testVector2TangentVector),
-    ("testVector2Move", testVector2Move),
-    ("testVector2TensorInit", testVector2TensorInit),
-    ("testVector2TensorExtract", testVector2TensorExtract),
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 13)
-    ("testVector3Init", testVector3Init),
-    ("testVector3Equality", testVector3Equality),
-    ("testVector3Norm", testVector3Norm),
-    ("testVector3SquaredNorm", testVector3SquaredNorm),
-    ("testVector3Add", testVector3Add),
-    ("testVector3Subtract", testVector3Subtract),
-    ("testVector3ScalarMultiply", testVector3ScalarMultiply),
-    ("testVector3Negate", testVector3Negate),
-    ("testVector3Squared", testVector3Squared),
-    ("testVector3Sum", testVector3Sum),
-    ("testVector3TangentVector", testVector3TangentVector),
-    ("testVector3Move", testVector3Move),
-    ("testVector3TensorInit", testVector3TensorInit),
-    ("testVector3TensorExtract", testVector3TensorExtract)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 28)
+    ("testInitializers", testInitializers),
+    ("testComputedProperties", testComputedProperties),
+    ("testElementArithmetic", testElementArithmetic),
+    ("testEuclideanNorm", testEuclideanNorm),
+    ("testAdditiveArithmetic", testAdditiveArithmetic),
+    ("testVectorProtocol", testVectorProtocol),
+    ("testTensorConversion", testTensorConversion),
   ]
 
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 34)
-
-  /// Test that initializing a vector from coordinate values works.
-  func testVector1Init() {
-    let vector1 = Vector1(1)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 39)
-    XCTAssertEqual(vector1.x, 1)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 41)
+  /// Tests that the initializers work.
+  func testInitializers() {
+    XCTAssertEqual(
+      Vector([1, 2, 3]).scalars,
+      [1, 2, 3]
+    )
+    XCTAssertEqual(
+      Vector(zeros: 4).scalars,
+      [0, 0, 0, 0]
+    )
   }
 
-  /// Test that vector norm works.
-  func testVector1Norm() {
-    let vector1 = Vector1(1)
-    XCTAssertEqual(vector1.norm, 1.0, accuracy: 1e-6)
+  /// Tests that the miscellaneous computed properties work.
+  func testComputedProperties() {
+    XCTAssertEqual(
+      Vector(zeros: 5).dimension,
+      5
+    )
   }
 
-  /// Test that vector squared norm works.
-  func testVector1SquaredNorm() {
-    let vector1 = Vector1(1)
-    XCTAssertEqual(vector1.squaredNorm, 1, accuracy: 1e-6)
+  /// Tests that the element arithmetic methods work.
+  func testElementArithmetic() {
+    let vector = Vector([1, 2, 3])
+    XCTAssertEqual(vector.sum(), 6)
+    XCTAssertEqual(vector.squared(), Vector([1, 4, 9]))
   }
 
-  /// Test that vector `==` works.
-  func testVector1Equality() {
-    let vector1 = Vector1(1)
-    let vector2 = Vector1(2)
-    XCTAssertTrue(vector1 == vector1)
-    XCTAssertFalse(vector1 == vector2)
+  /// Tests that the euclidean norm methods work.
+  func testEuclideanNorm() {
+    let vector = Vector([3, 4])
+    XCTAssertEqual(vector.squaredNorm, 25)
+    XCTAssertEqual(vector.norm, 5)
   }
 
-  /// Test that vector addition works.
-  func testVector1Add() {
-    let vector1 = Vector1(1)
-    let vector2 = Vector1(2)
-    let sum = vector1 + vector2
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 69)
-    XCTAssertEqual(sum.x, 3)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 71)
+  /// Test the AdditiveArithmetic conformance.
+  func testAdditiveArithmetic() {
+    let vector1 = Vector([1, 2, 3])
+    let vector2 = Vector([4, 5, 6])
+    XCTAssertEqual(Vector.zero, Vector([]))
+    XCTAssertEqual(vector1 + vector2, Vector([5, 7, 9]))
+    XCTAssertEqual(vector1 - vector2, Vector([-3, -3, -3]))
   }
 
-  /// Test that vector subtraction works.
-  func testVector1Subtract() {
-    let vector1 = Vector1(1)
-    let vector2 = Vector1(2)
-    let difference = vector1 - vector2
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 79)
-    XCTAssertEqual(difference.x, -1)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 81)
+  /// Test the VectorProtocol conformance.
+  func testVectorProtocol() {
+    let vector1 = Vector([1, 2, 3])
+    XCTAssertEqual(vector1.adding(1), Vector([2, 3, 4]))
+    XCTAssertEqual(vector1.subtracting(1), Vector([0, 1, 2]))
+    XCTAssertEqual(vector1.scaled(by: 2), Vector([2, 4, 6]))
   }
 
-  /// Test that vector scalar multiplication works.
-  func testVector1ScalarMultiply() {
-    let vector1 = Vector1(1)
-    let scaled = vector1.scaled(by: 2)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 88)
-    XCTAssertEqual(scaled.x, 2)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 90)
+  /// Test conversion to tensor.
+  func testTensorConversion() {
+    let vector = Vector([1, 2, 3])
+    XCTAssertEqual(vector.tensor, Tensor<Double>([1, 2, 3]))
   }
-
-  /// Test that vector negation works.
-  func testVector1Negate() {
-    let vector1 = Vector1(1)
-    let negated = -vector1
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 97)
-    XCTAssertEqual(negated.x, -1)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 99)
-  }
-
-  /// Test that vector squaring works.
-  func testVector1Squared() {
-    let vector1 = Vector1(1)
-    let squared = vector1.squared()
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 106)
-    XCTAssertEqual(squared.x, 1)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 108)
-  }
-
-  /// Test that vector sum works.
-  func testVector1Sum() {
-    let vector1 = Vector1(1)
-    XCTAssertEqual(vector1.sum(), 1)
-  }
-
-  /// Tests that `Vector1.TangentVector == Vector1`.
-  func testVector1TangentVector() {
-    let vector1 = Vector1(1)
-    let _: Vector1.TangentVector = vector1
-  }
-
-  /// Tests that the move (exponential map) operation works on vectors.
-  func testVector1Move() {
-    let vector1 = Vector1(1)
-    let vector2 = Vector1(2)
-    var moved = vector1
-    moved.move(along: vector2)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 129)
-    XCTAssertEqual(moved.x, 3)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 131)
-  }
-
-  /// Tests that we can initialize a vector from a tensor.
-  func testVector1TensorInit() {
-    let vector1 = Vector1(1)
-    let tensor1 = Tensor<Double>([1])
-    XCTAssertEqual(Vector1(tensor1), vector1)
-  }
-
-  /// Tests that we can extract a tensor from a vector.
-  func testVector1TensorExtract() {
-    let vector1 = Vector1(1)
-    let tensor1 = Tensor<Double>([1])
-    XCTAssertEqual(vector1.tensor, tensor1)
-  }
-
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 34)
-
-  /// Test that initializing a vector from coordinate values works.
-  func testVector2Init() {
-    let vector1 = Vector2(1, 2)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 39)
-    XCTAssertEqual(vector1.x, 1)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 39)
-    XCTAssertEqual(vector1.y, 2)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 41)
-  }
-
-  /// Test that vector norm works.
-  func testVector2Norm() {
-    let vector1 = Vector2(1, 2)
-    XCTAssertEqual(vector1.norm, 2.23606797749979, accuracy: 1e-6)
-  }
-
-  /// Test that vector squared norm works.
-  func testVector2SquaredNorm() {
-    let vector1 = Vector2(1, 2)
-    XCTAssertEqual(vector1.squaredNorm, 5, accuracy: 1e-6)
-  }
-
-  /// Test that vector `==` works.
-  func testVector2Equality() {
-    let vector1 = Vector2(1, 2)
-    let vector2 = Vector2(3, 4)
-    XCTAssertTrue(vector1 == vector1)
-    XCTAssertFalse(vector1 == vector2)
-  }
-
-  /// Test that vector addition works.
-  func testVector2Add() {
-    let vector1 = Vector2(1, 2)
-    let vector2 = Vector2(3, 4)
-    let sum = vector1 + vector2
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 69)
-    XCTAssertEqual(sum.x, 4)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 69)
-    XCTAssertEqual(sum.y, 6)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 71)
-  }
-
-  /// Test that vector subtraction works.
-  func testVector2Subtract() {
-    let vector1 = Vector2(1, 2)
-    let vector2 = Vector2(3, 4)
-    let difference = vector1 - vector2
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 79)
-    XCTAssertEqual(difference.x, -2)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 79)
-    XCTAssertEqual(difference.y, -2)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 81)
-  }
-
-  /// Test that vector scalar multiplication works.
-  func testVector2ScalarMultiply() {
-    let vector1 = Vector2(1, 2)
-    let scaled = vector1.scaled(by: 2)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 88)
-    XCTAssertEqual(scaled.x, 2)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 88)
-    XCTAssertEqual(scaled.y, 4)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 90)
-  }
-
-  /// Test that vector negation works.
-  func testVector2Negate() {
-    let vector1 = Vector2(1, 2)
-    let negated = -vector1
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 97)
-    XCTAssertEqual(negated.x, -1)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 97)
-    XCTAssertEqual(negated.y, -2)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 99)
-  }
-
-  /// Test that vector squaring works.
-  func testVector2Squared() {
-    let vector1 = Vector2(1, 2)
-    let squared = vector1.squared()
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 106)
-    XCTAssertEqual(squared.x, 1)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 106)
-    XCTAssertEqual(squared.y, 4)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 108)
-  }
-
-  /// Test that vector sum works.
-  func testVector2Sum() {
-    let vector1 = Vector2(1, 2)
-    XCTAssertEqual(vector1.sum(), 3)
-  }
-
-  /// Tests that `Vector2.TangentVector == Vector2`.
-  func testVector2TangentVector() {
-    let vector1 = Vector2(1, 2)
-    let _: Vector2.TangentVector = vector1
-  }
-
-  /// Tests that the move (exponential map) operation works on vectors.
-  func testVector2Move() {
-    let vector1 = Vector2(1, 2)
-    let vector2 = Vector2(3, 4)
-    var moved = vector1
-    moved.move(along: vector2)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 129)
-    XCTAssertEqual(moved.x, 4)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 129)
-    XCTAssertEqual(moved.y, 6)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 131)
-  }
-
-  /// Tests that we can initialize a vector from a tensor.
-  func testVector2TensorInit() {
-    let vector1 = Vector2(1, 2)
-    let tensor1 = Tensor<Double>([1, 2])
-    XCTAssertEqual(Vector2(tensor1), vector1)
-  }
-
-  /// Tests that we can extract a tensor from a vector.
-  func testVector2TensorExtract() {
-    let vector1 = Vector2(1, 2)
-    let tensor1 = Tensor<Double>([1, 2])
-    XCTAssertEqual(vector1.tensor, tensor1)
-  }
-
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 34)
-
-  /// Test that initializing a vector from coordinate values works.
-  func testVector3Init() {
-    let vector1 = Vector3(1, 2, 3)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 39)
-    XCTAssertEqual(vector1.x, 1)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 39)
-    XCTAssertEqual(vector1.y, 2)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 39)
-    XCTAssertEqual(vector1.z, 3)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 41)
-  }
-
-  /// Test that vector norm works.
-  func testVector3Norm() {
-    let vector1 = Vector3(1, 2, 3)
-    XCTAssertEqual(vector1.norm, 3.7416573867739413, accuracy: 1e-6)
-  }
-
-  /// Test that vector squared norm works.
-  func testVector3SquaredNorm() {
-    let vector1 = Vector3(1, 2, 3)
-    XCTAssertEqual(vector1.squaredNorm, 14, accuracy: 1e-6)
-  }
-
-  /// Test that vector `==` works.
-  func testVector3Equality() {
-    let vector1 = Vector3(1, 2, 3)
-    let vector2 = Vector3(4, 5, 6)
-    XCTAssertTrue(vector1 == vector1)
-    XCTAssertFalse(vector1 == vector2)
-  }
-
-  /// Test that vector addition works.
-  func testVector3Add() {
-    let vector1 = Vector3(1, 2, 3)
-    let vector2 = Vector3(4, 5, 6)
-    let sum = vector1 + vector2
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 69)
-    XCTAssertEqual(sum.x, 5)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 69)
-    XCTAssertEqual(sum.y, 7)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 69)
-    XCTAssertEqual(sum.z, 9)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 71)
-  }
-
-  /// Test that vector subtraction works.
-  func testVector3Subtract() {
-    let vector1 = Vector3(1, 2, 3)
-    let vector2 = Vector3(4, 5, 6)
-    let difference = vector1 - vector2
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 79)
-    XCTAssertEqual(difference.x, -3)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 79)
-    XCTAssertEqual(difference.y, -3)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 79)
-    XCTAssertEqual(difference.z, -3)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 81)
-  }
-
-  /// Test that vector scalar multiplication works.
-  func testVector3ScalarMultiply() {
-    let vector1 = Vector3(1, 2, 3)
-    let scaled = vector1.scaled(by: 2)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 88)
-    XCTAssertEqual(scaled.x, 2)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 88)
-    XCTAssertEqual(scaled.y, 4)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 88)
-    XCTAssertEqual(scaled.z, 6)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 90)
-  }
-
-  /// Test that vector negation works.
-  func testVector3Negate() {
-    let vector1 = Vector3(1, 2, 3)
-    let negated = -vector1
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 97)
-    XCTAssertEqual(negated.x, -1)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 97)
-    XCTAssertEqual(negated.y, -2)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 97)
-    XCTAssertEqual(negated.z, -3)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 99)
-  }
-
-  /// Test that vector squaring works.
-  func testVector3Squared() {
-    let vector1 = Vector3(1, 2, 3)
-    let squared = vector1.squared()
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 106)
-    XCTAssertEqual(squared.x, 1)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 106)
-    XCTAssertEqual(squared.y, 4)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 106)
-    XCTAssertEqual(squared.z, 9)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 108)
-  }
-
-  /// Test that vector sum works.
-  func testVector3Sum() {
-    let vector1 = Vector3(1, 2, 3)
-    XCTAssertEqual(vector1.sum(), 6)
-  }
-
-  /// Tests that `Vector3.TangentVector == Vector3`.
-  func testVector3TangentVector() {
-    let vector1 = Vector3(1, 2, 3)
-    let _: Vector3.TangentVector = vector1
-  }
-
-  /// Tests that the move (exponential map) operation works on vectors.
-  func testVector3Move() {
-    let vector1 = Vector3(1, 2, 3)
-    let vector2 = Vector3(4, 5, 6)
-    var moved = vector1
-    moved.move(along: vector2)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 129)
-    XCTAssertEqual(moved.x, 5)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 129)
-    XCTAssertEqual(moved.y, 7)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 129)
-    XCTAssertEqual(moved.z, 9)
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 131)
-  }
-
-  /// Tests that we can initialize a vector from a tensor.
-  func testVector3TensorInit() {
-    let vector1 = Vector3(1, 2, 3)
-    let tensor1 = Tensor<Double>([1, 2, 3])
-    XCTAssertEqual(Vector3(tensor1), vector1)
-  }
-
-  /// Tests that we can extract a tensor from a vector.
-  func testVector3TensorExtract() {
-    let vector1 = Vector3(1, 2, 3)
-    let tensor1 = Tensor<Double>([1, 2, 3])
-    XCTAssertEqual(vector1.tensor, tensor1)
-  }
-
-// ###sourceLocation(file: "Tests/SwiftFusionTests/Core/VectorTests.swift.gyb", line: 148)
 }

--- a/Tests/SwiftFusionTests/Inference/GaussianFactorGraphTests.swift
+++ b/Tests/SwiftFusionTests/Inference/GaussianFactorGraphTests.swift
@@ -8,15 +8,15 @@ final class GaussianFactorGraphTests: XCTestCase {
     let A = SimpleGaussianFactorGraph.create()
 
     var e = Errors()
-    e += [Vector2_t(0.0, 0.0)]
-    e += [Vector2_t(15.0, 0.0)]
-    e += [Vector2_t(0.0, -5.0)]
-    e += [Vector2_t(-7.5, -5.0)]
+    e += [Vector([0.0, 0.0])]
+    e += [Vector([15.0, 0.0])]
+    e += [Vector([0.0, -5.0])]
+    e += [Vector([-7.5, -5.0])]
 
     var expected = VectorValues()
-    expected.insert(1, Vector2_t(-37.5, -50.0))
-    expected.insert(2, Vector2_t(-150.0, 25.0))
-    expected.insert(0, Vector2_t(187.5, 25.0))
+    expected.insert(1, Vector([-37.5, -50.0]))
+    expected.insert(2, Vector([-150.0, 25.0]))
+    expected.insert(0, Vector([187.5, 25.0]))
 
     let actual = A.atr(e)
     XCTAssertEqual(expected, actual)
@@ -27,14 +27,19 @@ final class GaussianFactorGraphTests: XCTestCase {
     let A = SimpleGaussianFactorGraph.create()
 
     var expected = Errors()
-    expected += [Vector2_t(-1.0, -1.0)]
-    expected += [Vector2_t(2.0, -1.0)]
-    expected += [Vector2_t(0.0, 1.0)]
-    expected += [Vector2_t(-1.0, 1.5)]
+    expected += [Vector([-1.0, -1.0])]
+    expected += [Vector([2.0, -1.0])]
+    expected += [Vector([0.0, 1.0])]
+    expected += [Vector([-1.0, 1.5])]
 
     let x = SimpleGaussianFactorGraph.correctDelta()
 
     let actual = A * x
     XCTAssertEqual(expected, actual)
   }
+
+  static var allTests = [
+    ("testTransposeMultiplication", testTransposeMultiplication),
+    ("testMultiplication", testMultiplication)
+  ]
 }

--- a/Tests/SwiftFusionTests/Inference/NonlinearFactorGraphTests.swift
+++ b/Tests/SwiftFusionTests/Inference/NonlinearFactorGraphTests.swift
@@ -19,14 +19,14 @@ final class NonlinearFactorGraphTests: XCTestCase {
     
     var vv = VectorValues()
     
-    vv.insert(0, Tensor<Double>(shape:[3, 1], scalars: [0.0, 0.0, 0.0]))
-    vv.insert(1, Tensor<Double>(shape:[3, 1], scalars: [0.0, 0.0, 0.0]))
+    vv.insert(0, Vector(zeros: 3))
+    vv.insert(1, Vector(zeros: 3))
     
     let expected = Tensor<Double>(shape:[3, 1], scalars: [.pi, 0.0, 0.0])
     
     print("gfg = \(gfg)")
     print("error = \(gfg.residual(vv).norm)")
-    assertEqual((gfg.residual(vv))[0], expected, accuracy: 1e-6)
+    assertEqual((gfg.residual(vv))[0].tensor, expected, accuracy: 1e-6)
   }
   
   /// test CGLS iterative solver
@@ -62,14 +62,14 @@ final class NonlinearFactorGraphTests: XCTestCase {
       var dx = VectorValues()
       
       for i in 0..<5 {
-        dx.insert(i, Tensor<Double>(shape: [3, 1], scalars: [0, 0, 0]))
+        dx.insert(i, Vector(zeros: 3))
       }
       
       optimizer.optimize(gfg: gfg, initial: &dx)
       
       for i in 0..<5 {
         var p = val[i].baseAs(Pose2.self)
-        p.move(along: Vector3(dx[i].reshaped(toShape: [3])))
+        p.move(along: Vector3(dx[i]))
         val[i] = AnyDifferentiable(p)
       }
     }
@@ -96,4 +96,9 @@ final class NonlinearFactorGraphTests: XCTestCase {
     // Test condition: P_5 should be identical to P_1 (close loop)
     XCTAssertEqual(p5T1.t.norm, 0.0, accuracy: 1e-2)
   }
+
+  static var allTests = [
+    ("testCGLSPose2SLAM", testCGLSPose2SLAM)
+  ]
+
 }

--- a/Tests/SwiftFusionTests/Inference/NonlinearFactorGraphTests.swift
+++ b/Tests/SwiftFusionTests/Inference/NonlinearFactorGraphTests.swift
@@ -22,7 +22,7 @@ final class NonlinearFactorGraphTests: XCTestCase {
     vv.insert(0, Vector(zeros: 3))
     vv.insert(1, Vector(zeros: 3))
     
-    let expected = Tensor<Double>(shape:[3, 1], scalars: [.pi, 0.0, 0.0])
+    let expected = Tensor<Double>(shape:[3], scalars: [.pi, 0.0, 0.0])
     
     print("gfg = \(gfg)")
     print("error = \(gfg.residual(vv).norm)")
@@ -98,6 +98,7 @@ final class NonlinearFactorGraphTests: XCTestCase {
   }
 
   static var allTests = [
+    ("testBasicOps", testBasicOps),
     ("testCGLSPose2SLAM", testCGLSPose2SLAM)
   ]
 

--- a/Tests/SwiftFusionTests/Optimizers/CGLSTests.swift
+++ b/Tests/SwiftFusionTests/Optimizers/CGLSTests.swift
@@ -16,7 +16,7 @@ final class CGLSTests: XCTestCase {
     let expected = SimpleGaussianFactorGraph.correctDelta()
     
     for k in x.keys {
-      assertEqual(x[k], expected[k], accuracy: 1e-6)
+      assertEqual(x[k].tensor, expected[k].tensor, accuracy: 1e-6)
     }
   }
 

--- a/Tests/SwiftFusionTests/TestUtilities.swift
+++ b/Tests/SwiftFusionTests/TestUtilities.swift
@@ -37,38 +37,31 @@ func assertAllKeyPathEqual<T: KeyPathIterable>(
   }
 }
 
-/// Create a `Tensor<Double>` with shape (2, 1)
-/// TODO: replace with the `Vector2` Marc prototyped
-public func Vector2_t(_ x: Double, _ y: Double) -> Tensor<Double> {
-  let t = Tensor<Double>(shape: [2, 1], scalars: [x, y])
-  return t
-}
-
 /// Factor graph with 2 2D factors on 3 2D variables
 public final class SimpleGaussianFactorGraph {
   public static func create() -> GaussianFactorGraph {
     var fg = GaussianFactorGraph()
     
-    let I_2x2: Tensor<Double> = eye(rowCount: 2)
+    let I_2x2 = Matrix(eye: 2)
     let x1 = 2, x2 = 0, l1 = 1
     
     // linearized prior on x1: c[_x1_]+x1=0 i.e. x1=-c[_x1_]
-    fg += JacobianFactor([x1], [10 * I_2x2], -1.0 * Vector2_t(1.0, 1.0))
+    fg += JacobianFactor([x1], [10 * I_2x2], -1.0 * Vector([1.0, 1.0]))
     // odometry between x1 and x2: x2-x1=[0.2;-0.1]
-    fg += JacobianFactor([x2, x1], [10 * I_2x2, -10 * I_2x2], Vector2_t(2.0, -1.0))
+    fg += JacobianFactor([x2, x1], [10 * I_2x2, -10 * I_2x2], Vector([2.0, -1.0]))
     // measurement between x1 and l1: l1-x1=[0.0;0.2]
-    fg += JacobianFactor([l1, x1], [5 * I_2x2, -5 * I_2x2], Vector2_t(0.0, 1.0))
+    fg += JacobianFactor([l1, x1], [5 * I_2x2, -5 * I_2x2], Vector([0.0, 1.0]))
     // measurement between x2 and l1: l1-x2=[-0.2;0.3]
-    fg += JacobianFactor([x2, l1], [-5 * I_2x2, 5 * I_2x2], Vector2_t(-1.0, 1.5))
+    fg += JacobianFactor([x2, l1], [-5 * I_2x2, 5 * I_2x2], Vector([-1.0, 1.5]))
     return fg;
   }
 
   public static func correctDelta() -> VectorValues {
     let x1 = 2, x2 = 0, l1 = 1
     var c = VectorValues()
-    c.insert(l1, Vector2_t(-0.1, 0.1))
-    c.insert(x1, Vector2_t(-0.1, -0.1))
-    c.insert(x2, Vector2_t(0.1, -0.2))
+    c.insert(l1, Vector([-0.1, 0.1]))
+    c.insert(x1, Vector([-0.1, -0.1]))
+    c.insert(x2, Vector([0.1, -0.2]))
     
     return c
   }
@@ -76,9 +69,9 @@ public final class SimpleGaussianFactorGraph {
   public static func zeroDelta() -> VectorValues {
     let x1 = 2, x2 = 0, l1 = 1
     var c = VectorValues()
-    c.insert(l1, Vector2_t(0.0, 0.0))
-    c.insert(x1, Vector2_t(0.0, 0.0))
-    c.insert(x2, Vector2_t(0.0, 0.0))
+    c.insert(l1, Vector([0.0, 0.0]))
+    c.insert(x1, Vector([0.0, 0.0]))
+    c.insert(x2, Vector([0.0, 0.0]))
     
     return c
   }

--- a/Tests/SwiftFusionTests/XCTestManifests.swift
+++ b/Tests/SwiftFusionTests/XCTestManifests.swift
@@ -4,11 +4,16 @@ import XCTest
 public func allTests() -> [XCTestCaseEntry] {
   [
     testCase(AnyDifferentiableTests.allTests),
+    testCase(CGLSTests.allTests),
     testCase(DictionaryDifferentiableTests.allTests),
     testCase(G2OReaderTests.allTests),
-    testCase(Rot2Tests.allTests),
+    testCase(GaussianFactorGraphTests.allTests),
+    testCase(NonlinearFactorGraphTests.allTests),
+    testCase(MatrixTests.allTests),
     testCase(Pose2Tests.allTests),
-    testCase(JacobianTests.allTests),
+    testCase(Rot2Tests.allTests),
+    testCase(TensorFlowMatrixTests.allTests),
+    testCase(VectorNTests.allTests),
     testCase(VectorTests.allTests),
   ]
 }

--- a/generate.sh
+++ b/generate.sh
@@ -17,8 +17,8 @@ fi
 GYB="$SWIFT_BASE"/utils/gyb
 
 GENERATED_FILES=(
-  "Sources/SwiftFusion/Core/Vector.swift"
-  "Tests/SwiftFusionTests/Core/VectorTests.swift"
+  "Sources/SwiftFusion/Core/VectorN.swift"
+  "Tests/SwiftFusionTests/Core/VectorNTests.swift"
 )
 
 for GENERATED_FILE in "${GENERATED_FILES[@]}"


### PR DESCRIPTION
This PR adds array-backed `Vector` and `Matrix` types, and replaces most uses of `Tensor` with them.

I renamed the existing `Vector.swift.gyb` to `VectorN.swift.gyb`, so that I could free up the name `Vector.swift` for the dynamically-sized `Vector` type.

This gives me a 15x speedup on CGLS: before, 200 iterations of CGLS on INTEL took 90s; after, they take 6s. This is not the full 900x speedup that I mentioned in https://github.com/borglab/SwiftFusion/issues/42#issuecomment-626142882 because the full speedup involves more changes and I wanted to keep this PR as small as possible.