### PR TITLE
Make Values.TangentVector == VectorValues

### DIFF
--- a/Examples/Pose2SLAMG2O/main.swift
+++ b/Examples/Pose2SLAMG2O/main.swift
@@ -36,7 +36,7 @@ struct G2OFactorGraph: G2OReader {
   var graph: NonlinearFactorGraph = NonlinearFactorGraph()
 
   public mutating func addInitialGuess(index: Int, pose: Pose2) {
-    initialGuess.insert(index, AnyDifferentiable(pose))
+    initialGuess.insert(index, pose)
   }
 
   public mutating func addMeasurement(frameIndex: Int, measuredIndex: Int, pose: Pose2) {
@@ -72,11 +72,7 @@ func main() {
       dx.insert(i, Vector(zeros: 3))
     }
     optimizer.optimize(gfg: gfg, initial: &dx)
-    for i in 0..<val.count {
-      var p = val[i].baseAs(Pose2.self)
-      p.move(along: Vector3(dx[i]))
-      val[i] = AnyDifferentiable(p)
-    }
+    val.move(along: dx)
     print("Current error: \(problem.graph.error(val))")
   }
   print("Final error: \(problem.graph.error(val))")

--- a/Sources/SwiftFusion/Inference/BetweenFactor.swift
+++ b/Sources/SwiftFusion/Inference/BetweenFactor.swift
@@ -68,7 +68,7 @@ public struct BetweenFactor: NonlinearFactor {
   @differentiable(wrt: values)
   public func error(_ values: Values) -> Double {
     let error = between(
-      between(values[key2].baseAs(Pose2.self), values[key1].baseAs(Pose2.self)),
+      between(values[key2, as: Pose2.self], values[key1, as: Pose2.self]),
         difference
     )
     
@@ -78,7 +78,7 @@ public struct BetweenFactor: NonlinearFactor {
   @differentiable(wrt: values)
   public func errorVector(_ values: Values) -> Vector3 {
     let error = between(
-      between(values[key2].baseAs(Pose2.self), values[key1].baseAs(Pose2.self)),
+      between(values[key2, as: Pose2.self], values[key1, as: Pose2.self]),
       difference
     )
     
@@ -86,12 +86,6 @@ public struct BetweenFactor: NonlinearFactor {
   }
   
   public func linearize(_ values: Values) -> JacobianFactor {
-    let j = jacobian(of: self.errorVector, at: values)
-
-    let j1 = Matrix(stacking: (0..<3).map { i in (j[i]._values[values._indices[key1]!].base as! Pose2.TangentVector).vector } )
-    let j2 = Matrix(stacking: (0..<3).map { i in (j[i]._values[values._indices[key2]!].base as! Pose2.TangentVector).vector } )
-
-    // TODO: remove this negative sign
-    return JacobianFactor(keys, [j1, j2], errorVector(values).vector.scaled(by: -1))
+    return JacobianFactor(of: self.errorVector, at: values)
   }
 }

--- a/Sources/SwiftFusion/Inference/PriorFactor.swift
+++ b/Sources/SwiftFusion/Inference/PriorFactor.swift
@@ -42,7 +42,7 @@ public struct PriorFactor: NonlinearFactor {
   @differentiable(wrt: values)
   public func error(_ values: Values) -> Double {
     let error = between(
-      values[keys[0]].baseAs(Pose2.self),
+      values[keys[0], as: Pose2.self],
       difference
     )
     
@@ -52,7 +52,7 @@ public struct PriorFactor: NonlinearFactor {
   @differentiable(wrt: values)
   public func errorVector(_ values: Values) -> Vector3 {
     let error = between(
-      values[keys[0]].baseAs(Pose2.self),
+      values[keys[0], as: Pose2.self],
       difference
     )
     
@@ -60,8 +60,6 @@ public struct PriorFactor: NonlinearFactor {
   }
   
   public func linearize(_ values: Values) -> JacobianFactor {
-    let j = jacobian(of: self.errorVector, at: values)
-    let j1 = Matrix(stacking: (0..<3).map { i in (j[i]._values[values._indices[keys[0]]!].base as! Pose2.TangentVector).vector } )
-    return JacobianFactor(keys, [j1], errorVector(values).vector.scaled(by: -1))
+    return JacobianFactor(of: self.errorVector, at: values)
   }
 }

--- a/Tests/SwiftFusionTests/Inference/NonlinearFactorGraphTests.swift
+++ b/Tests/SwiftFusionTests/Inference/NonlinearFactorGraphTests.swift
@@ -12,8 +12,8 @@ final class NonlinearFactorGraphTests: XCTestCase {
     fg += bf1
     
     var val = Values()
-    val.insert(0, AnyDifferentiable(Pose2(1.0, 1.0, 0.0)))
-    val.insert(1, AnyDifferentiable(Pose2(1.0, 1.0, .pi)))
+    val.insert(0, Pose2(1.0, 1.0, 0.0))
+    val.insert(1, Pose2(1.0, 1.0, .pi))
     
     let gfg = fg.linearize(val)
     
@@ -51,7 +51,7 @@ final class NonlinearFactorGraphTests: XCTestCase {
     var val = Values()
     
     for i in 0..<5 {
-      val.insert(i, AnyDifferentiable(map[i]))
+      val.insert(i, map[i])
     }
     
     for _ in 0..<2 {
@@ -67,11 +67,7 @@ final class NonlinearFactorGraphTests: XCTestCase {
       
       optimizer.optimize(gfg: gfg, initial: &dx)
       
-      for i in 0..<5 {
-        var p = val[i].baseAs(Pose2.self)
-        p.move(along: Vector3(dx[i]))
-        val[i] = AnyDifferentiable(p)
-      }
+      val.move(along: dx)
     }
     
     let dumpjson = { (p: Pose2) -> String in
@@ -84,14 +80,14 @@ final class NonlinearFactorGraphTests: XCTestCase {
     }
     print("]")
     
-    let map_final = (0..<5).map { val[$0].baseAs(Pose2.self) }
+    let map_final = (0..<5).map { val[$0, as: Pose2.self] }
     print("map = [")
     for v in map_final.indices {
       print("\(dumpjson(map_final[v]))\({ () -> String in if v == map_final.indices.endIndex - 1 { return "" } else { return "," } }())")
     }
     print("]")
     
-    let p5T1 = between(val[4].baseAs(Pose2.self), val[0].baseAs(Pose2.self))
+    let p5T1 = between(val[4, as: Pose2.self], val[0, as: Pose2.self])
 
     // Test condition: P_5 should be identical to P_1 (close loop)
     XCTAssertEqual(p5T1.t.norm, 0.0, accuracy: 1e-2)


### PR DESCRIPTION
This sets `Values.TangentVector` to `VectorValues`, which allows a few nice improvements to the APIs:
* To update a `Value` using a `VectorValues`, now all you need is `vals.move(along: vectorval)` instead of needing to loop over all the components and cast them.
* We can now write a generic `JacobianFactor` initializer that linearizes any error function, which simplifies the implementation of `linearize`.

Other API changes:
* Now you access values using `vals[key, as: Pose2.self]` instead of `vals[key].baseAs(Pose2.self)`. This is necessary so that `Values` knows what type you are accessing and therefore knows how to convert its tangent vector to a `Vector` suitable for inclusion in `VectorValues`.
* Now you insert values with `vals.insert(key, value)` instead of `vals.insert(key, AnyDifferentiable(value)`. (It still gets stored as a type-erased `AnyDifferentiable` though).