### PR TITLE
generic Factor protocol

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/saeta/penguin.git",
         "state": {
           "branch": "master",
-          "revision": "749620ae314d1899b71005ecec337cdb171ec629",
+          "revision": "d2dabbaf5a432f81577a20a34bd0a59a0bda7a62",
           "version": null
         }
       },

--- a/Sources/SwiftFusion/Inference/FactorsStorage.swift
+++ b/Sources/SwiftFusion/Inference/FactorsStorage.swift
@@ -1,0 +1,61 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Contiguous storage for factors of statically unknown type.
+
+import PenguinStructures
+
+/// Contiguous storage of homogeneous `Factor` values of statically unknown type.
+class AnyFactorStorage: AnyArrayStorage {
+  typealias FactorImplementation = AnyFactorStorageImplementation
+  var factorImplementation: FactorImplementation {
+    fatalError("implement me!")
+  }
+
+  /// Returns the errors of the factors given `variableAssignments`.
+  final func errors(_ variableAssignments: ValuesArray) -> [Double] {
+    factorImplementation.errors_(variableAssignments)
+  }
+}
+
+/// Contiguous storage of homogeneous `Factor` values of statically unknown type.
+protocol AnyFactorStorageImplementation: AnyFactorStorage {
+  /// Returns the errors of the factors given `variableAssignments`.
+  func errors_(_ variableAssignments: ValuesArray) -> [Double]
+}
+
+/// APIs that depend on `Factor` `Element` type.
+extension ArrayStorageImplementation where Element: GenericFactor {
+  /// Returns the errors of the factors given `variableAssignments`.
+  func errors_(_ variableAssignments: ValuesArray) -> [Double] {
+    return Element.Variables.withVariableBufferBaseUnsafePointers(variableAssignments) { varsBuf in
+      return withUnsafeMutableBufferPointer { factors in
+        return factors.map { factor in
+          return factor.error(Element.Variables(varsBuf, indices: factor.edges))
+        }
+      }
+    }
+  }
+}
+
+/// Type-erasable storage for contiguous `Factor` `Element` instances.
+///
+/// Note: instances have reference semantics.
+final class FactorArrayStorage<Element: GenericFactor>:
+  AnyFactorStorage, AnyFactorStorageImplementation,
+  ArrayStorageImplementation
+{
+  override var implementation: AnyArrayStorageImplementation { self }
+  override var factorImplementation: AnyFactorStorageImplementation { self }
+}

--- a/Sources/SwiftFusion/Inference/GenericFactor.swift
+++ b/Sources/SwiftFusion/Inference/GenericFactor.swift
@@ -1,0 +1,101 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import PenguinStructures
+
+/// A factor in a factor graph.
+///
+/// Note: This is currently named `GenericFactor` to avoid clashing with the other `Factor`
+/// protocol. When we completely replace `Factor`, we should rename this one to `Factor`.
+protocol GenericFactor {
+  /// A tuple of the variable types of variables adjacent to this factor.
+  associatedtype Variables: VariableTuple
+
+  /// The IDs of the variables adjacent to this factor.
+  var edges: Variables.Indices { get }
+
+  /// Returns the error given the values of the adjacent variables.
+  func error(_: Variables) -> Double
+}
+
+// MARK: - `VariableTuple`.
+
+/// Collections of variable types suitable for a factor.
+protocol VariableTuple: TupleProtocol where Tail: VariableTuple {
+  /// A tuple of `UnsafePointer`s to the types of the variables adjacent to a factor.
+  associatedtype UnsafePointers: TupleProtocol
+
+  /// A tuple of `TypedID`s referring to variables adjacent to a factor.
+  associatedtype Indices: TupleProtocol
+
+  /// Invokes `body` with the base addressess of the variable assignment buffers for the variable
+  /// types in this `VariableTuble`.
+  static func withVariableBufferBaseUnsafePointers<R>(
+    _ variableAssignments: ValuesArray,
+    _ body: (UnsafePointers) -> R
+  ) -> R
+
+  /// Creates a tuple containing the variable values in `variableBufferBases`, at `indices`.
+  ///
+  /// Parameter variableBufferBases: the base addresses from `withVariableBufferBaseUnsafePointers`.
+  init(_ variableBufferBases: UnsafePointers, indices: Indices)
+}
+
+extension Empty: VariableTuple {
+  typealias UnsafePointers = Self
+  typealias Indices = Self
+
+  static func withVariableBufferBaseUnsafePointers<R>(
+    _ variableAssignments: ValuesArray,
+    _ body: (UnsafePointers) -> R
+  ) -> R {
+    return body(Empty())
+  }
+
+  init(_ variableBufferBases: UnsafePointers, indices: Indices) {
+    self.init()
+  }
+}
+
+extension Tuple: VariableTuple where Tail: VariableTuple {
+  typealias UnsafePointers = Tuple<UnsafePointer<Head>, Tail.UnsafePointers>
+  typealias Indices = Tuple<TypedID<Head, Int>, Tail.Indices>
+
+  static func withVariableBufferBaseUnsafePointers<R>(
+    _ variableAssignments: ValuesArray,
+    _ body: (UnsafePointers) -> R
+  ) -> R {
+    return variableAssignments
+      .contiguousStorage[ObjectIdentifier(Head.self)].unsafelyUnwrapped
+      .withUnsafeMutableRawBufferPointer { headBuffer in
+        let headBase: UnsafePointer<Head>
+        if let rawHeadBase = headBuffer.baseAddress {
+          headBase = UnsafePointer(rawHeadBase.assumingMemoryBound(to: Head.self))
+        } else {
+          // An invalid pointer is okay because we know it'll never get dereferenced.
+          headBase = UnsafePointer<Head>(bitPattern: -1).unsafelyUnwrapped
+        }
+        return Tail.withVariableBufferBaseUnsafePointers(variableAssignments) { tailBase in
+          return body(UnsafePointers(head: headBase, tail: tailBase))
+        }
+      }
+  }
+
+  init(_ variableBufferBases: UnsafePointers, indices: Indices) {
+    self.init(
+      head: variableBufferBases.head.advanced(by: indices.head.perTypeID).pointee,
+      tail: Tail(variableBufferBases.tail, indices: indices.tail)
+    )
+  }
+}

--- a/Sources/SwiftFusion/Inference/ValuesArray.swift
+++ b/Sources/SwiftFusion/Inference/ValuesArray.swift
@@ -1,0 +1,41 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import PenguinStructures
+
+/// A heterogeneous array of values.
+///
+/// e.g. variable assignments, factor error vectors.
+///
+/// Note: This is just a temporary placeholder until we get the real heterogeneous array type. This
+/// one has many problems, such as reference semantics and non-growing storage.
+struct ValuesArray {
+  /// Dictionary from variable type to contiguous storage for that type.
+  var contiguousStorage: [ObjectIdentifier: AnyArrayStorage]
+}
+
+/// An identifier of a given abstract value with the value's type attached
+///
+/// - Parameter Value: the type of value this ID refers to.
+/// - Parameter PerTypeID: a type that, given `Value`, identifies a given
+///   logical value of that type.
+///
+/// Note: This is just a temporary placeholder until we get the real `TypedID` in penguin.
+public struct TypedID<Value, PerTypeID: Equatable> {
+  /// A specifier of which logical value of type `value` is being identified.
+  let perTypeID: PerTypeID
+
+  /// Creates an instance indicating the given logical value of type `Value`.
+  init(_ perTypeID: PerTypeID) { self.perTypeID = perTypeID }
+}

--- a/Tests/SwiftFusionTests/Inference/GenericFactorTests.swift
+++ b/Tests/SwiftFusionTests/Inference/GenericFactorTests.swift
@@ -1,0 +1,75 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import TensorFlow
+import XCTest
+
+import PenguinStructures
+@testable import SwiftFusion
+
+/// A factor that selects a pose prior using an integer input index.
+fileprivate struct DemoFactor<Pose: LieGroup>: GenericFactor {
+  typealias Variables = Tuple2<Int, Pose>
+
+  let edges: Variables.Indices
+
+  let priors: [Pose]
+
+  func error(_ variables: Variables) -> Double {
+    let (priorIndex, position) = (variables.head, variables.tail.head)
+    return priors[priorIndex].localCoordinate(position).squaredNorm
+  }
+}
+
+class GenericFactorTests: XCTestCase {
+  /// Tests errors in a simple factor graph.
+  func testErrors() {
+    // Set up 4 variables:
+    // - `intVar1` is an `Int` with value `0`.
+    // - `intVar2` is an `Int` with value `1`.
+    // - `poseVar1` is a `Pose2` with value `Pose2(1, 0, 0)`.
+    // - `poseVar2` is a `Pose2` with value `Pose2(0, 1, 1)`.
+
+    let intVariables = ArrayStorage<Int>.create(minimumCapacity: 2)
+    let intVar1 = TypedID<Int, Int>(intVariables.append(0)!)
+    let intVar2 = TypedID<Int, Int>(intVariables.append(1)!)
+
+    let poseVariables = ArrayStorage<Pose2>.create(minimumCapacity: 2)
+    let poseVar1 = TypedID<Pose2, Int>(poseVariables.append(Pose2(1, 0, 0))!)
+    let poseVar2 = TypedID<Pose2, Int>(poseVariables.append(Pose2(0, 1, 1))!)
+
+    let variableAssignments = ValuesArray(contiguousStorage: [
+      ObjectIdentifier(Int.self): intVariables,
+      ObjectIdentifier(Pose2.self): poseVariables
+    ])
+
+    // Set up 4 `DemoFactor`s, connected to each combination of `Int` and `Pose2` variables.
+
+    let priors = [Pose2(1, 0, 0), Pose2(0, 1, 1)]
+    let factors = FactorArrayStorage<DemoFactor<Pose2>>.create(minimumCapacity: 4)
+    _ = factors.append(DemoFactor(edges: Tuple2(intVar1, poseVar1), priors: priors))
+    _ = factors.append(DemoFactor(edges: Tuple2(intVar1, poseVar2), priors: priors))
+    _ = factors.append(DemoFactor(edges: Tuple2(intVar2, poseVar1), priors: priors))
+    _ = factors.append(DemoFactor(edges: Tuple2(intVar2, poseVar2), priors: priors))
+
+    // Check that the errors are what we expect.
+
+    let errors = factors.errors(variableAssignments)
+    XCTAssertEqual(errors[0], 0)
+    XCTAssertEqual(errors[1], Pose2(1, 0, 0).localCoordinate(Pose2(0, 1, 1)).squaredNorm)
+    XCTAssertEqual(errors[2], Pose2(1, 0, 0).localCoordinate(Pose2(0, 1, 1)).squaredNorm)
+    XCTAssertEqual(errors[3], 0)
+  }
+}


### PR DESCRIPTION
(This is a PR on top of https://github.com/borglab/SwiftFusion/pull/73).

Adds:
* a `Factor` protocol that lets you declare factors with arbitrary input types and an error function that computes an error based on the input
* `AnyFactorStorage` for type-erased storage of `Factor`s
* `AnyFactorStorage.errors`, which calculates errors for all factors in an `AnyFactorStorage`. (This works very efficiently, by doing pointer arithmetic into contiguous buffers of input values.)

Credit: Uses lots of ideas and code that @dabrahams shared with me.

There is a test demonstrating how to use it.

Note that this is missing all the sugar that will make it nicer to declare and use factors. I'll do that in subsequent PRs.