### PR TITLE
Add type-erased contiguous storage for `Differentiable` and `EuclideanVector` types.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "Penguin",
+        "repositoryURL": "https://github.com/saeta/penguin.git",
+        "state": {
+          "branch": "master",
+          "revision": "749620ae314d1899b71005ecec337cdb171ec629",
+          "version": null
+        }
+      },
+      {
         "package": "swift-argument-parser",
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -19,13 +19,14 @@ let package = Package(
     // Dependencies declare other packages that this package depends on.
     // .package(url: /* package url */, from: "1.0.0"),
     .package(url: "https://github.com/google/swift-benchmark.git", .branch("master")),
+    .package(url: "https://github.com/saeta/penguin.git", .branch("master")),
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module or a test suite.
     // Targets can depend on other targets in this package, and on products in packages which this package depends on.
     .target(
       name: "SwiftFusion",
-      dependencies: []),
+      dependencies: ["PenguinStructures"]),
     .target(
       name: "Benchmarks",
       dependencies: [

--- a/Sources/SwiftFusion/Inference/ValuesStorage.swift
+++ b/Sources/SwiftFusion/Inference/ValuesStorage.swift
@@ -1,0 +1,227 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Contiguous storage for factor graph values (variable assignments, error vectors) of statically
+/// unknown type.
+
+import PenguinStructures
+
+// MARK: - Storage for contiguous arrays of `Differentiable` values.
+
+/// Contiguous storage of homogeneous `Differentiable` values of statically unknown type.
+class AnyDifferentiableStorage: AnyArrayStorage {
+  typealias DifferentiableImplementation = AnyDifferentiableStorageImplementation
+  var differentiableImplementation: DifferentiableImplementation {
+    fatalError("implement me!")
+  }
+  
+  /// Moves each element of `self` along the corresponding element of `direction`.
+  ///
+  /// `direction` must point to a buffer of `Element.TangentVector`s, where `Element` is the type
+  /// stored in `self`, and `direction.count` must be `self.count`.
+  final func move(along direction: UnsafeRawBufferPointer) {
+    differentiableImplementation.move_(along: direction)
+  }
+}
+
+/// Contiguous storage of homogeneous `Differentiable` values of statically unknown type.
+protocol AnyDifferentiableStorageImplementation: AnyDifferentiableStorage {
+  /// Moves each element of `self` along the corresponding element of `direction`.
+  ///
+  /// `direction` must point to a buffer of `Element.TangentVector`s, where `Element` is the type
+  /// stored in `self`, and `direction.count` must be `self.count`.
+  func move_(along direction: UnsafeRawBufferPointer)
+}
+
+/// APIs that depend on `Differentiable` `Element` type.
+extension ArrayStorageImplementation where Element: Differentiable {
+  /// Moves each element of `self` along the corresponding element of `direction`.
+  ///
+  /// `direction.count` must be `self.count`.
+  func move(along direction: UnsafeBufferPointer<Element.TangentVector>) {
+    withUnsafeMutableBufferPointer { elementBuffer in
+      precondition(elementBuffer.count == direction.count)
+      var elementIndex = elementBuffer.startIndex
+      var directionIndex = direction.startIndex
+      while elementIndex != elementBuffer.endIndex {
+        elementBuffer[elementIndex].move(along: direction[directionIndex])
+        elementIndex = elementBuffer.index(after: elementIndex)
+        directionIndex = direction.index(after: directionIndex)
+      }
+    }
+  }
+  
+  /// Moves each element of `self` along the corresponding element of `direction`.
+  ///
+  /// `direction` must point to a buffer of `Element.TangentVector`s, and  `direction.count` must
+  /// be `self.count`.
+  func move_(along direction: UnsafeRawBufferPointer) {
+    move(along: UnsafeBufferPointer(
+      start: direction.baseAddress?.assumingMemoryBound(to: Element.TangentVector.self),
+      count: direction.count / MemoryLayout<Element.TangentVector>.stride
+    ))
+  }
+}
+
+/// Type-erasable storage for contiguous `Differentiable` `Element` instances.
+///
+/// Note: instances have reference semantics.
+final class DifferentiableArrayStorage<Element: Differentiable>:
+  AnyDifferentiableStorage, AnyDifferentiableStorageImplementation,
+  ArrayStorageImplementation
+{
+  override var implementation: AnyArrayStorageImplementation { self }
+  override var differentiableImplementation: AnyDifferentiableStorageImplementation {
+    self
+  }
+}
+
+// MARK: - Storage for contiguous arrays of `EuclideanVector` values.
+
+/// Contiguous storage of homogeneous `EuclideanVector` values of statically unknown type.
+class AnyVectorStorage: AnyDifferentiableStorage {
+  typealias VectorImplementation = AnyVectorStorageImplementation
+  var vectorImplementation: VectorImplementation {
+    fatalError("implement me!")
+  }
+  
+  /// Adds each element of `other` to the corresponding element of `self`.
+  ///
+  /// `other` must point to a buffer of the same type stored in `self`, and `other.count` must be
+  /// `self.count`.
+  final func add(_ other: UnsafeRawBufferPointer) {
+    vectorImplementation.add_(other)
+  }
+  
+  /// Scales each element of `self` by `scalar`.
+  final func scale(by scalar: Double) {
+    vectorImplementation.scale_(by: scalar)
+  }
+  
+  /// Returns the dot product of `self` with `other`.
+  ///
+  /// This is the sum of the dot product of corresponding elements.
+  ///
+  /// `other` must point to a buffer of the same type stored in `self`, and `other.count` must be
+  /// `self.count`.
+  final func dot(_ other: UnsafeRawBufferPointer) -> Double {
+    vectorImplementation.dot_(other)
+  }
+}
+
+/// Contiguous storage of homogeneous `EuclideanVector` values of statically unknown type.
+protocol AnyVectorStorageImplementation:
+  AnyVectorStorage, AnyDifferentiableStorageImplementation
+{
+  /// Adds each element of `other` to the corresponding element of `self`.
+  ///
+  /// `other` must point to a buffer of the same type stored in `self`, and `other.count` must be
+  /// `self.count`.
+  func add_(_ other: UnsafeRawBufferPointer)
+  
+  /// Scales each element of `self` by `scalar`.
+  func scale_(by scalar: Double)
+  
+  /// Returns the dot product of `self` with `other`.
+  ///
+  /// This is the sum of the dot products of corresponding elements.
+  ///
+  /// `other` must point to a buffer of the same type stored in `self`, and `other.count` must be
+  /// `self.count`.
+  func dot_(_ other: UnsafeRawBufferPointer) -> Double
+}
+
+/// APIs that depend on `EuclideanVector` `Element` type.
+extension ArrayStorageImplementation where Element: EuclideanVector {
+  /// Adds each element of `other` to the corresponding element of `self`.
+  ///
+  /// `other.count` must be `self.count`.
+  func add(_ other: UnsafeBufferPointer<Element>) {
+    withUnsafeMutableBufferPointer { elementBuffer in
+      precondition(elementBuffer.count == other.count)
+      var elementIndex = elementBuffer.startIndex
+      var otherIndex = other.startIndex
+      while elementIndex != elementBuffer.endIndex {
+        elementBuffer[elementIndex] += other[otherIndex]
+        elementIndex = elementBuffer.index(after: elementIndex)
+        otherIndex = other.index(after: otherIndex)
+      }
+    }
+  }
+  
+  /// Returns the dot product of `self` with `other`.
+  ///
+  /// This is the sum of the dot products of corresponding elements.
+  ///
+  /// `other.count` must be `self.count`.
+  func dot(_ other: UnsafeBufferPointer<Element>) -> Double {
+    var result = Double(0)
+    withUnsafeMutableBufferPointer { elementBuffer in
+      precondition(elementBuffer.count == other.count)
+      var elementIndex = elementBuffer.startIndex
+      var otherIndex = other.startIndex
+      while elementIndex != elementBuffer.endIndex {
+        result += elementBuffer[elementIndex].dot(other[otherIndex])
+        elementIndex = elementBuffer.index(after: elementIndex)
+        otherIndex = other.index(after: otherIndex)
+      }
+    }
+    return result
+  }
+  
+  /// Adds each element of `other` to the corresponding element of `self`.
+  ///
+  /// `other` must point to a buffer of the same type stored in `self`, and `other.count` must be
+  /// `self.count`.
+  func add_(_ other: UnsafeRawBufferPointer) {
+    add(UnsafeBufferPointer(
+      start: other.baseAddress?.assumingMemoryBound(to: Element.self),
+      count: other.count / MemoryLayout<Element>.stride
+    ))
+  }
+  
+  /// Scales each element of `self` by `scalar`.
+  func scale_(by scalar: Double) {
+    withUnsafeMutableBufferPointer { elementBuffer in
+      for index in elementBuffer.indices {
+        elementBuffer[index] *= scalar
+      }
+    }
+  }
+  
+  /// Returns the dot product of `self` with `other`.
+  ///
+  /// This is the sum of the dot products of corresponding elements.
+  ///
+  /// `other` must point to a buffer of the same type stored in `self`, and `other.count` must be
+  /// `self.count`.
+  func dot_(_ other: UnsafeRawBufferPointer) -> Double {
+    return dot(UnsafeBufferPointer(
+      start: other.baseAddress?.assumingMemoryBound(to: Element.self),
+      count: other.count / MemoryLayout<Element>.stride
+    ))
+  }
+}
+
+/// Type-erasable storage for contiguous `EuclideanVector` `Element` instances.
+///
+/// Note: instances have reference semantics.
+final class VectorArrayStorage<Element: EuclideanVector>:
+  AnyVectorStorage, AnyVectorStorageImplementation,
+  ArrayStorageImplementation
+{  
+  override var implementation: AnyArrayStorageImplementation { self }
+  override var differentiableImplementation: DifferentiableImplementation { self }
+  override var vectorImplementation: AnyVectorStorageImplementation { self }
+}

--- a/Sources/SwiftFusion/Inference/ValuesStorage.swift
+++ b/Sources/SwiftFusion/Inference/ValuesStorage.swift
@@ -51,12 +51,8 @@ extension ArrayStorageImplementation where Element: Differentiable {
   /// Precondition: all values in `directionsStart..<directionsStart+count` point to initialized
   /// `Element.TangentVector`s.
   func move(along directionsStart: UnsafePointer<Element.TangentVector>) {
-    withUnsafeMutableBufferPointer { elementBuffer in
-      var directionPointer = directionsStart
-      for elementIndex in elementBuffer.indices {
-        elementBuffer[elementIndex].move(along: directionPointer.pointee)
-        directionPointer = directionPointer.advanced(by: 1)
-      }
+    withUnsafeMutableBufferPointer { b in
+      b.indices.forEach { i in b[i].move(along: directionsStart[i]) }
     }
   }
   

--- a/Tests/SwiftFusionTests/Inference/ValuesStorageTests.swift
+++ b/Tests/SwiftFusionTests/Inference/ValuesStorageTests.swift
@@ -1,0 +1,91 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import TensorFlow
+import XCTest
+
+import PenguinStructures
+@testable import SwiftFusion
+
+/// Test helpers.
+extension ArrayStorageImplementation {
+  /// Creates an array with `count` copies of `element`.
+  static func create(repeating element: Element, count: Int) -> Self {
+    let array = Self.create(minimumCapacity: count)
+    for _ in 0..<count { _ = array.append(element) }
+    return array
+  }
+  
+  /// Returns the element at `index`.
+  subscript(index: Int) -> Element {
+    return withUnsafeMutableBufferPointer { buffer in
+      return buffer[index]
+    }
+  }
+}
+
+class ValuesStorageTests: XCTestCase {
+  
+  func testDifferentiableMove() {
+    let values = DifferentiableArrayStorage.create(repeating: Pose2(0, 0, 0), count: 5)
+    let directions = VectorArrayStorage.create(repeating: Vector3(1, 0, 0), count: 5)
+    directions.withUnsafeMutableRawBufferPointer { directionBuffer in
+      values.move(along: UnsafeRawBufferPointer(directionBuffer))
+    }
+    for i in 0..<5 {
+      XCTAssertEqual(values[i], Pose2(0, 0, 1))
+    }
+  }
+  
+  func testVectorMove() {
+    let values = VectorArrayStorage.create(repeating: Vector3(1, 2, 3), count: 5)
+    let directions = VectorArrayStorage.create(repeating: Vector3(10, 20, 30), count: 5)
+    directions.withUnsafeMutableRawBufferPointer { directionBuffer in
+      values.move(along: UnsafeRawBufferPointer(directionBuffer))
+    }
+    for i in 0..<5 {
+      XCTAssertEqual(values[i], Vector3(11, 22, 33))
+    }
+  }
+  
+  func testVectorAdd() {
+    let a = VectorArrayStorage.create(repeating: Vector3(1, 2, 3), count: 5)
+    let b = VectorArrayStorage.create(repeating: Vector3(10, 20, 30), count: 5)
+    b.withUnsafeMutableBufferPointer { bBuffer in
+      a.add(UnsafeRawBufferPointer(bBuffer))
+    }
+    for i in 0..<5 {
+      XCTAssertEqual(a[i], Vector3(11, 22, 33))
+    }
+  }
+  
+  func testVectorScale() {
+    let a = VectorArrayStorage.create(repeating: Vector3(1, 2, 3), count: 5)
+    a.scale(by: 10)
+    for i in 0..<5 {
+      XCTAssertEqual(a[i], Vector3(10, 20, 30))
+    }
+  }
+  
+  func testVectorDot() {
+    let a = VectorArrayStorage.create(repeating: Vector3(1, 2, 3), count: 5)
+    let b = VectorArrayStorage.create(repeating: Vector3(10, 20, 30), count: 5)
+    let dot = b.withUnsafeMutableBufferPointer { bBuffer in
+      return a.dot(UnsafeRawBufferPointer(bBuffer))
+    }
+    XCTAssertEqual(dot, 5 * (Double(1 * 10 + 2 * 20 + 3 * 30)))
+  }
+  
+}

--- a/Tests/SwiftFusionTests/Inference/ValuesStorageTests.swift
+++ b/Tests/SwiftFusionTests/Inference/ValuesStorageTests.swift
@@ -42,7 +42,7 @@ class ValuesStorageTests: XCTestCase {
     let values = DifferentiableArrayStorage.create(repeating: Pose2(0, 0, 0), count: 5)
     let directions = VectorArrayStorage.create(repeating: Vector3(1, 0, 0), count: 5)
     directions.withUnsafeMutableRawBufferPointer { directionBuffer in
-      values.move(along: UnsafeRawBufferPointer(directionBuffer))
+      values.move(along: UnsafeRawPointer(directionBuffer.baseAddress!))
     }
     for i in 0..<5 {
       XCTAssertEqual(values[i], Pose2(0, 0, 1))
@@ -53,7 +53,7 @@ class ValuesStorageTests: XCTestCase {
     let values = VectorArrayStorage.create(repeating: Vector3(1, 2, 3), count: 5)
     let directions = VectorArrayStorage.create(repeating: Vector3(10, 20, 30), count: 5)
     directions.withUnsafeMutableRawBufferPointer { directionBuffer in
-      values.move(along: UnsafeRawBufferPointer(directionBuffer))
+      values.move(along: UnsafeRawPointer(directionBuffer.baseAddress!))
     }
     for i in 0..<5 {
       XCTAssertEqual(values[i], Vector3(11, 22, 33))
@@ -64,7 +64,7 @@ class ValuesStorageTests: XCTestCase {
     let a = VectorArrayStorage.create(repeating: Vector3(1, 2, 3), count: 5)
     let b = VectorArrayStorage.create(repeating: Vector3(10, 20, 30), count: 5)
     b.withUnsafeMutableBufferPointer { bBuffer in
-      a.add(UnsafeRawBufferPointer(bBuffer))
+      a.add(UnsafeRawPointer(bBuffer.baseAddress!))
     }
     for i in 0..<5 {
       XCTAssertEqual(a[i], Vector3(11, 22, 33))
@@ -83,7 +83,7 @@ class ValuesStorageTests: XCTestCase {
     let a = VectorArrayStorage.create(repeating: Vector3(1, 2, 3), count: 5)
     let b = VectorArrayStorage.create(repeating: Vector3(10, 20, 30), count: 5)
     let dot = b.withUnsafeMutableBufferPointer { bBuffer in
-      return a.dot(UnsafeRawBufferPointer(bBuffer))
+      return a.dot(UnsafeRawPointer(bBuffer.baseAddress!))
     }
     XCTAssertEqual(dot, 5 * (Double(1 * 10 + 2 * 20 + 3 * 30)))
   }

--- a/Tests/SwiftFusionTests/Inference/ValuesStorageTests.swift
+++ b/Tests/SwiftFusionTests/Inference/ValuesStorageTests.swift
@@ -23,9 +23,9 @@ import PenguinStructures
 extension ArrayStorageImplementation {
   /// Creates an array with `count` copies of `element`.
   static func create(repeating element: Element, count: Int) -> Self {
-    let array = Self.create(minimumCapacity: count)
-    for _ in 0..<count { _ = array.append(element) }
-    return array
+    let r = Self.create(minimumCapacity: count)
+    for _ in 0..<count { _ = r.append(element) }
+    return r
   }
   
   /// Returns the element at `index`.


### PR DESCRIPTION
This storage will be used to store differentiable and vector values for factor graph variable assignments and for factor graph error vectors.

This uses the Penguin ArrayStorage data structure, and this is modeled on the [example here](https://github.com/saeta/penguin/blob/master/Tests/PenguinStructuresTests/ArrayStorageExtensionTests.swift).

This doesn't include the user-facing wrapper that manages these and lets users store values of multiple different types.

(@ProfFan, @dellaert, here is the first in a series of small incremental PRs for the real implementation of the generic factor graph prototype that I showed you ~2 weeks ago. I want to get reviews on each of the small pieces, and @dabrahams has agreed to review them, so you can pay as much or as little attention as you like to the small pieces. I will merge all the small pieces into `feature/generic_factor_graph`. When the implementation is complete enough to be useful, I'll create a PR to merge it into `master`.)