### PR TITLE
new group operators

### DIFF
--- a/Sources/SwiftFusion/Geometry/Rot2.swift
+++ b/Sources/SwiftFusion/Geometry/Rot2.swift
@@ -63,7 +63,7 @@ extension Rot2 {
 }
 
 @differentiable
-func * (r: Rot2, p: Vector2) -> Vector2 {
+func *^ (r: Rot2, p: Vector2) -> Vector2 {
   r.rotate(p)
 }
 
@@ -94,7 +94,7 @@ extension Rot2Coordinate: LieGroupCoordinate {
 
   /// Product of two rotations.
   @differentiable
-  public static func * (lhs: Rot2Coordinate, rhs: Rot2Coordinate) -> Rot2Coordinate {
+  public static func ** (lhs: Rot2Coordinate, rhs: Rot2Coordinate) -> Rot2Coordinate {
     Rot2Coordinate(
       c: lhs.c * rhs.c - lhs.s * rhs.s,
       s: lhs.s * rhs.c + lhs.c * rhs.s)
@@ -112,12 +112,12 @@ extension Rot2Coordinate: ManifoldCoordinate {
 
   @differentiable(wrt: local)
   public func retract(_ local: Vector1) -> Self {
-    self * Rot2Coordinate(local.x)
+    self ** Rot2Coordinate(local.x)
   }
 
   @differentiable(wrt: global)
   public func localCoordinate(_ global: Self) -> Vector1 {
-    Vector1((self.inverse() * global).theta)
+    Vector1((self.inverse() ** global).theta)
   }
 }
 

--- a/Sources/SwiftFusion/Geometry/Rot3.swift
+++ b/Sources/SwiftFusion/Geometry/Rot3.swift
@@ -43,7 +43,7 @@ public struct Rot3: LieGroup, Equatable, KeyPathIterable {
   
   /// Returns the result of acting `self` on `v`.
   @differentiable
-  static func * (r: Rot3, p: Vector3) -> Vector3 {
+  static func *^ (r: Rot3, p: Vector3) -> Vector3 {
     r.rotate(p)
   }
 }
@@ -116,7 +116,7 @@ extension Matrix3Coordinate: LieGroupCoordinate {
   
   /// Product of two rotations.
   @differentiable(wrt: (lhs, rhs))
-  public static func * (lhs: Matrix3Coordinate, rhs: Matrix3Coordinate) -> Matrix3Coordinate {
+  public static func ** (lhs: Matrix3Coordinate, rhs: Matrix3Coordinate) -> Matrix3Coordinate {
     Matrix3Coordinate(matmul(lhs.R, rhs.R))
   }
   
@@ -181,18 +181,18 @@ extension Matrix3Coordinate: ManifoldCoordinate {
       let K = W / theta
       let KK = matmul(K, K)
       
-      return self * Matrix3Coordinate(
+      return self ** Matrix3Coordinate(
         I_3x3 + Tensor<Double>(repeating: sin_theta, shape: [3, 3]) * K
           + Tensor<Double>(repeating: one_minus_cos, shape: [3, 3]) * KK
       )
     } else {
-      return self * Matrix3Coordinate(I_3x3 + W)
+      return self ** Matrix3Coordinate(I_3x3 + W)
     }
   }
 
   @differentiable(wrt: global)
   public func localCoordinate(_ global: Matrix3Coordinate) -> Vector3 {
-    let relative = self.inverse() * global
+    let relative = self.inverse() ** global
     let R = relative.R
     let (R11, R12, R13) = (R[0, 0].scalars[0], R[0, 1].scalars[0], R[0, 2].scalars[0])
     let (R21, R22, R23) = (R[1, 0].scalars[0], R[1, 1].scalars[0], R[1, 2].scalars[0])

--- a/Sources/SwiftFusion/Inference/BetweenFactor.swift
+++ b/Sources/SwiftFusion/Inference/BetweenFactor.swift
@@ -67,18 +67,13 @@ public struct BetweenFactor<T: LieGroup>: NonlinearFactor {
   /// Returns the `error` of the factor.
   @differentiable(wrt: values)
   public func error(_ values: Values) -> Double {
-    let actual = values[key1, as: T.self].inverse() * values[key2, as: T.self]
-    let error = difference.localCoordinate(actual)
-    // TODO: It would be faster to call `error.squaredNorm` because then we don't have to pay
-    // the cost of a conversion to `Vector`. To do this, we need a protocol
-    // with a `squaredNorm` requirement.
-    return error.vector.squaredNorm
+    return errorVector(values).squaredNorm
   }
   
   @differentiable(wrt: values)
   public func errorVector(_ values: Values) -> T.Coordinate.LocalCoordinate {
     let error = difference.localCoordinate(
-      values[key1, as: T.self].inverse() * values[key2, as: T.self]
+      values[key1, as: T.self].inverse() ** values[key2, as: T.self]
     )
     
     return error


### PR DESCRIPTION
I propose that we use something other than `*` for the group operation and the group action. I have no strong opinion on what other operator we should use, please suggest better options! (Is there any precedent in other libraries?)

Reasons:

`*` will be highly confusing to human readers when we make `VectorN` conform to `LieGroup`, because `a * b` looks like some kind of multiplication but it's actually `a + b`!!

The Swift typechecker is notoriously slow when it has to resolve overloaded operators. This simple change hugely decreases compile time.

Before:
```
marcrasi@marcrasi:~/git/SwiftFusion$ swift package clean && time swift build
[88/88] Linking Benchmarks

real    0m27.196s
user    1m54.372s
sys     0m5.155s
```

After:
```
marcrasi@marcrasi:~/git/SwiftFusion$ swift package clean && time swift build
[88/88] Linking Benchmarks

real    0m18.016s
user    1m47.860s
sys     0m4.806s
```