### PR TITLE
default implementations of lie group and manifold operations, with faster derivatives

### DIFF
--- a/Sources/SwiftFusion/Core/LieGroup.swift
+++ b/Sources/SwiftFusion/Core/LieGroup.swift
@@ -1,17 +1,172 @@
 import TensorFlow
 
-/// Generic Lie Group protocol
-public protocol LieGroup: Manifold {
+/// An element of a Lie group.
+///
+/// To create a Lie group type, follow the manifold recipe [1] and conform the coordinate type to
+/// `LieGroupCoordinate`. Then, conform your manifold type to `LieGroup` and it will automatically
+/// get Lie group operations.
+///
+/// [1] SwiftFusion/doc/DifferentiableManifoldRecipe.md
+public protocol LieGroup: Manifold
+  where Coordinate: LieGroupCoordinate, TangentVector == Coordinate.LocalCoordinate {}
+
+/// Default implementations of group operations in terms of the corresponding coordinate operations.
+extension LieGroup {
+  /// Creates the group identity.
+  public init() {
+    self.init(coordinate: Coordinate())
+  }
+
+  /// Returns the group inverse.
+  @differentiable(wrt: self)
+  public func inverse() -> Self {
+    return Self(coordinate: self.coordinate.inverse())
+  }
+
+  /// Derivative of `inverse`.
+  ///
+  /// Swift AD can compute this, but we know a mathematical expression for the derivative that
+  /// is more efficient than the compiler can figure out.
+  @derivative(of: inverse)
+  @usableFromInline
+  func vjpInverse() -> (value: Self, pullback: (TangentVector) -> TangentVector) {
+    // Derivative from https://github.com/borglab/gtsam/blob/develop/doc/math.pdf section 5.3. We
+    // use the transpose of the Adjoint because the pullback is the transpose of the differential.
+    return (self.inverse(), { TangentVector.zero - self.AdjointTranspose($0) })
+  }
+
+  /// The group operation.
+  @differentiable(wrt: (lhs, rhs))
+  @differentiable(wrt: lhs)
+  @differentiable(wrt: rhs)
+  public static func * (_ lhs: Self, _ rhs: Self) -> Self {
+    return Self(coordinate: lhs.coordinate * rhs.coordinate)
+  }
+
+  /// Derivative of `*` with respect to both sides.
+  ///
+  /// We define separate derivatives with respect to different sets of arguments so that we can
+  /// avoid doing unnecessary work when some of the arguments are not changing.
+  ///
+  /// Swift AD can compute this, but we know a mathematical expression for the derivative that
+  /// is more efficient than the compiler can figure out.
+  @derivative(of: *, wrt: (lhs, rhs))
+  @usableFromInline
+  static func vjpGroupOperationWrtBoth(_ lhs: Self, _ rhs: Self) ->
+    (value: Self, pullback: (TangentVector) -> (TangentVector, TangentVector))
+  {
+    // Derivative from https://github.com/borglab/gtsam/blob/develop/doc/math.pdf sections 5.2 and
+    // 5.4. We use the transpose of the Adjoint because the pullback is the transpose of the
+    // differential.
+    return (lhs * rhs, { (rhs.inverse().AdjointTranspose($0), $0) })
+  }
+
+  /// Derivative of `*` with respect to the left side.
+  ///
+  /// We define separate derivatives with respect to different sets of arguments so that we can
+  /// avoid doing unnecessary work when some of the arguments are not changing.
+  ///
+  /// Swift AD can compute this, but we know a mathematical expression for the derivative that
+  /// is more efficient than the compiler can figure out.
+  @derivative(of: *, wrt: lhs)
+  @usableFromInline
+  static func vjpGroupOperationWrtLhs(_ lhs: Self, _ rhs: Self) ->
+    (value: Self, pullback: (TangentVector) -> TangentVector)
+  {
+    // Derivative from https://github.com/borglab/gtsam/blob/develop/doc/math.pdf section 5.4. We
+    // use the transpose of the Adjoint because the pullback is the transpose of the differential.
+    return (lhs * rhs, { rhs.inverse().AdjointTranspose($0) })
+  }
+
+  /// Derivative of `*` with respect to the right side.
+  ///
+  /// We define separate derivatives with respect to different sets of arguments so that we can
+  /// avoid doing unnecessary work when some of the arguments are not changing.
+  ///
+  /// Swift AD can compute this, but we know a mathematical expression for the derivative that
+  /// is more efficient than the compiler can figure out.
+  @derivative(of: *, wrt: rhs)
+  @usableFromInline
+  static func vjpGroupOperationWrtRhs(_ lhs: Self, _ rhs: Self) ->
+    (value: Self, pullback: (TangentVector) -> TangentVector)
+  {
+    // Derivative from https://github.com/borglab/gtsam/blob/develop/doc/math.pdf section 5.2. We
+    // use the transpose of the Adjoint because the pullback is the transpose of the differential.
+    return (lhs * rhs, { $0 })
+  }
+
+  /// The Adjoint group action of `self` on `v`.
+  public func Adjoint(_ v: TangentVector) -> TangentVector {
+    return coordinate.Adjoint(v)
+  }
+
+  /// The transpose of the Adjoint group action of `self` on `v`.
+  public func AdjointTranspose(_ v: TangentVector) -> TangentVector {
+    return coordinate.AdjointTranspose(v)
+  }
+}
+
+/// The `ManifoldCoordinate` of a `LieGroup`.
+public protocol LieGroupCoordinate: ManifoldCoordinate {
+  /// Creates the group identity.
   init()
 
-  @differentiable(wrt: (lhs, rhs))
-  static func * (_ lhs: Self, _ rhs: Self) -> Self
-  
+  /// Returns the group inverse.
   @differentiable
   func inverse() -> Self
-  
-  @differentiable(wrt: global)
-  func localCoordinate(_ global: Self) -> Self.Coordinate.LocalCoordinate
+
+  /// The group operation.
+  @differentiable
+  static func * (_ lhs: Self, _ rhs: Self) -> Self
+
+  /// The Adjoint group action of `self` on `v`.
+  ///
+  /// A default implementation in terms of other group and manifold operations is provided.
+  /// Implementers may wish to provide a more efficient implementation, because the compiler may
+  /// not have enough knowledge about the mathematical structure to simplify the default
+  /// implementation as much as possible.
+  ///
+  /// This is differentiable with respect to `v` so that we can use a `pullback` to transpose it in
+  /// the default implementation for `AdjointTranspose`.
+  @differentiable(wrt: v)
+  func Adjoint(_ v: LocalCoordinate) -> LocalCoordinate
+
+  /// The transpose of the Adjoint group action of `self` on `v`.
+  ///
+  /// A default implementation in terms of other group and manifold operations is provided.
+  /// Implementers may wish to provide a more efficient implementation, because the compiler may
+  /// not have enough knowledge about the mathematical structure to simplify the default
+  /// implementation as much as possible.
+  func AdjointTranspose(_ v: LocalCoordinate) -> LocalCoordinate
+}
+
+/// Default implementations of `Adjoint` and `AdjointTranspose` in terms of other group
+/// operations.
+extension LieGroupCoordinate {
+  @differentiable(wrt: v)
+  public func Adjoint(_ v: LocalCoordinate) -> LocalCoordinate {
+    return defaultAdjoint(v)
+  }
+
+  public func AdjointTranspose(_ v: LocalCoordinate) -> LocalCoordinate {
+    return defaultAdjointTranspose(v)
+  }
+
+  /// The default implementation of `Adjoint`, provided so that implementers can test their
+  /// implementation against the default implementation.
+  public func defaultAdjoint(_ v: LocalCoordinate) -> LocalCoordinate {
+    let identity = Self()
+    func log(_ g: Self) -> LocalCoordinate { return identity.localCoordinate(g) }
+    func exp(_ v: LocalCoordinate) -> Self { return identity.retract(v) }
+    return log(self * exp(v) * self.inverse())
+  }
+
+  /// The default implementation of `Adjoint`, provided so that implementers can test their
+  /// implementation against the default implementation.
+  public func defaultAdjointTranspose(_ v: LocalCoordinate) -> LocalCoordinate {
+    // This works because the pullback of a linear function is its transpose.
+    return pullback(at: LocalCoordinate.zero, in: { self.Adjoint($0) })(v)
+  }
 }
 
 /// Calculate relative pose 1T2 between two poses wT1 and wT2

--- a/Sources/SwiftFusion/Core/LieGroup.swift
+++ b/Sources/SwiftFusion/Core/LieGroup.swift
@@ -161,8 +161,8 @@ extension LieGroupCoordinate {
     return log(self * exp(v) * self.inverse())
   }
 
-  /// The default implementation of `Adjoint`, provided so that implementers can test their
-  /// implementation against the default implementation.
+  /// The default implementation of `AdjointTranspose`, provided so that implementers can test
+  /// their implementation against the default implementation.
   public func defaultAdjointTranspose(_ v: LocalCoordinate) -> LocalCoordinate {
     // This works because the pullback of a linear function is its transpose.
     return pullback(at: LocalCoordinate.zero, in: { self.Adjoint($0) })(v)

--- a/Sources/SwiftFusion/Geometry/Pose2.swift
+++ b/Sources/SwiftFusion/Geometry/Pose2.swift
@@ -171,8 +171,10 @@ extension Pose2Coordinate: ManifoldCoordinate {
 extension Pose2Coordinate {
   public func Adjoint(_ v: Vector3) -> Vector3 {
     let (w, v) = Pose2Coordinate.decomposed(tangentVector: v)
-    let tPerp = Vector2(-t.y, t.x)
-    return Pose2Coordinate.tangentVector(w: w, v: rot.rotate(v) - tPerp.scaled(by: w.x))
+    return Pose2Coordinate.tangentVector(
+      w: w,
+      v: rot.rotate(v) - Rot2(.pi / 2).rotate(t).scaled(by: w.x)
+    )
   }
 
   public func AdjointTranspose(_ v: Vector3) -> Vector3 {

--- a/Sources/SwiftFusion/Geometry/Pose2.swift
+++ b/Sources/SwiftFusion/Geometry/Pose2.swift
@@ -59,31 +59,10 @@ public struct Pose2: Manifold, LieGroup, Equatable, TangentStandardBasis, KeyPat
   @differentiable public var t: Vector2 { coordinate.t }
   
   @differentiable public var rot: Rot2 { coordinate.rot }
-  
-  /// Product of two rotations.
-  @differentiable
-  public static func * (lhs: Pose2, rhs: Pose2) -> Pose2 {
-    Pose2(coordinate: lhs.coordinate * rhs.coordinate)
-  }
-  
-  @differentiable
-  public func inverse() -> Pose2 {
-    Pose2(coordinate: coordinate.inverse())
-  }
-  
-  @differentiable
-  public func localCoordinate(_ global: Self) -> Self.Coordinate.LocalCoordinate {
-    coordinate.localCoordinate(global.coordinate)
-  }
 }
 
 // MARK: Convenience initializers
 extension Pose2 {
-  /// Creates the identity.
-  public init() {
-    self.init(0, 0, 0)
-  }
-
   /// Creates a `Pose2` with translation `x` and `y` and with rotation `theta`.
   @differentiable
   public init(_ x: Double, _ y: Double, _ theta: Double) {
@@ -124,16 +103,21 @@ public extension Pose2Coordinate {
 }
 
 // MARK: Coordinate Operators
-public extension Pose2Coordinate {
+extension Pose2Coordinate: LieGroupCoordinate {
+  /// Creates the group identity.
+  public init() {
+    self.init(Rot2(), Vector2.zero)
+  }
+
   /// Product of two transforms
   @differentiable
-  static func * (lhs: Pose2Coordinate, rhs: Pose2Coordinate) -> Pose2Coordinate {
+  public static func * (lhs: Pose2Coordinate, rhs: Pose2Coordinate) -> Pose2Coordinate {
     Pose2Coordinate(lhs.rot * rhs.rot, lhs.t + lhs.rot * rhs.t)
   }
 
   /// Inverse of the rotation.
   @differentiable
-  func inverse() -> Pose2Coordinate {
+  public func inverse() -> Pose2Coordinate {
     Pose2Coordinate(self.rot.inverse(), self.rot.unrotate(-self.t))
   }
 }
@@ -184,19 +168,26 @@ extension Pose2Coordinate: ManifoldCoordinate {
 }
 
 /// Methods related to the Lie group structure.
-extension Pose2 {
-  /// The Adjoint group action of `self` on the tangent space, as a linear map.
-  public var groupAdjoint: (Vector3) -> Vector3 {
-    {
-      let (w, v) = Pose2Coordinate.decomposed(tangentVector: $0)
-      let tPerp = Vector2(-coordinate.t.y, coordinate.t.x)
-      return Pose2Coordinate.tangentVector(w: w, v: coordinate.rot.rotate(v) - tPerp.scaled(by: w.x))
-    }
+extension Pose2Coordinate {
+  public func Adjoint(_ v: Vector3) -> Vector3 {
+    let (w, v) = Pose2Coordinate.decomposed(tangentVector: v)
+    let tPerp = Vector2(-t.y, t.x)
+    return Pose2Coordinate.tangentVector(w: w, v: rot.rotate(v) - tPerp.scaled(by: w.x))
   }
 
+  public func AdjointTranspose(_ v: Vector3) -> Vector3 {
+    let (w, v) = Pose2Coordinate.decomposed(tangentVector: v)
+    return Pose2Coordinate.tangentVector(
+      w: Vector1(w.x - t.x * v.y + t.y * v.x),
+      v: rot.unrotate(v)
+    )
+  }
+}
+
+extension Pose2 {
   /// The Adjoint group action of `self` on the tangent space, as a matrix.
-  public var groupAdjointMatrix: Tensor<Double> {
-    Tensor(stacking: Pose2.tangentStandardBasis.map { groupAdjoint($0).tensor }).transposed()
+  public var AdjointMatrix: Tensor<Double> {
+    Tensor(stacking: Pose2.tangentStandardBasis.map { Adjoint($0).tensor }).transposed()
   }
 }
 
@@ -205,4 +196,3 @@ extension Pose2: CustomStringConvertible {
     "Pose2(rot: \(coordinate.rot), t: \(coordinate.t))"
   }
 }
-

--- a/Sources/SwiftFusion/Geometry/Rot2.swift
+++ b/Sources/SwiftFusion/Geometry/Rot2.swift
@@ -18,11 +18,6 @@ public struct Rot2: Manifold, LieGroup, Equatable, KeyPathIterable {
 
   // MARK: - Convenience initializers and computed properties
 
-  /// Creates the identity.
-  public init() {
-    self.init(0)
-  }
-
   // Construct from theta.
   @differentiable
   public init(_ theta: Double) {
@@ -45,11 +40,6 @@ public struct Rot2: Manifold, LieGroup, Equatable, KeyPathIterable {
   /// Sine value.
   @differentiable
   public var s: Double { coordinate.s }
-
-  @differentiable
-  public func localCoordinate(_ global: Rot2) -> Vector1 {
-    coordinate.localCoordinate(global.coordinate)
-  }
 }
 
 extension Rot2: TangentStandardBasis {
@@ -63,12 +53,6 @@ extension Rot2: CustomDebugStringConvertible {
 }
 
 extension Rot2 {
-  /// Product of two rotations.
-  @differentiable
-  public static func * (lhs: Rot2, rhs: Rot2) -> Rot2 {
-    Rot2(coordinate: lhs.coordinate * rhs.coordinate)
-  }
-
   /// Returns the result of acting `self` on `v`.
   @differentiable
   func rotate(_ v: Vector2) -> Vector2 {
@@ -79,12 +63,6 @@ extension Rot2 {
   @differentiable
   func unrotate(_ v: Vector2) -> Vector2 {
     Vector2(c * v.x + s * v.y, -s * v.x + c * v.y)
-  }
-
-  /// Inverse of the rotation.
-  @differentiable
-  public func inverse() -> Rot2 {
-    Rot2(coordinate: coordinate.inverse())
   }
 }
 
@@ -112,10 +90,15 @@ public extension Rot2Coordinate {
   }
 }
 
-public extension Rot2Coordinate {
+extension Rot2Coordinate: LieGroupCoordinate {
+  /// Creates the group identity.
+  public init() {
+    self.init(0)
+  }
+
   /// Product of two rotations.
   @differentiable
-  static func * (lhs: Rot2Coordinate, rhs: Rot2Coordinate) -> Rot2Coordinate {
+  public static func * (lhs: Rot2Coordinate, rhs: Rot2Coordinate) -> Rot2Coordinate {
     Rot2Coordinate(
       c: lhs.c * rhs.c - lhs.s * rhs.s,
       s: lhs.s * rhs.c + lhs.c * rhs.s)
@@ -123,7 +106,7 @@ public extension Rot2Coordinate {
 
   /// Inverse of the rotation.
   @differentiable
-  func inverse() -> Rot2Coordinate {
+  public func inverse() -> Rot2Coordinate {
     Rot2Coordinate(c: self.c, s: -self.s)
   }
 }

--- a/Sources/SwiftFusion/Geometry/Rot3.swift
+++ b/Sources/SwiftFusion/Geometry/Rot3.swift
@@ -132,6 +132,16 @@ extension Matrix3Coordinate: LieGroupCoordinate {
   public func inverse() -> Matrix3Coordinate {
     Matrix3Coordinate(R.transposed())
   }
+
+  @differentiable(wrt: v)
+  public func Adjoint(_ v: Vector3) -> Vector3 {
+    return Vector3(matmul(R, v.tensor.reshaped(to: [3, 1])).reshaped(to: [3]))
+  }
+
+  @differentiable(wrt: v)
+  public func AdjointTranspose(_ v: Vector3) -> Vector3 {
+    return Vector3(matmul(R, transposed: true, v.tensor.reshaped(to: [3, 1])).reshaped(to: [3]))
+  }
 }
 
 func sqrtWrap(_ v: Double) -> Double {

--- a/Sources/SwiftFusion/Geometry/Rot3.swift
+++ b/Sources/SwiftFusion/Geometry/Rot3.swift
@@ -39,13 +39,13 @@ public struct Rot3: LieGroup, TangentStandardBasis, Equatable, KeyPathIterable {
   /// Returns the result of acting `self` on `v`.
   @differentiable
   func rotate(_ v: Vector3) -> Vector3 {
-    Vector3(matmul(coordinate.R, v.tensor.reshaped(to: [3, 1])).reshaped(to: [3]))
+    return coordinate.rotate(v)
   }
   
   /// Returns the result of acting the inverse of `self` on `v`.
   @differentiable
   func unrotate(_ v: Vector3) -> Vector3 {
-    Vector3(matmul(coordinate.R.transposed(), v.tensor.reshaped(to: [3, 1])).reshaped(to: [3]))
+    return coordinate.unrotate(v)
   }
   
   /// Returns the result of acting `self` on `v`.
@@ -135,11 +135,26 @@ extension Matrix3Coordinate: LieGroupCoordinate {
 
   @differentiable(wrt: v)
   public func Adjoint(_ v: Vector3) -> Vector3 {
-    return Vector3(matmul(R, v.tensor.reshaped(to: [3, 1])).reshaped(to: [3]))
+    return rotate(v)
   }
 
   @differentiable(wrt: v)
   public func AdjointTranspose(_ v: Vector3) -> Vector3 {
+    return unrotate(v)
+  }
+}
+
+/// Actions.
+extension Matrix3Coordinate {
+  /// Returns the result of acting `self` on `v`.
+  @differentiable
+  func rotate(_ v: Vector3) -> Vector3 {
+    return Vector3(matmul(R, v.tensor.reshaped(to: [3, 1])).reshaped(to: [3]))
+  }
+
+  /// Returns the result of acting the inverse of `self` on `v`.
+  @differentiable
+  func unrotate(_ v: Vector3) -> Vector3 {
     return Vector3(matmul(R, transposed: true, v.tensor.reshaped(to: [3, 1])).reshaped(to: [3]))
   }
 }

--- a/Sources/SwiftFusion/Inference/BetweenFactor.swift
+++ b/Sources/SwiftFusion/Inference/BetweenFactor.swift
@@ -23,7 +23,7 @@ import TensorFlow
 /// `Input`: the input values as key-value pairs
 ///
 public struct BetweenFactor<T: LieGroup>: NonlinearFactor
-  where T.TangentVector: VectorConvertible, T.TangentVector == T.Coordinate.LocalCoordinate
+  where T.TangentVector: VectorConvertible
 {
   
   var key1: Int

--- a/Sources/SwiftFusion/Inference/PriorFactor.swift
+++ b/Sources/SwiftFusion/Inference/PriorFactor.swift
@@ -23,7 +23,7 @@ import TensorFlow
 /// `Input`: the input values as key-value pairs
 ///
 public struct PriorFactor<T: LieGroup>: NonlinearFactor
-  where T.TangentVector: VectorConvertible, T.TangentVector == T.Coordinate.LocalCoordinate
+  where T.TangentVector: VectorConvertible
 {
   @noDerivative
   public var keys: Array<Int> = []

--- a/Tests/SwiftFusionTests/Geometry/Pose2Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Pose2Tests.swift
@@ -204,7 +204,7 @@ final class Pose2Tests: XCTestCase {
 //
 //    let v = Vector3(0.99, 0.01, -0.015);
 //    let pose = Pose2(coordinate: Pose2(0, 0, 0).coordinate.retract(v))
-//    let actual = pose.groupAdjointMatrix
+//    let actual = pose.AdjointMatrix
     // assertEqual(actual, expected, accuracy: 1e-5)
     // TODO: This is also commented out in GTSAM, why?
   }
@@ -251,7 +251,7 @@ final class Pose2Tests: XCTestCase {
   func testDerivativeInverse() {
     for _ in 0..<10 {
       let pose = Pose2(randomWithCovariance: eye(rowCount: 3))
-      let expected = -pose.groupAdjointMatrix
+      let expected = -pose.AdjointMatrix
       assertEqual(
         Tensor<Double>(stacking: jacobian(of: { $0.inverse() }, at: pose).map { $0.tensor }),
         expected,
@@ -265,7 +265,7 @@ final class Pose2Tests: XCTestCase {
     for _ in 0..<10 {
       let lhs = Pose2(randomWithCovariance: eye(rowCount: 3))
       let rhs = Pose2(randomWithCovariance: eye(rowCount: 3))
-      let expectedWrtLhs = rhs.inverse().groupAdjointMatrix
+      let expectedWrtLhs = rhs.inverse().AdjointMatrix
       let expectedWrtRhs: Tensor<Double> = eye(rowCount: 3)
       assertEqual(
         Tensor<Double>(stacking: jacobian(of: { $0 * rhs }, at: lhs).map { $0.tensor }),
@@ -389,16 +389,22 @@ final class Pose2Tests: XCTestCase {
     XCTAssertEqual(p5T1.t.norm, 0.0, accuracy: 1e-2)
   }
 
-  static var allTests = [
-    ("testBetweenIdentitiesTrivial", testBetweenIdentitiesTrivial),
-    ("testBetweenIdentities", testBetweenIdentities),
-    ("testBetweenIdentities", testBetweenIdentitiesRotated),
-    ("testBetweenDerivatives", testBetweenDerivatives),
-    ("testDerivativeIdentity", testDerivativeIdentity),
-    ("testDerivativeInverse", testDerivativeInverse),
-    ("testDerivativeMultiplication", testDerivativeMultiplication),
-    ("testJacobianPose2Identity", testJacobianPose2Identity),
-    ("testJacobianPose2Trivial", testJacobianPose2Trivial),
-    ("testPose2SLAM", testPose2SLAM),
-  ]
+  /// Tests that the custom implementations of `Adjoint` and `AdjointTranspose` are correct.
+  func testAdjoint() {
+    for _ in 0..<10 {
+      let pose = Pose2(randomWithCovariance: eye(rowCount: 3))
+      for v in Pose2.tangentStandardBasis {
+        assertEqual(
+          pose.Adjoint(v).tensor,
+          pose.coordinate.defaultAdjoint(v).tensor,
+          accuracy: 1e-10
+        )
+        assertEqual(
+          pose.AdjointTranspose(v).tensor,
+          pose.coordinate.defaultAdjointTranspose(v).tensor,
+          accuracy: 1e-10
+        )
+      }
+    }
+  }
 }

--- a/Tests/SwiftFusionTests/Geometry/Rot3Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Rot3Tests.swift
@@ -114,4 +114,23 @@ final class Rot3Tests: XCTestCase {
     
     assertAllKeyPathEqual(actual, expected, accuracy: 1e-5)
   }
+
+  /// Tests that the custom implementations of `Adjoint` and `AdjointTranspose` are correct.
+  func testAdjoint() {
+    for _ in 0..<10 {
+      let rot = Rot3.fromTangent(Vector3(Tensor<Double>(randomNormal: [3])))
+      for v in Pose2.tangentStandardBasis {
+        assertEqual(
+          rot.Adjoint(v).tensor,
+          rot.coordinate.defaultAdjoint(v).tensor,
+          accuracy: 1e-10
+        )
+        assertEqual(
+          rot.AdjointTranspose(v).tensor,
+          rot.coordinate.defaultAdjointTranspose(v).tensor,
+          accuracy: 1e-10
+        )
+      }
+    }
+  }
 }


### PR DESCRIPTION
This makes lie groups slightly easier to define, and also makes their derivatives faster. Specifically:
* Now you only need to define the manifold operations (`localCoordinate`, `retract`) and group operations (identity, inverse, group op) on the `ManifoldCoordinate`. The `Manifold` type gets them automatically.
* I added derivatives for all these operations that use the mathematical structure to be simpler and more efficient.

One result is a pretty big speedup in the Pose3SLAM test:
* Before: 12.097 seconds
* After: 8.249 seconds