### PR TITLE
update generic factor graph to use ArrayBuffer

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/saeta/penguin.git",
         "state": {
           "branch": "marcrasi/arraybuffer_methods",
-          "revision": "3cbd6c7a418398c75a93ce7b5d578b4f61ed4643",
+          "revision": "b1a514b1f02487f797101c049e1e8bfc333f082e",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
         "package": "Penguin",
         "repositoryURL": "https://github.com/saeta/penguin.git",
         "state": {
-          "branch": "marcrasi/arraybuffer_methods",
-          "revision": "b1a514b1f02487f797101c049e1e8bfc333f082e",
+          "branch": "master",
+          "revision": "3081343f667134e6a7e43701c2c91e433567abea",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
         "package": "Penguin",
         "repositoryURL": "https://github.com/saeta/penguin.git",
         "state": {
-          "branch": "master",
-          "revision": "d2dabbaf5a432f81577a20a34bd0a59a0bda7a62",
+          "branch": "marcrasi/arraybuffer_methods",
+          "revision": "3cbd6c7a418398c75a93ce7b5d578b4f61ed4643",
           "version": null
         }
       },
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "223d62adc52d51669ae2ee19bdb8b7d9fd6fcd9c",
-          "version": "0.0.6"
+          "revision": "3d79b2b5a2e5af52c14e462044702ea7728f5770",
+          "version": "0.1.0"
         }
       },
       {
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/google/swift-benchmark.git",
         "state": {
           "branch": "master",
-          "revision": "a952f1d7deed2368805ac29f09da6a676dde8015",
+          "revision": "687068e9e7dae20a8c46e1e1a4d04c5873a7c373",
           "version": null
         }
       }

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     // Dependencies declare other packages that this package depends on.
     // .package(url: /* package url */, from: "1.0.0"),
     .package(url: "https://github.com/google/swift-benchmark.git", .branch("master")),
-    .package(url: "https://github.com/saeta/penguin.git", .branch("master")),
+    .package(url: "https://github.com/saeta/penguin.git", .branch("marcrasi/arraybuffer_methods")),
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     // Dependencies declare other packages that this package depends on.
     // .package(url: /* package url */, from: "1.0.0"),
     .package(url: "https://github.com/google/swift-benchmark.git", .branch("master")),
-    .package(url: "https://github.com/saeta/penguin.git", .branch("marcrasi/arraybuffer_methods")),
+    .package(url: "https://github.com/saeta/penguin.git", .branch("master")),
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/SwiftFusion/Inference/FactorsStorage.swift
+++ b/Sources/SwiftFusion/Inference/FactorsStorage.swift
@@ -29,6 +29,12 @@ class AnyFactorStorage: AnyArrayStorage {
   }
 }
 
+extension AnyArrayBuffer where Storage: AnyFactorStorage {
+  func errors(_ variableAssignments: ValuesArray) -> [Double] {
+    withStorage { s in s.errors(variableAssignments) }
+  }
+}
+
 /// Contiguous storage of homogeneous `Factor` values of statically unknown type.
 protocol AnyFactorStorageImplementation: AnyFactorStorage {
   /// Returns the errors of the factors given `variableAssignments`.
@@ -46,6 +52,12 @@ extension ArrayStorageImplementation where Element: GenericFactor {
         }
       }
     }
+  }
+}
+
+extension ArrayBuffer where Element: GenericFactor {
+  func errors(_ variableAssignments: ValuesArray) -> [Double] {
+    withStorage { s in s.errors_(variableAssignments) }
   }
 }
 

--- a/Sources/SwiftFusion/Inference/FactorsStorage.swift
+++ b/Sources/SwiftFusion/Inference/FactorsStorage.swift
@@ -31,7 +31,7 @@ class AnyFactorStorage: AnyArrayStorage {
 
 extension AnyArrayBuffer where Storage: AnyFactorStorage {
   func errors(_ variableAssignments: ValuesArray) -> [Double] {
-    withStorage { s in s.errors(variableAssignments) }
+    storage.errors(variableAssignments)
   }
 }
 
@@ -57,7 +57,7 @@ extension ArrayStorageImplementation where Element: GenericFactor {
 
 extension ArrayBuffer where Element: GenericFactor {
   func errors(_ variableAssignments: ValuesArray) -> [Double] {
-    withStorage { s in s.errors_(variableAssignments) }
+    storage.errors_(variableAssignments)
   }
 }
 

--- a/Sources/SwiftFusion/Inference/GenericFactor.swift
+++ b/Sources/SwiftFusion/Inference/GenericFactor.swift
@@ -80,9 +80,8 @@ extension Tuple: VariableTuple where Tail: VariableTuple {
       .contiguousStorage[ObjectIdentifier(Head.self)].unsafelyUnwrapped
       .withUnsafeRawPointerToElements { headBase in
         return Tail.withVariableBufferBaseUnsafePointers(variableAssignments) { tailBase in
-          return body(UnsafePointers(
-            head: headBase.assumingMemoryBound(to: Head.self),
-            tail: tailBase)
+          return body(
+            UnsafePointers(head: headBase.assumingMemoryBound(to: Head.self), tail: tailBase)
           )
         }
       }

--- a/Sources/SwiftFusion/Inference/GenericFactor.swift
+++ b/Sources/SwiftFusion/Inference/GenericFactor.swift
@@ -78,7 +78,7 @@ extension Tuple: VariableTuple where Tail: VariableTuple {
   ) -> R {
     return variableAssignments
       .contiguousStorage[ObjectIdentifier(Head.self)].unsafelyUnwrapped
-      .withUnsafeRawBaseAddress { headBase in
+      .withUnsafeRawPointerToElements { headBase in
         return Tail.withVariableBufferBaseUnsafePointers(variableAssignments) { tailBase in
           return body(UnsafePointers(
             head: headBase.assumingMemoryBound(to: Head.self),

--- a/Sources/SwiftFusion/Inference/GenericFactor.swift
+++ b/Sources/SwiftFusion/Inference/GenericFactor.swift
@@ -78,16 +78,12 @@ extension Tuple: VariableTuple where Tail: VariableTuple {
   ) -> R {
     return variableAssignments
       .contiguousStorage[ObjectIdentifier(Head.self)].unsafelyUnwrapped
-      .withUnsafeMutableRawBufferPointer { headBuffer in
-        let headBase: UnsafePointer<Head>
-        if let rawHeadBase = headBuffer.baseAddress {
-          headBase = UnsafePointer(rawHeadBase.assumingMemoryBound(to: Head.self))
-        } else {
-          // An invalid pointer is okay because we know it'll never get dereferenced.
-          headBase = UnsafePointer<Head>(bitPattern: -1).unsafelyUnwrapped
-        }
+      .withUnsafeRawBaseAddress { headBase in
         return Tail.withVariableBufferBaseUnsafePointers(variableAssignments) { tailBase in
-          return body(UnsafePointers(head: headBase, tail: tailBase))
+          return body(UnsafePointers(
+            head: headBase.assumingMemoryBound(to: Head.self),
+            tail: tailBase)
+          )
         }
       }
   }

--- a/Sources/SwiftFusion/Inference/ValuesArray.swift
+++ b/Sources/SwiftFusion/Inference/ValuesArray.swift
@@ -19,10 +19,11 @@ import PenguinStructures
 /// e.g. variable assignments, factor error vectors.
 ///
 /// Note: This is just a temporary placeholder until we get the real heterogeneous array type. This
-/// one has many problems, such as reference semantics and non-growing storage.
+/// one is missing nice abstractions that let clients interact with it without knowing about
+/// `contiguousStorage`.
 struct ValuesArray {
   /// Dictionary from variable type to contiguous storage for that type.
-  var contiguousStorage: [ObjectIdentifier: AnyArrayStorage]
+  var contiguousStorage: [ObjectIdentifier: AnyArrayBuffer<AnyArrayStorage>]
 }
 
 /// An identifier of a given abstract value with the value's type attached

--- a/Sources/SwiftFusion/Inference/ValuesStorage.swift
+++ b/Sources/SwiftFusion/Inference/ValuesStorage.swift
@@ -37,7 +37,8 @@ class AnyDifferentiableStorage: AnyArrayStorage {
 
 extension AnyArrayBuffer where Storage: AnyDifferentiableStorage {
   mutating func move(along directionsStart: UnsafeRawPointer) {
-    withMutableStorage { s in s.move(along: directionsStart) }
+    ensureUniqueStorage()
+    storage.move(along: directionsStart)
   }
 }
 
@@ -73,7 +74,8 @@ extension ArrayStorageImplementation where Element: Differentiable {
 
 extension ArrayBuffer where Element: Differentiable {
   mutating func move(along directionsStart: UnsafePointer<Element.TangentVector>) {
-    withMutableStorage { s in s.move(along: directionsStart) }
+    ensureUniqueStorage()
+    storage.move(along: directionsStart)
   }
 }
 
@@ -125,15 +127,17 @@ class AnyVectorStorage: AnyDifferentiableStorage {
 
 extension AnyArrayBuffer where Storage: AnyVectorStorage {
   mutating func add(_ otherStart: UnsafeRawPointer) {
-    withMutableStorage { s in s.add(otherStart) }
+    ensureUniqueStorage()
+    storage.add(otherStart)
   }
 
   mutating func scale(by scalar: Double) {
-    withMutableStorage { s in s.scale(by: scalar) }
+    ensureUniqueStorage()
+    storage.scale(by: scalar)
   }
 
   func dot(_ other: UnsafeRawPointer) -> Double {
-    withStorage { s in s.dot(other) }
+    storage.dot(other)
   }
 }
 
@@ -207,15 +211,17 @@ extension ArrayStorageImplementation where Element: EuclideanVector {
 
 extension ArrayBuffer where Element: EuclideanVector {
   mutating func add(_ otherStart: UnsafePointer<Element>) {
-    withMutableStorage { s in s.add(otherStart) }
+    ensureUniqueStorage()
+    storage.add(otherStart)
   }
 
   mutating func scale(by scalar: Double) {
-    withMutableStorage { s in s.scale_(by: scalar) }
+    ensureUniqueStorage()
+    storage.scale_(by: scalar)
   }
 
   func dot(_ otherStart: UnsafePointer<Element>) -> Double {
-    withStorage { s in s.dot(otherStart) }
+    storage.dot(otherStart)
   }
 }
 

--- a/Sources/SwiftFusion/Inference/ValuesStorage.swift
+++ b/Sources/SwiftFusion/Inference/ValuesStorage.swift
@@ -35,6 +35,12 @@ class AnyDifferentiableStorage: AnyArrayStorage {
   }
 }
 
+extension AnyArrayBuffer where Storage: AnyDifferentiableStorage {
+  mutating func move(along directionsStart: UnsafeRawPointer) {
+    withMutableStorage { s in s.move(along: directionsStart) }
+  }
+}
+
 /// Contiguous storage of homogeneous `Differentiable` values of statically unknown type.
 protocol AnyDifferentiableStorageImplementation: AnyDifferentiableStorage {
   /// Moves `self` along the vector starting at `directionsStart`.
@@ -62,6 +68,12 @@ extension ArrayStorageImplementation where Element: Differentiable {
   /// `Element.TangentVector`s where `Element` is the element type of `self`.
   func move_(along directionsStart: UnsafeRawPointer) {
     move(along: directionsStart.assumingMemoryBound(to: Element.TangentVector.self))
+  }
+}
+
+extension ArrayBuffer where Element: Differentiable {
+  mutating func move(along directionsStart: UnsafePointer<Element.TangentVector>) {
+    withMutableStorage { s in s.move(along: directionsStart) }
   }
 }
 
@@ -108,6 +120,20 @@ class AnyVectorStorage: AnyDifferentiableStorage {
   /// where `Element` is the element type of `self`.
   final func dot(_ other: UnsafeRawPointer) -> Double {
     vectorImplementation.dot_(other)
+  }
+}
+
+extension AnyArrayBuffer where Storage: AnyVectorStorage {
+  mutating func add(_ otherStart: UnsafeRawPointer) {
+    withMutableStorage { s in s.add(otherStart) }
+  }
+
+  mutating func scale(by scalar: Double) {
+    withMutableStorage { s in s.scale(by: scalar) }
+  }
+
+  func dot(_ other: UnsafeRawPointer) -> Double {
+    withStorage { s in s.dot(other) }
   }
 }
 
@@ -176,6 +202,20 @@ extension ArrayStorageImplementation where Element: EuclideanVector {
   /// Precondition: `otherStart` points to memory with at least `count` initialized `Element`s.
   func dot_(_ otherStart: UnsafeRawPointer) -> Double {
     return dot(otherStart.assumingMemoryBound(to: Element.self))
+  }
+}
+
+extension ArrayBuffer where Element: EuclideanVector {
+  mutating func add(_ otherStart: UnsafePointer<Element>) {
+    withMutableStorage { s in s.add(otherStart) }
+  }
+
+  mutating func scale(by scalar: Double) {
+    withMutableStorage { s in s.scale_(by: scalar) }
+  }
+
+  func dot(_ otherStart: UnsafePointer<Element>) -> Double {
+    withStorage { s in s.dot(otherStart) }
   }
 }
 

--- a/Tests/SwiftFusionTests/Inference/GenericFactorTests.swift
+++ b/Tests/SwiftFusionTests/Inference/GenericFactorTests.swift
@@ -63,27 +63,26 @@ class GenericFactorTests: XCTestCase {
 
     // Set up the initial guess.
 
-    let intVariables = ArrayStorage<Int>.create(minimumCapacity: 2)
-    let motionLabel1ID = TypedID<Int, Int>(intVariables.append(0)!)
-    let motionLabel2ID = TypedID<Int, Int>(intVariables.append(1)!)
+    var intVariables = ArrayBuffer<ArrayStorage<Int>>()
+    let motionLabel1ID = TypedID<Int, Int>(intVariables.append(0))
+    let motionLabel2ID = TypedID<Int, Int>(intVariables.append(1))
 
-    let poseVariables = ArrayStorage<Pose2>.create(minimumCapacity: 3)
-    let pose1ID = TypedID<Pose2, Int>(poseVariables.append(Pose2(0, 0, 0))!)
-    let pose2ID = TypedID<Pose2, Int>(poseVariables.append(Pose2(1, 1, 0))!)
-    let pose3ID = TypedID<Pose2, Int>(poseVariables.append(Pose2(1, 1, 0.9))!)
+    var poseVariables = ArrayBuffer<ArrayStorage<Pose2>>()
+    let pose1ID = TypedID<Pose2, Int>(poseVariables.append(Pose2(0, 0, 0)))
+    let pose2ID = TypedID<Pose2, Int>(poseVariables.append(Pose2(1, 1, 0)))
+    let pose3ID = TypedID<Pose2, Int>(poseVariables.append(Pose2(1, 1, 0.9)))
 
     let variableAssignments = ValuesArray(contiguousStorage: [
-      ObjectIdentifier(Int.self): intVariables,
-      ObjectIdentifier(Pose2.self): poseVariables
+      ObjectIdentifier(Int.self): AnyArrayBuffer(intVariables),
+      ObjectIdentifier(Pose2.self): AnyArrayBuffer(poseVariables)
     ])
 
     // Set up the factor graph.
 
-    let priorFactors = FactorArrayStorage<PriorFactor<Pose2>>.create(minimumCapacity: 1)
+    var priorFactors = ArrayBuffer<FactorArrayStorage<PriorFactor<Pose2>>>()
     _ = priorFactors.append(PriorFactor(edges: Tuple1(pose1ID), prior: Pose2(0, 0, 0)))
 
-    let motionFactors =
-      FactorArrayStorage<SwitchingMotionModelFactor<Pose2>>.create(minimumCapacity: 2)
+    var motionFactors = ArrayBuffer<FactorArrayStorage<SwitchingMotionModelFactor<Pose2>>>()
     _ = motionFactors.append(SwitchingMotionModelFactor(
       edges: Tuple3(motionLabel1ID, pose1ID, pose2ID),
       motions: [Pose2(1, 1, 0), Pose2(0, 0, 1)]

--- a/Tests/SwiftFusionTests/Inference/ValuesStorageTests.swift
+++ b/Tests/SwiftFusionTests/Inference/ValuesStorageTests.swift
@@ -19,11 +19,16 @@ import XCTest
 import PenguinStructures
 @testable import SwiftFusion
 
+fileprivate typealias VectorArray<Element: EuclideanVector> =
+  ArrayBuffer<VectorArrayStorage<Element>>
+fileprivate typealias DifferentiableArray<Element: Differentiable> =
+  ArrayBuffer<DifferentiableArrayStorage<Element>>
+
 class ValuesStorageTests: XCTestCase {
   
   func testDifferentiableMove() {
-    var values = ArrayBuffer<DifferentiableArrayStorage>((0..<5).map { _ in Pose2(0, 0, 0) })
-    let directions = ArrayBuffer<VectorArrayStorage>((0..<5).map { _ in Vector3(1, 0, 0) })
+    var values = DifferentiableArray((0..<5).map { _ in Pose2(0, 0, 0) })
+    let directions = VectorArray((0..<5).map { _ in Vector3(1, 0, 0) })
     values.move(along: directions)
     for i in 0..<5 {
       XCTAssertEqual(values[i], Pose2(0, 0, 1))
@@ -31,8 +36,8 @@ class ValuesStorageTests: XCTestCase {
   }
   
   func testVectorMove() {
-    var values = ArrayBuffer<VectorArrayStorage>((0..<5).map { _ in Vector3(1, 2, 3) })
-    let directions = ArrayBuffer<VectorArrayStorage>((0..<5).map { _ in Vector3(10, 20, 30) })
+    var values = VectorArray((0..<5).map { _ in Vector3(1, 2, 3) })
+    let directions = VectorArray((0..<5).map { _ in Vector3(10, 20, 30) })
     values.move(along: directions)
     for i in 0..<5 {
       XCTAssertEqual(values[i], Vector3(11, 22, 33))
@@ -40,8 +45,8 @@ class ValuesStorageTests: XCTestCase {
   }
 
   func testVectorAdd() {
-    var a = ArrayBuffer<VectorArrayStorage>((0..<5).map { _ in Vector3(1, 2, 3) })
-    let b = ArrayBuffer<VectorArrayStorage>((0..<5).map { _ in Vector3(10, 20, 30) })
+    var a = VectorArray((0..<5).map { _ in Vector3(1, 2, 3) })
+    let b = VectorArray((0..<5).map { _ in Vector3(10, 20, 30) })
     a.add(b)
     for i in 0..<5 {
       XCTAssertEqual(a[i], Vector3(11, 22, 33))
@@ -49,7 +54,7 @@ class ValuesStorageTests: XCTestCase {
   }
 
   func testVectorScale() {
-    var a = ArrayBuffer<VectorArrayStorage>((0..<5).map { _ in Vector3(1, 2, 3) })
+    var a = VectorArray((0..<5).map { _ in Vector3(1, 2, 3) })
     a.scale(by: 10)
     for i in 0..<5 {
       XCTAssertEqual(a[i], Vector3(10, 20, 30))
@@ -57,8 +62,8 @@ class ValuesStorageTests: XCTestCase {
   }
 
   func testVectorDot() {
-    let a = ArrayBuffer<VectorArrayStorage>((0..<5).map { _ in Vector3(1, 2, 3) })
-    let b = ArrayBuffer<VectorArrayStorage>((0..<5).map { _ in Vector3(10, 20, 30) })
+    let a = VectorArray((0..<5).map { _ in Vector3(1, 2, 3) })
+    let b = VectorArray((0..<5).map { _ in Vector3(10, 20, 30) })
     XCTAssertEqual(a.dot(b), 5 * (Double(1 * 10 + 2 * 20 + 3 * 30)))
   }
 }

--- a/Tests/SwiftFusionTests/Inference/ValuesStorageTests.swift
+++ b/Tests/SwiftFusionTests/Inference/ValuesStorageTests.swift
@@ -19,30 +19,13 @@ import XCTest
 import PenguinStructures
 @testable import SwiftFusion
 
-/// Test helpers.
-extension ArrayStorageImplementation {
-  /// Creates an array with `count` copies of `element`.
-  static func create(repeating element: Element, count: Int) -> Self {
-    let r = Self.create(minimumCapacity: count)
-    for _ in 0..<count { _ = r.append(element) }
-    return r
-  }
-  
-  /// Returns the element at `index`.
-  subscript(index: Int) -> Element {
-    return withUnsafeMutableBufferPointer { buffer in
-      return buffer[index]
-    }
-  }
-}
-
 class ValuesStorageTests: XCTestCase {
   
   func testDifferentiableMove() {
-    let values = DifferentiableArrayStorage.create(repeating: Pose2(0, 0, 0), count: 5)
-    let directions = VectorArrayStorage.create(repeating: Vector3(1, 0, 0), count: 5)
-    directions.withUnsafeMutableRawBufferPointer { directionBuffer in
-      values.move(along: UnsafeRawPointer(directionBuffer.baseAddress!))
+    var values = ArrayBuffer<DifferentiableArrayStorage>((0..<5).map { _ in Pose2(0, 0, 0) })
+    let directions = ArrayBuffer<VectorArrayStorage>((0..<5).map { _ in Vector3(1, 0, 0) })
+    directions.withUnsafeBufferPointer { directionsBuffer in
+      values.move(along: directionsBuffer.baseAddress!)
     }
     for i in 0..<5 {
       XCTAssertEqual(values[i], Pose2(0, 0, 1))
@@ -50,42 +33,41 @@ class ValuesStorageTests: XCTestCase {
   }
   
   func testVectorMove() {
-    let values = VectorArrayStorage.create(repeating: Vector3(1, 2, 3), count: 5)
-    let directions = VectorArrayStorage.create(repeating: Vector3(10, 20, 30), count: 5)
-    directions.withUnsafeMutableRawBufferPointer { directionBuffer in
-      values.move(along: UnsafeRawPointer(directionBuffer.baseAddress!))
+    var values = ArrayBuffer<VectorArrayStorage>((0..<5).map { _ in Vector3(1, 2, 3) })
+    let directions = ArrayBuffer<VectorArrayStorage>((0..<5).map { _ in Vector3(10, 20, 30) })
+    directions.withUnsafeBufferPointer { directionsBuffer in
+      values.move(along: directionsBuffer.baseAddress!)
     }
     for i in 0..<5 {
       XCTAssertEqual(values[i], Vector3(11, 22, 33))
     }
   }
-  
+
   func testVectorAdd() {
-    let a = VectorArrayStorage.create(repeating: Vector3(1, 2, 3), count: 5)
-    let b = VectorArrayStorage.create(repeating: Vector3(10, 20, 30), count: 5)
-    b.withUnsafeMutableBufferPointer { bBuffer in
-      a.add(UnsafeRawPointer(bBuffer.baseAddress!))
+    var a = ArrayBuffer<VectorArrayStorage>((0..<5).map { _ in Vector3(1, 2, 3) })
+    let b = ArrayBuffer<VectorArrayStorage>((0..<5).map { _ in Vector3(10, 20, 30) })
+    b.withUnsafeBufferPointer { bBuffer in
+      a.add(bBuffer.baseAddress!)
     }
     for i in 0..<5 {
       XCTAssertEqual(a[i], Vector3(11, 22, 33))
     }
   }
-  
+
   func testVectorScale() {
-    let a = VectorArrayStorage.create(repeating: Vector3(1, 2, 3), count: 5)
+    var a = ArrayBuffer<VectorArrayStorage>((0..<5).map { _ in Vector3(1, 2, 3) })
     a.scale(by: 10)
     for i in 0..<5 {
       XCTAssertEqual(a[i], Vector3(10, 20, 30))
     }
   }
-  
+
   func testVectorDot() {
-    let a = VectorArrayStorage.create(repeating: Vector3(1, 2, 3), count: 5)
-    let b = VectorArrayStorage.create(repeating: Vector3(10, 20, 30), count: 5)
-    let dot = b.withUnsafeMutableBufferPointer { bBuffer in
-      return a.dot(UnsafeRawPointer(bBuffer.baseAddress!))
+    let a = ArrayBuffer<VectorArrayStorage>((0..<5).map { _ in Vector3(1, 2, 3) })
+    let b = ArrayBuffer<VectorArrayStorage>((0..<5).map { _ in Vector3(10, 20, 30) })
+    let dot = b.withUnsafeBufferPointer { bBuffer in
+      return a.dot(bBuffer.baseAddress!)
     }
     XCTAssertEqual(dot, 5 * (Double(1 * 10 + 2 * 20 + 3 * 30)))
   }
-  
 }

--- a/Tests/SwiftFusionTests/Inference/ValuesStorageTests.swift
+++ b/Tests/SwiftFusionTests/Inference/ValuesStorageTests.swift
@@ -24,9 +24,7 @@ class ValuesStorageTests: XCTestCase {
   func testDifferentiableMove() {
     var values = ArrayBuffer<DifferentiableArrayStorage>((0..<5).map { _ in Pose2(0, 0, 0) })
     let directions = ArrayBuffer<VectorArrayStorage>((0..<5).map { _ in Vector3(1, 0, 0) })
-    directions.withUnsafeBufferPointer { directionsBuffer in
-      values.move(along: directionsBuffer.baseAddress!)
-    }
+    values.move(along: directions)
     for i in 0..<5 {
       XCTAssertEqual(values[i], Pose2(0, 0, 1))
     }
@@ -35,9 +33,7 @@ class ValuesStorageTests: XCTestCase {
   func testVectorMove() {
     var values = ArrayBuffer<VectorArrayStorage>((0..<5).map { _ in Vector3(1, 2, 3) })
     let directions = ArrayBuffer<VectorArrayStorage>((0..<5).map { _ in Vector3(10, 20, 30) })
-    directions.withUnsafeBufferPointer { directionsBuffer in
-      values.move(along: directionsBuffer.baseAddress!)
-    }
+    values.move(along: directions)
     for i in 0..<5 {
       XCTAssertEqual(values[i], Vector3(11, 22, 33))
     }
@@ -46,9 +42,7 @@ class ValuesStorageTests: XCTestCase {
   func testVectorAdd() {
     var a = ArrayBuffer<VectorArrayStorage>((0..<5).map { _ in Vector3(1, 2, 3) })
     let b = ArrayBuffer<VectorArrayStorage>((0..<5).map { _ in Vector3(10, 20, 30) })
-    b.withUnsafeBufferPointer { bBuffer in
-      a.add(bBuffer.baseAddress!)
-    }
+    a.add(b)
     for i in 0..<5 {
       XCTAssertEqual(a[i], Vector3(11, 22, 33))
     }
@@ -65,9 +59,6 @@ class ValuesStorageTests: XCTestCase {
   func testVectorDot() {
     let a = ArrayBuffer<VectorArrayStorage>((0..<5).map { _ in Vector3(1, 2, 3) })
     let b = ArrayBuffer<VectorArrayStorage>((0..<5).map { _ in Vector3(10, 20, 30) })
-    let dot = b.withUnsafeBufferPointer { bBuffer in
-      return a.dot(bBuffer.baseAddress!)
-    }
-    XCTAssertEqual(dot, 5 * (Double(1 * 10 + 2 * 20 + 3 * 30)))
+    XCTAssertEqual(a.dot(b), 5 * (Double(1 * 10 + 2 * 20 + 3 * 30)))
   }
 }


### PR DESCRIPTION
`ArrayBuffer` is the value-semantic container for `ArrayStorage`, and we should be using `ArrayBuffer` everywhere. This PR updates everything to use `ArrayBuffer`.

This depends on https://github.com/saeta/penguin/pull/70.