### PR TITLE
small math improvements

### DIFF
--- a/Sources/SwiftFusion/Core/EuclideanVectorSpace.swift
+++ b/Sources/SwiftFusion/Core/EuclideanVectorSpace.swift
@@ -1,6 +1,11 @@
+import Foundation
+
 /// A Euclidean vector space.
 public protocol EuclideanVectorSpace: Differentiable, VectorProtocol
-  where Self.TangentVector == Self
+  where Self.TangentVector == Self, Self.VectorSpaceScalar == Double
 {
   // Note: This is a work in progress. We intend to add more requirements here as we need them.
+
+  /// The squared Euclidean norm of `self`.
+  var squaredNorm: Double { get }
 }

--- a/Sources/SwiftFusion/Core/LieGroup.swift
+++ b/Sources/SwiftFusion/Core/LieGroup.swift
@@ -2,6 +2,8 @@ import TensorFlow
 
 /// Generic Lie Group protocol
 public protocol LieGroup: Manifold {
+  init()
+
   @differentiable(wrt: (lhs, rhs))
   static func * (_ lhs: Self, _ rhs: Self) -> Self
   

--- a/Sources/SwiftFusion/Core/Vector.swift
+++ b/Sources/SwiftFusion/Core/Vector.swift
@@ -192,6 +192,8 @@ extension Vector: VectorProtocol {
   }
 }
 
+extension Vector: EuclideanVectorSpace {}
+
 /// Conversion to tensor.
 extension Vector {
   /// Returns this vector as a `Tensor<Double>`.

--- a/Sources/SwiftFusion/Geometry/Pose2.swift
+++ b/Sources/SwiftFusion/Geometry/Pose2.swift
@@ -79,6 +79,11 @@ public struct Pose2: Manifold, LieGroup, Equatable, TangentStandardBasis, KeyPat
 
 // MARK: Convenience initializers
 extension Pose2 {
+  /// Creates the identity.
+  public init() {
+    self.init(0, 0, 0)
+  }
+
   /// Creates a `Pose2` with translation `x` and `y` and with rotation `theta`.
   @differentiable
   public init(_ x: Double, _ y: Double, _ theta: Double) {

--- a/Sources/SwiftFusion/Geometry/Pose3.swift
+++ b/Sources/SwiftFusion/Geometry/Pose3.swift
@@ -4,6 +4,10 @@ import TensorFlow
 public struct Vector6: EuclideanVectorSpace, VectorProtocol, KeyPathIterable, TangentStandardBasis {
   var w: Vector3
   var v: Vector3
+
+  public var squaredNorm: Double {
+    return w.squaredNorm + v.squaredNorm
+  }
 }
 
 extension Vector6 {
@@ -49,6 +53,11 @@ public struct Pose3: Manifold, LieGroup, Equatable, TangentStandardBasis, KeyPat
 
   public mutating func move(along direction: Coordinate.LocalCoordinate) {
     coordinateStorage = coordinateStorage.retract(direction)
+  }
+
+  /// Creates the identity.
+  public init() {
+    self.init(Rot3(), Vector3.zero)
   }
 
   /// Creates a `Pose3` with rotation `r` and translation `t`.

--- a/Sources/SwiftFusion/Geometry/Rot2.swift
+++ b/Sources/SwiftFusion/Geometry/Rot2.swift
@@ -18,6 +18,11 @@ public struct Rot2: Manifold, LieGroup, Equatable, KeyPathIterable {
 
   // MARK: - Convenience initializers and computed properties
 
+  /// Creates the identity.
+  public init() {
+    self.init(0)
+  }
+
   // Construct from theta.
   @differentiable
   public init(_ theta: Double) {


### PR DESCRIPTION
* Add `squaredNorm` requirement to `EuclideanVectorSpace`, so that we can ask for its norm generically.
* Add constraint that the `VectorSpaceScalar == Double` because we seem to be using `Double` everywhere and this constraint makes it easier. (We can relax the constraint later if we switch to generic floating point types.)
* Add a group identity requirement to `LieGroup`.