### PR TITLE
help the typechecker go faster

### DIFF
--- a/Sources/SwiftFusion/Geometry/Pose3.swift
+++ b/Sources/SwiftFusion/Geometry/Pose3.swift
@@ -97,13 +97,6 @@ extension Pose3Coordinate: LieGroupCoordinate {
   }
 }
 
-@differentiable(wrt: (a, b))
-func dot(_ a: Vector3, _ b: Vector3) -> Double {
-  let squared = a.x * b.x + a.y * b.y + a.z * b.z
-
-  return squared
-}
-
 extension Vector3 {
   public func cross(_ b: Vector3) -> Vector3 {
     let a = self
@@ -136,9 +129,9 @@ extension Pose3Coordinate: ManifoldCoordinate {
     
     let theta2 = omega.squaredNorm
     if theta2 > .ulpOfOne {
-        let t_parallel = dot(omega, v) * omega // translation parallel to axis
+        let t_parallel = omega.dot(v) * omega // translation parallel to axis
         let omega_cross_v = omega.cross(v); // points towards axis
-        let t = 1 / theta2 * (omega_cross_v - R * omega_cross_v + t_parallel)
+        let t = (1 / theta2) * (omega_cross_v - R * omega_cross_v + t_parallel as Vector3)
         return self * Pose3Coordinate(R, t)
     } else {
         return self * Pose3Coordinate(R, v)
@@ -186,7 +179,7 @@ extension Pose3Coordinate: ManifoldCoordinate {
     // simplified with Mathematica, and multiplying in T to avoid matrix math
     let Tan = tan(0.5 * t)
     let WT = matmul(W, T)
-    let u: Tensor<Double> = T - (0.5 * t) * WT + (1 - t / (2 * Tan)) * matmul(W, WT)
+    let u = ((T - (0.5 * t) * WT) as Tensor<Double>) + (1 - t / (2 * Tan)) * matmul(W, WT)
     precondition(u.shape == [3, 1])
     return Pose3Coordinate.tangentVector(
       DecomposedTangentVector(w: w, v: Vector3(u.reshaped(to: [3]))))

--- a/Sources/SwiftFusion/Geometry/Rot2.swift
+++ b/Sources/SwiftFusion/Geometry/Rot2.swift
@@ -134,8 +134,13 @@ fileprivate func atan2wrap(_ s: Double, _ c: Double) -> Double {
 // d atan2(s,c)/s = -s / (s^2+c^2)
 // TODO(frank): make use of fact that s^2 + c^2 = 1
 @derivative(of: atan2wrap)
-fileprivate func _vjpAtan2wrap(_ s: Double, _ c: Double) -> (value: Double, pullback: (Double) -> (Double, Double)) {
+fileprivate func _vjpAtan2wrap(_ s: Double, _ c: Double) ->
+  (value: Double, pullback: (Double) -> (Double, Double))
+{
   let theta = atan2(s, c)
   let normSquared = c * c + s * s
-  return (theta, { v in (v * c / normSquared, -v * s / normSquared) })
+  return (
+    theta,
+    { (v: Double) -> (Double, Double) in (v * c / normSquared, -v * s / normSquared) }
+  )
 }


### PR DESCRIPTION
As I mentioned in https://github.com/borglab/SwiftFusion/pull/66, the Swift typechecker is slow when there are overloaded operators.

We can speed it up without figuring out all the answers in that discussion by giving the compiler hints that help it resolve the overloads.

Before:
```
marcrasi@marcrasi:~/git/SwiftFusion$ swift package clean && time swift build
[88/88] Linking Benchmarks

real    0m27.196s
user    1m54.372s
sys     0m5.155s
```

After:
```
marcrasi@marcrasi:~/git/SwiftFusion$ swift package clean && time swift build
[88/88] Linking Benchmarks

real    0m12.526s
user    1m39.393s
sys     0m4.367s
```

For future reference, I found the offending expressions with:
```
swift package clean && swift build -Xswiftc -Xfrontend -Xswiftc -debug-time-function-bodies > compile_times.txt
sort -g compile_times.txt | uniq | tail -n10
```