### PR TITLE
Pose2SLAM benchmark with GenericFactorGraph

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
         "package": "Penguin",
         "repositoryURL": "https://github.com/saeta/penguin.git",
         "state": {
-          "branch": "master",
-          "revision": "3081343f667134e6a7e43701c2c91e433567abea",
+          "branch": "marcrasi/arraybuffer_cast",
+          "revision": "fb901e91cabfdb8ff409020aea928ff4452ed3ab",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     // Dependencies declare other packages that this package depends on.
     // .package(url: /* package url */, from: "1.0.0"),
     .package(url: "https://github.com/google/swift-benchmark.git", .branch("master")),
-    .package(url: "https://github.com/saeta/penguin.git", .branch("master")),
+    .package(url: "https://github.com/saeta/penguin.git", .branch("marcrasi/arraybuffer_cast")),
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Benchmarks/Pose2SLAM.swift
+++ b/Sources/Benchmarks/Pose2SLAM.swift
@@ -44,6 +44,17 @@ let pose2SLAM = BenchmarkSuite(name: "Pose2SLAM") { suite in
     }
 //    check(intelDataset.graph.error(val), near: 35.59, accuracy: 1e-2)
   }
+
+  // Uses `GenericFactorGraph` on the Intel dataset.
+  // The solvers are configured to run for a constant number of steps.
+  // The nonlinear solver is 10 iterations of Gauss-Newton.
+  // The linear solver is 500 iterations of CGLS.
+  suite.benchmark(
+    "GenericFactorGraph, Intel, 10 Gauss-Newton steps, 500 CGLS steps",
+    settings: .iterations(1)
+  ) {
+    runGenericFactorGraphBenchmark()
+  }
 }
 
 func check(_ actual: Double, near expected: Double, accuracy: Double) {

--- a/Sources/Benchmarks/Pose2SLAM.swift
+++ b/Sources/Benchmarks/Pose2SLAM.swift
@@ -66,7 +66,7 @@ let pose2SLAM = BenchmarkSuite(name: "Pose2SLAM") { suite in
 
     for _ in 0..<10 {
       let linearized = graph.linearized(at: x)
-      var dx = x.zeroTangent
+      var dx = x.linearizedZero
       var optimizer = GenericCGLS(precision: 0, max_iteration: 500)
       optimizer.optimize(gfg: linearized, initial: &dx)
       x.move(along: (-1) * dx)

--- a/Sources/SwiftFusion/Datasets/G2OReader.swift
+++ b/Sources/SwiftFusion/Datasets/G2OReader.swift
@@ -46,6 +46,28 @@ public enum G2OReader {
     }
   }
 
+  /// A G2O problem expressed as a `GenericFactorGraph`.
+  public struct G2OGenericFactorGraph {
+    /// The initial guess.
+    public var initialGuess = VariableAssignments()
+
+    /// The factor graph representing the measurements.
+    public var graph = GenericFactorGraph()
+
+    /// Creates a problem from the given 2D file.
+    public init(g2oFile2D: URL) throws {
+      try G2OReader.read2D(file: g2oFile2D) { entry in
+        switch entry {
+        case .initialGuess(index: let id, pose: let guess):
+          let typedID = initialGuess.store(guess)
+          assert(typedID.perTypeID == id)
+        case .measurement(frameIndex: let id1, measuredIndex: let id2, pose: let difference):
+          graph.store(GenericBetweenFactor2(TypedID(id1), TypedID(id2), difference))
+        }
+      }
+    }
+  }
+
   /// An entry in a G2O file.
   public enum Entry<Pose> {
     /// An initial guess that vertex `index` has pose `pose`.

--- a/Sources/SwiftFusion/Inference/FactorsStorage.swift
+++ b/Sources/SwiftFusion/Inference/FactorsStorage.swift
@@ -275,6 +275,8 @@ extension ArrayStorageImplementation where Element: GenericGaussianFactor {
   }
 
   /// Returns the results of the factors' linear functions at the given point.
+  @_specialize(where Self == GaussianFactorArrayStorage<JacobianFactor3x3>)
+  @_specialize(where Self == GaussianFactorArrayStorage<JacobianFactor3x3_2>)
   func linearForward_(_ x: VariableAssignments) -> AnyArrayBuffer<AnyVectorStorage> {
     return AnyArrayBuffer(linearForward(x))
   }
@@ -284,6 +286,8 @@ extension ArrayStorageImplementation where Element: GenericGaussianFactor {
   ///
   /// Precondition: `errorVectorsStart` points to memory with at least `count` initialized
   /// `Element.ErrorVector`s.
+  @_specialize(where Self == GaussianFactorArrayStorage<JacobianFactor3x3>)
+  @_specialize(where Self == GaussianFactorArrayStorage<JacobianFactor3x3_2>)
   func linearAdjoint_(
     _ errorVectorsStart: UnsafeRawPointer,
     into result: inout VariableAssignments

--- a/Sources/SwiftFusion/Inference/FactorsStorage.swift
+++ b/Sources/SwiftFusion/Inference/FactorsStorage.swift
@@ -275,7 +275,7 @@ extension ArrayStorageImplementation where Element: GenericGaussianFactor {
   }
 
   /// Returns the results of the factors' linear functions at the given point.
-  @_specialize(where Self == GaussianFactorArrayStorage<JacobianFactor3x3>)
+  @_specialize(where Self == GaussianFactorArrayStorage<JacobianFactor3x3_1>)
   @_specialize(where Self == GaussianFactorArrayStorage<JacobianFactor3x3_2>)
   func linearForward_(_ x: VariableAssignments) -> AnyArrayBuffer<AnyVectorStorage> {
     return AnyArrayBuffer(linearForward(x))
@@ -286,7 +286,7 @@ extension ArrayStorageImplementation where Element: GenericGaussianFactor {
   ///
   /// Precondition: `errorVectorsStart` points to memory with at least `count` initialized
   /// `Element.ErrorVector`s.
-  @_specialize(where Self == GaussianFactorArrayStorage<JacobianFactor3x3>)
+  @_specialize(where Self == GaussianFactorArrayStorage<JacobianFactor3x3_1>)
   @_specialize(where Self == GaussianFactorArrayStorage<JacobianFactor3x3_2>)
   func linearAdjoint_(
     _ errorVectorsStart: UnsafeRawPointer,

--- a/Sources/SwiftFusion/Inference/GenericBetweenFactor.swift
+++ b/Sources/SwiftFusion/Inference/GenericBetweenFactor.swift
@@ -1,0 +1,55 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import PenguinStructures
+
+/// A factor that specifies a difference between two poses.
+///
+/// Note: This is currently named with a "Generic" prefix to avoid clashing with the other factors.
+/// When we completely replace the existing factors with the "Generic" ones, we should remove this
+/// prefix.
+struct GenericBetweenFactor<Pose: LieGroup, JacobianRows: FixedSizeArray>:
+  GenericLinearizableFactor
+  where JacobianRows.Element == Tuple2<Pose.TangentVector, Pose.TangentVector>
+{
+  typealias Variables = Tuple2<Pose, Pose>
+
+  let edges: Variables.Indices
+
+  let difference: Pose
+
+  typealias ErrorVector = Pose.TangentVector
+  func errorVector(_ start: Pose, _ end: Pose) -> ErrorVector {
+    let actualMotion = between(start, end)
+    return difference.localCoordinate(actualMotion)
+  }
+
+  // Note: All the remaining code in this factor is boilerplate that we can eventually eliminate
+  // with sugar.
+  func error(at x: Variables) -> Double {
+    return errorVector(at: x).squaredNorm
+  }
+
+  func errorVector(at x: Variables) -> Pose.TangentVector {
+    return errorVector(x.head, x.tail.head)
+  }
+
+  typealias Linearized = GenericJacobianFactor<JacobianRows, ErrorVector>
+  func linearized(at x: Variables) -> Linearized {
+    Linearized(linearizing: errorVector, at: x, edges: edges)
+  }
+}
+
+typealias GenericBetweenFactor2 =
+  GenericBetweenFactor<Pose2, Array3<Tuple2<Vector3, Vector3>>>

--- a/Sources/SwiftFusion/Inference/GenericBetweenFactor.swift
+++ b/Sources/SwiftFusion/Inference/GenericBetweenFactor.swift
@@ -41,6 +41,7 @@ public struct GenericBetweenFactor<Pose: LieGroup, JacobianRows: FixedSizeArray>
 
   // Note: All the remaining code in this factor is boilerplate that we can eventually eliminate
   // with sugar.
+  
   public func error(at x: Variables) -> Double {
     return errorVector(at: x).squaredNorm
   }

--- a/Sources/SwiftFusion/Inference/GenericBetweenFactor.swift
+++ b/Sources/SwiftFusion/Inference/GenericBetweenFactor.swift
@@ -19,37 +19,41 @@ import PenguinStructures
 /// Note: This is currently named with a "Generic" prefix to avoid clashing with the other factors.
 /// When we completely replace the existing factors with the "Generic" ones, we should remove this
 /// prefix.
-struct GenericBetweenFactor<Pose: LieGroup, JacobianRows: FixedSizeArray>:
+public struct GenericBetweenFactor<Pose: LieGroup, JacobianRows: FixedSizeArray>:
   GenericLinearizableFactor
   where JacobianRows.Element == Tuple2<Pose.TangentVector, Pose.TangentVector>
 {
-  typealias Variables = Tuple2<Pose, Pose>
+  public typealias Variables = Tuple2<Pose, Pose>
 
-  let edges: Variables.Indices
+  public let edges: Variables.Indices
+  public let difference: Pose
 
-  let difference: Pose
+  public init(_ startId: TypedID<Pose, Int>, _ endId: TypedID<Pose, Int>, _ difference: Pose) {
+    self.edges = Tuple2(startId, endId)
+    self.difference = difference
+  }
 
-  typealias ErrorVector = Pose.TangentVector
-  func errorVector(_ start: Pose, _ end: Pose) -> ErrorVector {
+  public typealias ErrorVector = Pose.TangentVector
+  public func errorVector(_ start: Pose, _ end: Pose) -> ErrorVector {
     let actualMotion = between(start, end)
     return difference.localCoordinate(actualMotion)
   }
 
   // Note: All the remaining code in this factor is boilerplate that we can eventually eliminate
   // with sugar.
-  func error(at x: Variables) -> Double {
+  public func error(at x: Variables) -> Double {
     return errorVector(at: x).squaredNorm
   }
 
-  func errorVector(at x: Variables) -> Pose.TangentVector {
+  public func errorVector(at x: Variables) -> Pose.TangentVector {
     return errorVector(x.head, x.tail.head)
   }
 
-  typealias Linearized = GenericJacobianFactor<JacobianRows, ErrorVector>
-  func linearized(at x: Variables) -> Linearized {
+  public typealias Linearized = GenericJacobianFactor<JacobianRows, ErrorVector>
+  public func linearized(at x: Variables) -> Linearized {
     Linearized(linearizing: errorVector, at: x, edges: edges)
   }
 }
 
-typealias GenericBetweenFactor2 =
+public typealias GenericBetweenFactor2 =
   GenericBetweenFactor<Pose2, Array3<Tuple2<Vector3, Vector3>>>

--- a/Sources/SwiftFusion/Inference/GenericFactor.swift
+++ b/Sources/SwiftFusion/Inference/GenericFactor.swift
@@ -18,7 +18,7 @@ import PenguinStructures
 ///
 /// Note: This is currently named `GenericFactor` to avoid clashing with the other `Factor`
 /// protocol. When we completely replace `Factor`, we should rename this one to `Factor`.
-protocol GenericFactor {
+public protocol GenericFactor {
   /// A tuple of the variable types of variables adjacent to this factor.
   associatedtype Variables: VariableTuple
 
@@ -34,7 +34,7 @@ protocol GenericFactor {
 /// Note: This is currently named with a "Generic" prefix to avoid clashing with the other factors.
 /// When we completely replace the existing factors with the "Generic" ones, we should remove this
 /// prefix.
-protocol GenericLinearizableFactor: GenericFactor {
+public protocol GenericLinearizableFactor: GenericFactor {
   /// The type of the error vector.
   // TODO: Add a description of what an error vector is.
   associatedtype ErrorVector: EuclideanVector
@@ -55,7 +55,7 @@ protocol GenericLinearizableFactor: GenericFactor {
 /// Note: This is currently named with a "Generic" prefix to avoid clashing with the other factors.
 /// When we completely replace the existing factors with the "Generic" ones, we should remove this
 /// prefix.
-protocol GenericGaussianFactor: GenericLinearizableFactor where Variables: EuclideanVector {
+public protocol GenericGaussianFactor: GenericLinearizableFactor where Variables: EuclideanVector {
   /// Returns the result of the linear function at the given point.
   func linearForward(_ x: Variables) -> ErrorVector
 
@@ -67,7 +67,7 @@ protocol GenericGaussianFactor: GenericLinearizableFactor where Variables: Eucli
 // MARK: - `VariableTuple`.
 
 /// Collections of variable types suitable for a factor.
-protocol VariableTuple: TupleProtocol where Tail: VariableTuple {
+public protocol VariableTuple: TupleProtocol where Tail: VariableTuple {
   /// A tuple of `UnsafePointer`s to the types of the variables adjacent to a factor.
   associatedtype UnsafePointers: TupleProtocol
 
@@ -126,36 +126,39 @@ extension VariableTuple {
 }
 
 extension Empty: VariableTuple {
-  typealias UnsafePointers = Self
-  typealias UnsafeMutablePointers = Self
-  typealias Indices = Self
+  public typealias UnsafePointers = Self
+  public typealias UnsafeMutablePointers = Self
+  public typealias Indices = Self
 
-  static func withVariableBufferBaseUnsafePointers<R>(
+  public static func withVariableBufferBaseUnsafePointers<R>(
     _ variableAssignments: VariableAssignments,
     _ body: (UnsafePointers) -> R
   ) -> R {
     return body(Empty())
   }
 
-  static func ensureUniqueStorage(_ variableAssignments: inout VariableAssignments) {}
+  public static func ensureUniqueStorage(_ variableAssignments: inout VariableAssignments) {}
 
-  static func unsafeMutablePointers(mutating pointers: UnsafePointers) -> UnsafeMutablePointers {
+  public static func unsafeMutablePointers(mutating pointers: UnsafePointers)
+    -> UnsafeMutablePointers
+  {
     Self()
   }
 
-  init(_ variableBufferBases: UnsafeMutablePointers, indices: Indices) {
+  public init(_ variableBufferBases: UnsafeMutablePointers, indices: Indices) {
     self.init()
   }
 
-  func store(into variableBufferBases: UnsafeMutablePointers, indices: Indices) {}
+  public func store(into variableBufferBases: UnsafeMutablePointers, indices: Indices) {}
 }
 
 extension Tuple: VariableTuple where Tail: VariableTuple {
-  typealias UnsafePointers = Tuple<UnsafePointer<Head>, Tail.UnsafePointers>
-  typealias UnsafeMutablePointers = Tuple<UnsafeMutablePointer<Head>, Tail.UnsafeMutablePointers>
-  typealias Indices = Tuple<TypedID<Head, Int>, Tail.Indices>
+  public typealias UnsafePointers = Tuple<UnsafePointer<Head>, Tail.UnsafePointers>
+  public typealias UnsafeMutablePointers =
+    Tuple<UnsafeMutablePointer<Head>, Tail.UnsafeMutablePointers>
+  public typealias Indices = Tuple<TypedID<Head, Int>, Tail.Indices>
 
-  static func withVariableBufferBaseUnsafePointers<R>(
+  public static func withVariableBufferBaseUnsafePointers<R>(
     _ variableAssignments: VariableAssignments,
     _ body: (UnsafePointers) -> R
   ) -> R {
@@ -170,26 +173,28 @@ extension Tuple: VariableTuple where Tail: VariableTuple {
       }
   }
 
-  static func ensureUniqueStorage(_ variableAssignments: inout VariableAssignments) {
+  public static func ensureUniqueStorage(_ variableAssignments: inout VariableAssignments) {
     variableAssignments.contiguousStorage[ObjectIdentifier(Head.self)]!.ensureUniqueStorage()
     Tail.ensureUniqueStorage(&variableAssignments)
   }
 
-  static func unsafeMutablePointers(mutating pointers: UnsafePointers) -> UnsafeMutablePointers {
+  public static func unsafeMutablePointers(mutating pointers: UnsafePointers)
+    -> UnsafeMutablePointers
+  {
     return UnsafeMutablePointers(
       head: UnsafeMutablePointer(mutating: pointers.head),
       tail: Tail.unsafeMutablePointers(mutating: pointers.tail)
     )
   }
 
-  init(_ variableBufferBases: UnsafeMutablePointers, indices: Indices) {
+  public init(_ variableBufferBases: UnsafeMutablePointers, indices: Indices) {
     self.init(
       head: variableBufferBases.head.advanced(by: indices.head.perTypeID).pointee,
       tail: Tail(variableBufferBases.tail, indices: indices.tail)
     )
   }
 
-  func store(into variableBufferBases: UnsafeMutablePointers, indices: Indices) {
+  public func store(into variableBufferBases: UnsafeMutablePointers, indices: Indices) {
     variableBufferBases.head.advanced(by: indices.head.perTypeID)
       .assign(repeating: self.head, count: 1)
     self.tail.store(into: variableBufferBases.tail, indices: indices.tail)

--- a/Sources/SwiftFusion/Inference/GenericFactor.swift
+++ b/Sources/SwiftFusion/Inference/GenericFactor.swift
@@ -201,14 +201,19 @@ extension Tuple: VariableTuple where Tail: VariableTuple {
   }
 }
 
+/// Tuple of differentiable variable types suitable for a factor.
 protocol DifferentiableVariableTuple: VariableTuple {
+  /// A tuple of `TypedID`s referring to variables adjacent to a factor.
   associatedtype TangentIndices: TupleProtocol
-  static func tangentIndices(_ indices: Indices) -> TangentIndices
+
+  /// Returns the indices of the linearized variables corresponding to `indices` in the linearized
+  /// factor graph.
+  static func linearized(_ indices: Indices) -> TangentIndices
 }
 
 extension Empty: DifferentiableVariableTuple {
   typealias TangentIndices = Self
-  static func tangentIndices(_ indices: Indices) -> TangentIndices {
+  static func linearized(_ indices: Indices) -> TangentIndices {
     indices
   }
 }
@@ -216,10 +221,10 @@ extension Empty: DifferentiableVariableTuple {
 extension Tuple: DifferentiableVariableTuple
 where Head: Differentiable, Tail: DifferentiableVariableTuple {
   typealias TangentIndices = Tuple<TypedID<Head.TangentVector, Int>, Tail.TangentIndices>
-  static func tangentIndices(_ indices: Indices) -> TangentIndices {
+  static func linearized(_ indices: Indices) -> TangentIndices {
     TangentIndices(
       head: TypedID<Head.TangentVector, Int>(indices.head.perTypeID),
-      tail: Tail.tangentIndices(indices.tail)
+      tail: Tail.linearized(indices.tail)
     )
   }
 }

--- a/Sources/SwiftFusion/Inference/GenericFactorGraph.swift
+++ b/Sources/SwiftFusion/Inference/GenericFactorGraph.swift
@@ -1,0 +1,105 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import PenguinStructures
+
+/// A factor graph.
+///
+/// Note: This is currently named with a "Generic" prefix to avoid clashing with the other factors.
+/// When we completely replace the existing factors with the "Generic" ones, we should remove this
+/// prefix.
+public struct GenericFactorGraph {
+  /// Dictionary from variable type to contiguous storage for that type.
+  var contiguousStorage: [ObjectIdentifier: AnyArrayBuffer<AnyFactorStorage>] = [:]
+
+  /// Creates an empty instance.
+  public init() {}
+
+  internal init(contiguousStorage: [ObjectIdentifier: AnyArrayBuffer<AnyFactorStorage>]) {
+    self.contiguousStorage = contiguousStorage
+  }
+
+  /// Stores `factor` in the graph.
+  mutating func store<T: GenericFactor>(_ factor: T) {
+    _ = contiguousStorage[
+      ObjectIdentifier(T.self),
+      default: AnyArrayBuffer(ArrayBuffer<FactorArrayStorage<T>>())
+    ].append(factor)
+  }
+
+  /// Stores `factor` in the graph.
+  mutating func store<T: GenericLinearizableFactor>(_ factor: T) {
+    _ = contiguousStorage[
+      ObjectIdentifier(T.self),
+      default: AnyArrayBuffer(ArrayBuffer<LinearizableFactorArrayStorage<T>>())
+    ].append(factor)
+  }
+
+  /// Stores `factor` in the graph.
+  mutating func store<T: GenericGaussianFactor>(_ factor: T) {
+    _ = contiguousStorage[
+      ObjectIdentifier(T.self),
+      default: AnyArrayBuffer(ArrayBuffer<GaussianFactorArrayStorage<T>>())
+    ].append(factor)
+  }
+
+  func error(at x: VariableAssignments) -> Double {
+    return contiguousStorage.values.lazy.map { $0.errors(at: x).reduce(0, +) }.reduce(0, +)
+  }
+
+  func linearized(at x: VariableAssignments) -> GenericGaussianFactorGraph {
+    return GenericGaussianFactorGraph(
+      inputZero: x.zeroTangent,
+      contiguousStorage: contiguousStorage.compactMapValues { factors in
+        factors.cast(to: AnyLinearizableFactorStorage.self)?.linearized(at: x)
+      }
+    )
+  }
+}
+
+/// Benchmarks `GenericFactorGraph` on the Intel dataset.
+///
+/// The solvers are configured to run for a constant number of steps.
+/// The nonlinear solver is 10 iterations of Gauss-Newton.
+/// The linear solver is 500 iterations of CGLS.
+// TODO: Make APIs sufficiently public that we can implement this in "Benchmarks" instead of here.
+public func runGenericFactorGraphBenchmark() {
+  var x = VariableAssignments()
+  var graph = GenericFactorGraph()
+
+  try! G2OReader.read2D(file: try! cachedDataset("input_INTEL_g2o.txt")) {
+    switch $0 {
+    case .initialGuess(index: let id, pose: let guess):
+      let typedID = x.store(guess)
+      assert(typedID.perTypeID == id)
+    case .measurement(frameIndex: let id1, measuredIndex: let id2, pose: let difference):
+      graph.store(
+        GenericBetweenFactor2(
+          edges: Tuple2(TypedID(id1), TypedID(id2)),
+          difference: difference
+        )
+      )
+    }
+  }
+  graph.store(GenericPriorFactor2(edges: Tuple1(TypedID(0)), prior: Pose2(0, 0, 0)))
+
+  for _ in 0..<10 {
+    let linearized = graph.linearized(at: x)
+    var dx = x.zeroTangent
+    var optimizer = GenericCGLS(precision: 0, max_iteration: 500)
+    optimizer.optimize(gfg: linearized, initial: &dx)
+    x.move(along: (-1) * dx)
+  }
+  assert(abs(graph.error(at: x) - 0.987) < 1e-2)
+}

--- a/Sources/SwiftFusion/Inference/GenericFactorGraph.swift
+++ b/Sources/SwiftFusion/Inference/GenericFactorGraph.swift
@@ -31,7 +31,7 @@ public struct GenericFactorGraph {
   }
 
   /// Stores `factor` in the graph.
-  mutating func store<T: GenericFactor>(_ factor: T) {
+  public mutating func store<T: GenericFactor>(_ factor: T) {
     _ = contiguousStorage[
       ObjectIdentifier(T.self),
       default: AnyArrayBuffer(ArrayBuffer<FactorArrayStorage<T>>())
@@ -39,7 +39,7 @@ public struct GenericFactorGraph {
   }
 
   /// Stores `factor` in the graph.
-  mutating func store<T: GenericLinearizableFactor>(_ factor: T) {
+  public mutating func store<T: GenericLinearizableFactor>(_ factor: T) {
     _ = contiguousStorage[
       ObjectIdentifier(T.self),
       default: AnyArrayBuffer(ArrayBuffer<LinearizableFactorArrayStorage<T>>())
@@ -47,18 +47,18 @@ public struct GenericFactorGraph {
   }
 
   /// Stores `factor` in the graph.
-  mutating func store<T: GenericGaussianFactor>(_ factor: T) {
+  public mutating func store<T: GenericGaussianFactor>(_ factor: T) {
     _ = contiguousStorage[
       ObjectIdentifier(T.self),
       default: AnyArrayBuffer(ArrayBuffer<GaussianFactorArrayStorage<T>>())
     ].append(factor)
   }
 
-  func error(at x: VariableAssignments) -> Double {
+  public func error(at x: VariableAssignments) -> Double {
     return contiguousStorage.values.lazy.map { $0.errors(at: x).reduce(0, +) }.reduce(0, +)
   }
 
-  func linearized(at x: VariableAssignments) -> GenericGaussianFactorGraph {
+  public func linearized(at x: VariableAssignments) -> GenericGaussianFactorGraph {
     return GenericGaussianFactorGraph(
       inputZero: x.zeroTangent,
       contiguousStorage: contiguousStorage.compactMapValues { factors in
@@ -66,40 +66,4 @@ public struct GenericFactorGraph {
       }
     )
   }
-}
-
-/// Benchmarks `GenericFactorGraph` on the Intel dataset.
-///
-/// The solvers are configured to run for a constant number of steps.
-/// The nonlinear solver is 10 iterations of Gauss-Newton.
-/// The linear solver is 500 iterations of CGLS.
-// TODO: Make APIs sufficiently public that we can implement this in "Benchmarks" instead of here.
-public func runGenericFactorGraphBenchmark() {
-  var x = VariableAssignments()
-  var graph = GenericFactorGraph()
-
-  try! G2OReader.read2D(file: try! cachedDataset("input_INTEL_g2o.txt")) {
-    switch $0 {
-    case .initialGuess(index: let id, pose: let guess):
-      let typedID = x.store(guess)
-      assert(typedID.perTypeID == id)
-    case .measurement(frameIndex: let id1, measuredIndex: let id2, pose: let difference):
-      graph.store(
-        GenericBetweenFactor2(
-          edges: Tuple2(TypedID(id1), TypedID(id2)),
-          difference: difference
-        )
-      )
-    }
-  }
-  graph.store(GenericPriorFactor2(edges: Tuple1(TypedID(0)), prior: Pose2(0, 0, 0)))
-
-  for _ in 0..<10 {
-    let linearized = graph.linearized(at: x)
-    var dx = x.zeroTangent
-    var optimizer = GenericCGLS(precision: 0, max_iteration: 500)
-    optimizer.optimize(gfg: linearized, initial: &dx)
-    x.move(along: (-1) * dx)
-  }
-  assert(abs(graph.error(at: x) - 0.987) < 1e-2)
 }

--- a/Sources/SwiftFusion/Inference/GenericGaussianFactorGraph.swift
+++ b/Sources/SwiftFusion/Inference/GenericGaussianFactorGraph.swift
@@ -14,7 +14,7 @@
 
 import PenguinStructures
 
-struct GenericGaussianFactorGraph {
+public struct GenericGaussianFactorGraph {
   var inputZero: VariableAssignments
   var contiguousStorage: [ObjectIdentifier: AnyArrayBuffer<AnyGaussianFactorStorage>]
 

--- a/Sources/SwiftFusion/Inference/GenericGaussianFactorGraph.swift
+++ b/Sources/SwiftFusion/Inference/GenericGaussianFactorGraph.swift
@@ -1,0 +1,40 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import PenguinStructures
+
+struct GenericGaussianFactorGraph {
+  var inputZero: VariableAssignments
+  var contiguousStorage: [ObjectIdentifier: AnyArrayBuffer<AnyGaussianFactorStorage>]
+
+  func errorVectors(at x: VariableAssignments) -> VariableAssignments {
+    return VariableAssignments(contiguousStorage: contiguousStorage.mapValues { factors in
+      AnyArrayBuffer(factors.errorVectors(at: x))
+    })
+  }
+
+  func errorVectorLinearComponents(at x: VariableAssignments) -> VariableAssignments {
+    return VariableAssignments(contiguousStorage: contiguousStorage.mapValues { factors in
+      AnyArrayBuffer(factors.linearForward(x))
+    })
+  }
+
+  func errorVectorLinearComponentAdjoints(_ y: VariableAssignments) -> VariableAssignments {
+    var x = inputZero
+    contiguousStorage.forEach { (key, factor) in
+      factor.linearAdjoint(y.contiguousStorage[key].unsafelyUnwrapped, into: &x)
+    }
+    return x
+  }
+}

--- a/Sources/SwiftFusion/Inference/GenericJacobianFactor.swift
+++ b/Sources/SwiftFusion/Inference/GenericJacobianFactor.swift
@@ -19,23 +19,23 @@ import PenguinStructures
 /// Note: This is currently named with a "Generic" prefix to avoid clashing with the other factors.
 /// When we completely replace the existing factors with the "Generic" ones, we should remove this
 /// prefix.
-struct GenericJacobianFactor<
+public struct GenericJacobianFactor<
   Rows: FixedSizeArray,
   ErrorVector: EuclideanVectorN
 >: GenericGaussianFactor where Rows.Element: EuclideanVectorN & VariableTuple {
-  typealias Variables = Rows.Element
+  public typealias Variables = Rows.Element
 
   /// The Jacobian matrix, as a fixed size array of rows.
-  let jacobian: Rows
+  public let jacobian: Rows
 
   /// The error vector.
-  let error: ErrorVector
+  public let error: ErrorVector
 
   /// The ids of the variables adjacent to this factor.
-  let edges: Variables.Indices
+  public let edges: Variables.Indices
 
   /// Creates a Jacobian factor with the given `jacobian`, `error`, and `edges`.
-  init(jacobian: Rows, error: ErrorVector, edges: Variables.Indices) {
+  public init(jacobian: Rows, error: ErrorVector, edges: Variables.Indices) {
     self.jacobian = jacobian
     self.error = error
     self.edges = edges
@@ -55,27 +55,28 @@ struct GenericJacobianFactor<
     self.edges = Input.tangentIndices(edges)
   }
 
-  func error(at x: Variables) -> Double {
+  public func error(at x: Variables) -> Double {
     return errorVector(at: x).squaredNorm
   }
 
-  func errorVector(at x: Variables) -> ErrorVector {
+  public func errorVector(at x: Variables) -> ErrorVector {
     return linearForward(x) + error
   }
 
-  func linearForward(_ x: Variables) -> ErrorVector {
+  public func linearForward(_ x: Variables) -> ErrorVector {
     return ErrorVector(jacobian.lazy.map { $0.dot(x) })
   }
 
-  func linearAdjoint(_ y: ErrorVector) -> Variables {
+  public func linearAdjoint(_ y: ErrorVector) -> Variables {
     return zip(y.scalars, jacobian).lazy.map(*).reduce(Variables.zero, +)
   }
 
-  typealias Linearized = Self
-  func linearized(at x: Variables) -> Self {
+  public typealias Linearized = Self
+  public func linearized(at x: Variables) -> Self {
     return self
   }
 }
 
-typealias JacobianFactor3x3 = GenericJacobianFactor<Array3<Tuple1<Vector3>>, Vector3>
-typealias JacobianFactor3x3_2 = GenericJacobianFactor<Array3<Tuple2<Vector3, Vector3>>, Vector3>
+public typealias JacobianFactor3x3 = GenericJacobianFactor<Array3<Tuple1<Vector3>>, Vector3>
+public typealias JacobianFactor3x3_2 =
+  GenericJacobianFactor<Array3<Tuple2<Vector3, Vector3>>, Vector3>

--- a/Sources/SwiftFusion/Inference/GenericJacobianFactor.swift
+++ b/Sources/SwiftFusion/Inference/GenericJacobianFactor.swift
@@ -1,0 +1,81 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import PenguinStructures
+
+/// A Gaussian factor stored as a jacobian matrix and an error vector.
+///
+/// Note: This is currently named with a "Generic" prefix to avoid clashing with the other factors.
+/// When we completely replace the existing factors with the "Generic" ones, we should remove this
+/// prefix.
+struct GenericJacobianFactor<
+  Rows: FixedSizeArray,
+  ErrorVector: EuclideanVectorN
+>: GenericGaussianFactor where Rows.Element: EuclideanVectorN & VariableTuple {
+  typealias Variables = Rows.Element
+
+  /// The Jacobian matrix, as a fixed size array of rows.
+  let jacobian: Rows
+
+  /// The error vector.
+  let error: ErrorVector
+
+  /// The ids of the variables adjacent to this factor.
+  let edges: Variables.Indices
+
+  /// Creates a Jacobian factor with the given `jacobian`, `error`, and `edges`.
+  init(jacobian: Rows, error: ErrorVector, edges: Variables.Indices) {
+    self.jacobian = jacobian
+    self.error = error
+    self.edges = edges
+  }
+
+  /// Creates a Jacobian factor that linearizes `f` at `x`, and is adjacent to the variables
+  /// identifed by edges.
+  init<Input: Differentiable & DifferentiableVariableTuple>(
+    linearizing f: @differentiable (Input) -> ErrorVector,
+    at x: Input,
+    edges: Input.Indices
+  ) where Input.TangentVector == Variables, Input.TangentIndices == Variables.Indices {
+    let (value, pb) = valueWithPullback(at: x, in: f)
+    let rows = Rows(ErrorVector.standardBasis.lazy.map(pb))
+    self.jacobian = rows
+    self.error = value
+    self.edges = Input.tangentIndices(edges)
+  }
+
+  func error(at x: Variables) -> Double {
+    return errorVector(at: x).squaredNorm
+  }
+
+  func errorVector(at x: Variables) -> ErrorVector {
+    return linearForward(x) + error
+  }
+
+  func linearForward(_ x: Variables) -> ErrorVector {
+    return ErrorVector(jacobian.lazy.map { $0.dot(x) })
+  }
+
+  func linearAdjoint(_ y: ErrorVector) -> Variables {
+    return zip(y.scalars, jacobian).lazy.map(*).reduce(Variables.zero, +)
+  }
+
+  typealias Linearized = Self
+  func linearized(at x: Variables) -> Self {
+    return self
+  }
+}
+
+typealias JacobianFactor3x3 = GenericJacobianFactor<Array3<Tuple1<Vector3>>, Vector3>
+typealias JacobianFactor3x3_2 = GenericJacobianFactor<Array3<Tuple2<Vector3, Vector3>>, Vector3>

--- a/Sources/SwiftFusion/Inference/GenericJacobianFactor.swift
+++ b/Sources/SwiftFusion/Inference/GenericJacobianFactor.swift
@@ -14,7 +14,8 @@
 
 import PenguinStructures
 
-/// A Gaussian factor stored as a jacobian matrix and an error vector.
+/// A Gaussian distribution over the input, represented as a materialized Jacobian matrix and
+/// materialized error vector.
 ///
 /// Note: This is currently named with a "Generic" prefix to avoid clashing with the other factors.
 /// When we completely replace the existing factors with the "Generic" ones, we should remove this
@@ -35,7 +36,7 @@ public struct GenericJacobianFactor<
   public let edges: Variables.Indices
 
   /// Creates a Jacobian factor with the given `jacobian`, `error`, and `edges`.
-  public init(jacobian: Rows, error: ErrorVector, edges: Variables.Indices) {
+  init(jacobian: Rows, error: ErrorVector, edges: Variables.Indices) {
     self.jacobian = jacobian
     self.error = error
     self.edges = edges
@@ -52,7 +53,7 @@ public struct GenericJacobianFactor<
     let rows = Rows(ErrorVector.standardBasis.lazy.map(pb))
     self.jacobian = rows
     self.error = value
-    self.edges = Input.tangentIndices(edges)
+    self.edges = Input.linearized(edges)
   }
 
   public func error(at x: Variables) -> Double {
@@ -77,6 +78,9 @@ public struct GenericJacobianFactor<
   }
 }
 
-public typealias JacobianFactor3x3 = GenericJacobianFactor<Array3<Tuple1<Vector3>>, Vector3>
+/// A Jacobian factor with 1 3-dimensional input and a 3-dimensional error vector.
+public typealias JacobianFactor3x3_1 = GenericJacobianFactor<Array3<Tuple1<Vector3>>, Vector3>
+
+/// A Jacobian factor with 2 3-dimensional inputs and a 3-dimensional error vector.
 public typealias JacobianFactor3x3_2 =
   GenericJacobianFactor<Array3<Tuple2<Vector3, Vector3>>, Vector3>

--- a/Sources/SwiftFusion/Inference/GenericPriorFactor.swift
+++ b/Sources/SwiftFusion/Inference/GenericPriorFactor.swift
@@ -40,6 +40,7 @@ public struct GenericPriorFactor<Pose: LieGroup, JacobianRows: FixedSizeArray>:
 
   // Note: All the remaining code in this factor is boilerplate that we can eventually eliminate
   // with sugar.
+  
   public func error(at x: Variables) -> Double {
     return errorVector(at: x).squaredNorm
   }

--- a/Sources/SwiftFusion/Inference/GenericPriorFactor.swift
+++ b/Sources/SwiftFusion/Inference/GenericPriorFactor.swift
@@ -19,34 +19,39 @@ import PenguinStructures
 /// Note: This is currently named with a "Generic" prefix to avoid clashing with the other factors.
 /// When we completely replace the existing factors with the "Generic" ones, we should remove this
 /// prefix.
-struct GenericPriorFactor<Pose: LieGroup, JacobianRows: FixedSizeArray>:
+public struct GenericPriorFactor<Pose: LieGroup, JacobianRows: FixedSizeArray>:
   GenericLinearizableFactor
   where JacobianRows.Element == Tuple1<Pose.TangentVector>
 {
-  typealias Variables = Tuple1<Pose>
+  public typealias Variables = Tuple1<Pose>
 
-  let edges: Variables.Indices
-  let prior: Pose
+  public let edges: Variables.Indices
+  public let prior: Pose
 
-  typealias ErrorVector = Pose.TangentVector
-  func errorVector(_ x: Pose) -> ErrorVector {
+  public init(_ id: TypedID<Pose, Int>, _ prior: Pose) {
+    self.edges = Tuple1(id)
+    self.prior = prior
+  }
+
+  public typealias ErrorVector = Pose.TangentVector
+  public func errorVector(_ x: Pose) -> ErrorVector {
     return prior.localCoordinate(x)
   }
 
   // Note: All the remaining code in this factor is boilerplate that we can eventually eliminate
   // with sugar.
-  func error(at x: Variables) -> Double {
+  public func error(at x: Variables) -> Double {
     return errorVector(at: x).squaredNorm
   }
 
-  func errorVector(at x: Variables) -> Pose.TangentVector {
+  public func errorVector(at x: Variables) -> Pose.TangentVector {
     return errorVector(x.head)
   }
 
-  typealias Linearized = GenericJacobianFactor<JacobianRows, ErrorVector>
-  func linearized(at x: Variables) -> Linearized {
+  public typealias Linearized = GenericJacobianFactor<JacobianRows, ErrorVector>
+  public func linearized(at x: Variables) -> Linearized {
     Linearized(linearizing: errorVector, at: x, edges: edges)
   }
 }
 
-typealias GenericPriorFactor2 = GenericPriorFactor<Pose2, Array3<Tuple1<Vector3>>>
+public typealias GenericPriorFactor2 = GenericPriorFactor<Pose2, Array3<Tuple1<Vector3>>>

--- a/Sources/SwiftFusion/Inference/GenericPriorFactor.swift
+++ b/Sources/SwiftFusion/Inference/GenericPriorFactor.swift
@@ -1,0 +1,52 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import PenguinStructures
+
+/// A factor that specifies a prior on a pose.
+///
+/// Note: This is currently named with a "Generic" prefix to avoid clashing with the other factors.
+/// When we completely replace the existing factors with the "Generic" ones, we should remove this
+/// prefix.
+struct GenericPriorFactor<Pose: LieGroup, JacobianRows: FixedSizeArray>:
+  GenericLinearizableFactor
+  where JacobianRows.Element == Tuple1<Pose.TangentVector>
+{
+  typealias Variables = Tuple1<Pose>
+
+  let edges: Variables.Indices
+  let prior: Pose
+
+  typealias ErrorVector = Pose.TangentVector
+  func errorVector(_ x: Pose) -> ErrorVector {
+    return prior.localCoordinate(x)
+  }
+
+  // Note: All the remaining code in this factor is boilerplate that we can eventually eliminate
+  // with sugar.
+  func error(at x: Variables) -> Double {
+    return errorVector(at: x).squaredNorm
+  }
+
+  func errorVector(at x: Variables) -> Pose.TangentVector {
+    return errorVector(x.head)
+  }
+
+  typealias Linearized = GenericJacobianFactor<JacobianRows, ErrorVector>
+  func linearized(at x: Variables) -> Linearized {
+    Linearized(linearizing: errorVector, at: x, edges: edges)
+  }
+}
+
+typealias GenericPriorFactor2 = GenericPriorFactor<Pose2, Array3<Tuple1<Vector3>>>

--- a/Sources/SwiftFusion/Inference/ValuesStorage.swift
+++ b/Sources/SwiftFusion/Inference/ValuesStorage.swift
@@ -271,11 +271,13 @@ extension ArrayStorageImplementation where Element: EuclideanVector {
   /// Adds the vector starting at `otherStart` to `self`.
   ///
   /// Precondition: `otherStart` points to memory with at least `count` initialized `Element`s.
+  @_specialize(where Self == VectorArrayStorage<Vector3>)
   func add_(_ otherStart: UnsafeRawPointer) {
     add(UnsafeBufferPointer(start: otherStart.assumingMemoryBound(to: Element.self), count: count))
   }
   
   /// Scales each element of `self` by `scalar`.
+  @_specialize(where Self == VectorArrayStorage<Vector3>)
   func scale_(by scalar: Double) {
     withUnsafeMutableBufferPointer { b in
       b.indices.forEach { i in b[i] *= scalar }
@@ -287,6 +289,7 @@ extension ArrayStorageImplementation where Element: EuclideanVector {
   /// This is the sum of the dot products of corresponding elements.
   ///
   /// Precondition: `otherStart` points to memory with at least `count` initialized `Element`s.
+  @_specialize(where Self == VectorArrayStorage<Vector3>)
   func dot_(_ otherStart: UnsafeRawPointer) -> Double {
     return dot(
       UnsafeBufferPointer(start: otherStart.assumingMemoryBound(to: Element.self), count: count)

--- a/Sources/SwiftFusion/Inference/VariableAssignments.swift
+++ b/Sources/SwiftFusion/Inference/VariableAssignments.swift
@@ -14,18 +14,6 @@
 
 import PenguinStructures
 
-/// A heterogeneous array of values.
-///
-/// e.g. variable assignments, factor error vectors.
-///
-/// Note: This is just a temporary placeholder until we get the real heterogeneous array type. This
-/// one is missing nice abstractions that let clients interact with it without knowing about
-/// `contiguousStorage`.
-struct VariableAssignments {
-  /// Dictionary from variable type to contiguous storage for that type.
-  var contiguousStorage: [ObjectIdentifier: AnyArrayBuffer<AnyArrayStorage>]
-}
-
 /// An identifier of a given abstract value with the value's type attached
 ///
 /// - Parameter Value: the type of value this ID refers to.
@@ -39,4 +27,141 @@ public struct TypedID<Value, PerTypeID: Equatable> {
 
   /// Creates an instance indicating the given logical value of type `Value`.
   init(_ perTypeID: PerTypeID) { self.perTypeID = perTypeID }
+}
+
+/// Assignments of values to factor graph variables.
+public struct VariableAssignments {
+  /// Dictionary from variable type to contiguous storage for that type.
+  var contiguousStorage: [ObjectIdentifier: AnyArrayBuffer<AnyArrayStorage>] = [:]
+
+  /// Creates an empty instance.
+  public init() {}
+
+  internal init(contiguousStorage: [ObjectIdentifier: AnyArrayBuffer<AnyArrayStorage>]) {
+    self.contiguousStorage = contiguousStorage
+  }
+
+  /// Stores `value` as the assignment of a new variable, and returns the new variable's id.
+  public mutating func store<T>(_ value: T) -> TypedID<T, Int> {
+    let perTypeID = contiguousStorage[
+      ObjectIdentifier(T.self),
+      default: AnyArrayBuffer(ArrayBuffer<ArrayStorage<T>>())
+    ].append(value)
+    assert(type(of: contiguousStorage[ObjectIdentifier(T.self)]!.storage) == ArrayStorage<T>.self)
+    return TypedID(perTypeID)
+  }
+
+  /// Stores `value` as the assignment of a new variable, and returns the new variable's id.
+  public mutating func store<T: Differentiable>(_ value: T) -> TypedID<T, Int>
+    where T.TangentVector: EuclideanVector
+  {
+    let perTypeID = contiguousStorage[
+      ObjectIdentifier(T.self),
+      default: AnyArrayBuffer(ArrayBuffer<DifferentiableArrayStorage<T>>())
+    ].append(value)
+    assert(
+      type(of: contiguousStorage[ObjectIdentifier(T.self)]!.storage)
+        == DifferentiableArrayStorage<T>.self
+    )
+    return TypedID(perTypeID)
+  }
+
+  /// Stores `value` as the assignment of a new variable, and returns the new variable's id.
+  public mutating func store<T: EuclideanVector>(_ value: T) -> TypedID<T, Int> {
+    let perTypeID = contiguousStorage[
+      ObjectIdentifier(T.self),
+      default: AnyArrayBuffer(ArrayBuffer<VectorArrayStorage<T>>())
+    ].append(value)
+    assert(
+      type(of: contiguousStorage[ObjectIdentifier(T.self)]!.storage)
+        == VectorArrayStorage<T>.self
+    )
+    return TypedID(perTypeID)
+  }
+
+  /// Traps with an error indicating that an attempt was made to access a stored
+  /// variable of a type that is not represented in `self`.
+  private static var noSuchType: AnyArrayBuffer<AnyArrayStorage> {
+    fatalError("No such stored variable type")
+  }
+
+  /// Accesses the stored value with the given ID.
+  public subscript<T>(id: TypedID<T, Int>) -> T {
+    _read {
+      yield contiguousStorage[ObjectIdentifier(T.self), default: Self.noSuchType]
+        .withUnsafeRawPointerToElements { p in
+          p.assumingMemoryBound(to: T.self).advanced(by: id.perTypeID).pointee
+        }
+    }
+    _modify {
+      defer { _fixLifetime(self) }
+      yield &contiguousStorage[ObjectIdentifier(T.self), default: Self.noSuchType]
+        .withUnsafeMutableRawPointerToElements { p in
+          p.assumingMemoryBound(to: T.self).advanced(by: id.perTypeID)
+        }
+        .pointee
+    }
+  }
+}
+
+/// Differentiable operations.
+extension VariableAssignments {
+  var zeroTangent: VariableAssignments {
+    let r = Dictionary(uniqueKeysWithValues: contiguousStorage.compactMap {
+      (key, value) -> (ObjectIdentifier, AnyArrayBuffer<AnyArrayStorage>)? in
+      guard let differentiableValue = value.cast(to: AnyDifferentiableStorage.self) else {
+        return nil
+      }
+      return (
+        differentiableValue.tangentIdentifier,
+        AnyArrayBuffer(differentiableValue.zeroTangent)
+      )
+    })
+    return VariableAssignments(contiguousStorage: r)
+  }
+
+  mutating func move(along direction: VariableAssignments) {
+    contiguousStorage = contiguousStorage.mapValues { value in
+      guard var diffVal = value.cast(to: AnyDifferentiableStorage.self) else {
+        return value
+      }
+      guard let dirElem = direction.contiguousStorage[diffVal.tangentIdentifier] else {
+        return value
+      }
+      diffVal.move(along: dirElem)
+      return AnyArrayBuffer(diffVal)
+    }
+  }
+}
+
+/// Vector operations.
+// TODO: These currently have a precondition that all stored values are vectors. We could improve
+// this by adding a `VectorVariableAssignments` type that is statically known to contain only
+// vectors.
+extension VariableAssignments {
+  var squaredNorm: Double {
+    return contiguousStorage.values.lazy
+      .map { $0.storage as! AnyVectorStorage }
+      .map { $0.dot($0) }
+      .reduce(0, +)
+  }
+
+  static func * (_ lhs: Double, _ rhs: Self) -> Self {
+    VariableAssignments(contiguousStorage: rhs.contiguousStorage.mapValues { value in
+      var vector = value.cast(to: AnyVectorStorage.self)!
+      vector.scale(by: lhs)
+      return AnyArrayBuffer(vector)
+    })
+  }
+
+  static func + (_ lhs: Self, _ rhs: Self) -> Self {
+    let r = Dictionary(uniqueKeysWithValues: lhs.contiguousStorage.map {
+      (key, value) -> (ObjectIdentifier, AnyArrayBuffer<AnyArrayStorage>) in
+      var resultVector = value.cast(to: AnyVectorStorage.self)!
+      let rhsVector = rhs.contiguousStorage[key]!.cast(to: AnyVectorStorage.self)!
+      resultVector.add(rhsVector)
+      return (key, AnyArrayBuffer(resultVector))
+    })
+    return VariableAssignments(contiguousStorage: r)
+  }
 }

--- a/Sources/SwiftFusion/Inference/VariableAssignments.swift
+++ b/Sources/SwiftFusion/Inference/VariableAssignments.swift
@@ -23,10 +23,10 @@ import PenguinStructures
 /// Note: This is just a temporary placeholder until we get the real `TypedID` in penguin.
 public struct TypedID<Value, PerTypeID: Equatable> {
   /// A specifier of which logical value of type `value` is being identified.
-  let perTypeID: PerTypeID
+  public let perTypeID: PerTypeID
 
   /// Creates an instance indicating the given logical value of type `Value`.
-  init(_ perTypeID: PerTypeID) { self.perTypeID = perTypeID }
+  public init(_ perTypeID: PerTypeID) { self.perTypeID = perTypeID }
 }
 
 /// Assignments of values to factor graph variables.
@@ -106,7 +106,7 @@ public struct VariableAssignments {
 
 /// Differentiable operations.
 extension VariableAssignments {
-  var zeroTangent: VariableAssignments {
+  public var zeroTangent: VariableAssignments {
     let r = Dictionary(uniqueKeysWithValues: contiguousStorage.compactMap {
       (key, value) -> (ObjectIdentifier, AnyArrayBuffer<AnyArrayStorage>)? in
       guard let differentiableValue = value.cast(to: AnyDifferentiableStorage.self) else {
@@ -120,7 +120,7 @@ extension VariableAssignments {
     return VariableAssignments(contiguousStorage: r)
   }
 
-  mutating func move(along direction: VariableAssignments) {
+  public mutating func move(along direction: VariableAssignments) {
     contiguousStorage = contiguousStorage.mapValues { value in
       guard var diffVal = value.cast(to: AnyDifferentiableStorage.self) else {
         return value
@@ -139,14 +139,14 @@ extension VariableAssignments {
 // this by adding a `VectorVariableAssignments` type that is statically known to contain only
 // vectors.
 extension VariableAssignments {
-  var squaredNorm: Double {
+  public var squaredNorm: Double {
     return contiguousStorage.values.lazy
       .map { $0.storage as! AnyVectorStorage }
       .map { $0.dot($0) }
       .reduce(0, +)
   }
 
-  static func * (_ lhs: Double, _ rhs: Self) -> Self {
+  public static func * (_ lhs: Double, _ rhs: Self) -> Self {
     VariableAssignments(contiguousStorage: rhs.contiguousStorage.mapValues { value in
       var vector = value.cast(to: AnyVectorStorage.self)!
       vector.scale(by: lhs)
@@ -154,7 +154,7 @@ extension VariableAssignments {
     })
   }
 
-  static func + (_ lhs: Self, _ rhs: Self) -> Self {
+  public static func + (_ lhs: Self, _ rhs: Self) -> Self {
     let r = Dictionary(uniqueKeysWithValues: lhs.contiguousStorage.map {
       (key, value) -> (ObjectIdentifier, AnyArrayBuffer<AnyArrayStorage>) in
       var resultVector = value.cast(to: AnyVectorStorage.self)!

--- a/Sources/SwiftFusion/Optimizers/CGLS.swift
+++ b/Sources/SwiftFusion/Optimizers/CGLS.swift
@@ -88,16 +88,16 @@ public struct GenericCGLS {
     step += 1
 
     var r = gfg.errorVectors(at: x) // r(0) = b - A * x(0), the residual
-    var p = gfg.errorVectorLinearComponentAdjoints(r) // p(0) = s(0) = A^T * r(0), residual in value space
+    var p = gfg.errorVectorsLinearComponentAdjoint(r) // p(0) = s(0) = A^T * r(0), residual in value space
     var s = p // residual of normal equations
     var gamma = s.squaredNorm // γ(0) = ||s(0)||^2
 
     while step < max_iteration {
-      let q = gfg.errorVectorLinearComponents(at: p) // q(k) = A * p(k)
+      let q = gfg.errorVectorsLinearComponent(at: p) // q(k) = A * p(k)
       let alpha: Double = gamma / q.squaredNorm // α(k) = γ(k)/||q(k)||^2
       x = x + (alpha * p) // x(k+1) = x(k) + α(k) * p(k)
       r = r + (-alpha) * q // r(k+1) = r(k) - α(k) * q(k)
-      s = gfg.errorVectorLinearComponentAdjoints(r) // s(k+1) = A.T * r(k+1)
+      s = gfg.errorVectorsLinearComponentAdjoint(r) // s(k+1) = A.T * r(k+1)
 
       let gamma_next = s.squaredNorm // γ(k+1) = ||s(k+1)||^2
       let beta: Double = gamma_next/gamma // β(k) = γ(k+1)/γ(k)

--- a/Sources/SwiftFusion/Optimizers/CGLS.swift
+++ b/Sources/SwiftFusion/Optimizers/CGLS.swift
@@ -69,7 +69,7 @@ public class CGLS {
 /// Conjugate Gradient Least Squares (CGLS) optimizer.
 ///
 /// An optimizer that implements CGLS second order optimizer
-struct GenericCGLS {
+public struct GenericCGLS {
   /// The set of steps taken.
   public var step: Int = 0
   public var precision: Double = 1e-10

--- a/Sources/SwiftFusion/Optimizers/CGLS.swift
+++ b/Sources/SwiftFusion/Optimizers/CGLS.swift
@@ -11,7 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import TensorFlow
+
+import PenguinStructures
 
 /// Conjugate Gradient Least Squares (CGLS) optimizer.
 ///
@@ -62,5 +63,51 @@ public class CGLS {
     }
     
     initial = x
+  }
+}
+
+/// Conjugate Gradient Least Squares (CGLS) optimizer.
+///
+/// An optimizer that implements CGLS second order optimizer
+struct GenericCGLS {
+  /// The set of steps taken.
+  public var step: Int = 0
+  public var precision: Double = 1e-10
+  public var max_iteration: Int = 400
+
+  /// Constructor
+  public init(precision p: Double = 1e-10, max_iteration maxiter: Int = 400) {
+    precision = p
+    max_iteration = maxiter
+  }
+
+  /// Optimize the Gaussian Factor Graph with a initial estimate
+  /// Reference: Bjorck96book_numerical-methods-for-least-squares-problems
+  /// Page 289, Algorithm 7.4.1
+  public mutating func optimize(gfg: GenericGaussianFactorGraph, initial x: inout VariableAssignments) {
+    step += 1
+
+    var r = gfg.errorVectors(at: x) // r(0) = b - A * x(0), the residual
+    var p = gfg.errorVectorLinearComponentAdjoints(r) // p(0) = s(0) = A^T * r(0), residual in value space
+    var s = p // residual of normal equations
+    var gamma = s.squaredNorm // γ(0) = ||s(0)||^2
+
+    while step < max_iteration {
+      let q = gfg.errorVectorLinearComponents(at: p) // q(k) = A * p(k)
+      let alpha: Double = gamma / q.squaredNorm // α(k) = γ(k)/||q(k)||^2
+      x = x + (alpha * p) // x(k+1) = x(k) + α(k) * p(k)
+      r = r + (-alpha) * q // r(k+1) = r(k) - α(k) * q(k)
+      s = gfg.errorVectorLinearComponentAdjoints(r) // s(k+1) = A.T * r(k+1)
+
+      let gamma_next = s.squaredNorm // γ(k+1) = ||s(k+1)||^2
+      let beta: Double = gamma_next/gamma // β(k) = γ(k+1)/γ(k)
+      gamma = gamma_next
+      p = s + beta * p // p(k+1) = s(k+1) + β(k) * p(k)
+
+      if (alpha * p).squaredNorm < precision {
+        break
+      }
+      step += 1
+    }
   }
 }

--- a/Tests/SwiftFusionTests/Inference/GenericFactorGraphTests.swift
+++ b/Tests/SwiftFusionTests/Inference/GenericFactorGraphTests.swift
@@ -1,0 +1,53 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import TensorFlow
+import XCTest
+
+import PenguinStructures
+@testable import SwiftFusion
+
+class GenericFactorGraphTests: XCTestCase {
+  func testSimplePose2SLAM() {
+    var x = VariableAssignments()
+    let pose1ID = x.store(Pose2(Rot2(0.2), Vector2(0.5, 0.0)))
+    let pose2ID = x.store(Pose2(Rot2(-0.2), Vector2(2.3, 0.1)))
+    let pose3ID = x.store(Pose2(Rot2(.pi / 2), Vector2(4.1, 0.1)))
+    let pose4ID = x.store(Pose2(Rot2(.pi), Vector2(4.0, 2.0)))
+    let pose5ID = x.store(Pose2(Rot2(-.pi / 2), Vector2(2.1, 2.1)))
+
+    var graph = GenericFactorGraph()
+    graph.store(
+      GenericBetweenFactor2(edges: Tuple2(pose2ID, pose1ID), difference: Pose2(2.0, 0.0, .pi / 2)))
+    graph.store(
+      GenericBetweenFactor2(edges: Tuple2(pose3ID, pose2ID), difference: Pose2(2.0, 0.0, .pi / 2)))
+    graph.store(
+      GenericBetweenFactor2(edges: Tuple2(pose4ID, pose3ID), difference: Pose2(2.0, 0.0, .pi / 2)))
+    graph.store(
+      GenericBetweenFactor2(edges: Tuple2(pose5ID, pose4ID), difference: Pose2(2.0, 0.0, .pi / 2)))
+    graph.store(GenericPriorFactor2(edges: Tuple1(pose1ID), prior: Pose2(0, 0, 0)))
+
+    for _ in 0..<3 {
+      let linearized = graph.linearized(at: x)
+      var dx = x.zeroTangent
+      var optimizer = GenericCGLS(precision: 1e-6, max_iteration: 500)
+      optimizer.optimize(gfg: linearized, initial: &dx)
+      x.move(along: (-1) * dx)
+    }
+
+    // Test condition: pose 5 should be identical to pose 1 (close loop).
+    XCTAssertEqual(between(x[pose1ID], x[pose5ID]).t.norm, 0.0, accuracy: 1e-2)
+  }
+}

--- a/Tests/SwiftFusionTests/Inference/GenericFactorGraphTests.swift
+++ b/Tests/SwiftFusionTests/Inference/GenericFactorGraphTests.swift
@@ -17,7 +17,7 @@ import TensorFlow
 import XCTest
 
 import PenguinStructures
-@testable import SwiftFusion
+import SwiftFusion
 
 class GenericFactorGraphTests: XCTestCase {
   func testSimplePose2SLAM() {
@@ -29,15 +29,11 @@ class GenericFactorGraphTests: XCTestCase {
     let pose5ID = x.store(Pose2(Rot2(-.pi / 2), Vector2(2.1, 2.1)))
 
     var graph = GenericFactorGraph()
-    graph.store(
-      GenericBetweenFactor2(edges: Tuple2(pose2ID, pose1ID), difference: Pose2(2.0, 0.0, .pi / 2)))
-    graph.store(
-      GenericBetweenFactor2(edges: Tuple2(pose3ID, pose2ID), difference: Pose2(2.0, 0.0, .pi / 2)))
-    graph.store(
-      GenericBetweenFactor2(edges: Tuple2(pose4ID, pose3ID), difference: Pose2(2.0, 0.0, .pi / 2)))
-    graph.store(
-      GenericBetweenFactor2(edges: Tuple2(pose5ID, pose4ID), difference: Pose2(2.0, 0.0, .pi / 2)))
-    graph.store(GenericPriorFactor2(edges: Tuple1(pose1ID), prior: Pose2(0, 0, 0)))
+    graph.store(GenericBetweenFactor2(pose2ID, pose1ID, Pose2(2.0, 0.0, .pi / 2)))
+    graph.store(GenericBetweenFactor2(pose3ID, pose2ID, Pose2(2.0, 0.0, .pi / 2)))
+    graph.store(GenericBetweenFactor2(pose4ID, pose3ID, Pose2(2.0, 0.0, .pi / 2)))
+    graph.store(GenericBetweenFactor2(pose5ID, pose4ID, Pose2(2.0, 0.0, .pi / 2)))
+    graph.store(GenericPriorFactor2(pose1ID, Pose2(0, 0, 0)))
 
     for _ in 0..<3 {
       let linearized = graph.linearized(at: x)

--- a/Tests/SwiftFusionTests/Inference/GenericFactorGraphTests.swift
+++ b/Tests/SwiftFusionTests/Inference/GenericFactorGraphTests.swift
@@ -37,7 +37,7 @@ class GenericFactorGraphTests: XCTestCase {
 
     for _ in 0..<3 {
       let linearized = graph.linearized(at: x)
-      var dx = x.zeroTangent
+      var dx = x.linearizedZero
       var optimizer = GenericCGLS(precision: 1e-6, max_iteration: 500)
       optimizer.optimize(gfg: linearized, initial: &dx)
       x.move(along: (-1) * dx)

--- a/Tests/SwiftFusionTests/Inference/GenericFactorTests.swift
+++ b/Tests/SwiftFusionTests/Inference/GenericFactorTests.swift
@@ -89,7 +89,7 @@ fileprivate struct ExampleFactorGraph {
 
     // Set up the factor graph.
 
-    _ = priorFactors.append(GenericPriorFactor(edges: Tuple1(poseIDs[0]), prior: Pose2(0, 0, 0)))
+    _ = priorFactors.append(GenericPriorFactor(poseIDs[0], Pose2(0, 0, 0)))
 
     _ = motionFactors.append(SwitchingMotionModelFactor(
       edges: Tuple3(motionLabelIDs[0], poseIDs[0], poseIDs[1]),


### PR DESCRIPTION
Adds:
* `VariableAssignments` methods that make it nicer and easier to use.
* `GenericFactorGraph` and `GenericGaussianFactorGraph` with high-level methods that make it easy to build a graph and linearize it.
* `GenericJacobianFactor` for linearizing factors.
* `GenericPriorFactor` and `GenericBetweenFactor` for the Pose2SLAM problem.
* A `Pose2SLAM` benchmark using all of the above.

To run the benchmark: `swift build -c release -Xswiftc -cross-module-optimization && .build/release/Benchmarks --filter GenericFactorGraph`