### PR TITLE
scalar jacobians

### DIFF
--- a/Sources/SwiftFusion/Inference/AllVectors.swift
+++ b/Sources/SwiftFusion/Inference/AllVectors.swift
@@ -64,4 +64,12 @@ extension AllVectors {
     })
     return VariableAssignments(storage: r)
   }
+
+  /// Returns the `ErrorVector` from the `perFactorID`-th factor of type `F`.
+  subscript<F: NewLinearizableFactor>(_ perFactorID: Int, factorType _: F.Type) -> F.ErrorVector {
+    return storage[ObjectIdentifier(F.self)]!
+      .withUnsafeBufferPointer(assumingElementType: F.ErrorVector.self) { b in
+        return b[perFactorID]
+      }
+  }
 }

--- a/Sources/SwiftFusion/Inference/NewFactor.swift
+++ b/Sources/SwiftFusion/Inference/NewFactor.swift
@@ -30,7 +30,7 @@ public protocol NewFactor {
 public protocol NewLinearizableFactor: NewFactor {
   /// The type of the error vector.
   // TODO: Add a description of what an error vector is.
-  associatedtype ErrorVector: EuclideanVector
+  associatedtype ErrorVector: EuclideanVectorN
 
   /// Returns the error vector given the values of the adjacent variables.
   func errorVector(at x: Variables) -> ErrorVector
@@ -44,7 +44,7 @@ public protocol NewLinearizableFactor: NewFactor {
 }
 
 /// A factor whose `errorVector` is a linear function of the variables, plus a constant.
-public protocol NewGaussianFactor: NewLinearizableFactor where Variables: EuclideanVector {
+public protocol NewGaussianFactor: NewLinearizableFactor where Variables: EuclideanVectorN {
   /// The linear component of `errorVector`.
   func errorVector_linearComponent(_ x: Variables) -> ErrorVector
 

--- a/Sources/SwiftFusion/Inference/NewGaussianFactorGraph.swift
+++ b/Sources/SwiftFusion/Inference/NewGaussianFactorGraph.swift
@@ -22,6 +22,19 @@ public struct NewGaussianFactorGraph {
   /// Assignment of zero to all the variables in the factor graph.
   var zeroValues: VariableAssignments
 
+  /// For each variable, add a Jacobian factor that scales it by `scalar`.
+  ///
+  /// Precondition: `self` doesn't already contain scalar Jacobian factors. (Temporary limitation
+  /// that we can remove when necessary.)
+  public mutating func addScalarJacobians(_ scalar: Double) {
+    zeroValues.storage.values.forEach { value in
+      let (jacsKey, jacs) = value.cast(to: AnyVectorStorage.self)!.jacobians(scalar: scalar)
+      // TODO: Support adding more jacobians of the same type.
+      precondition(storage[jacsKey] == nil)
+      storage[jacsKey] = jacs
+    }
+  }
+
   /// Returns the error vectors, at `x`, of all the factors.
   func errorVectors(at x: AllVectors) -> AllVectors {
     return AllVectors(storage: storage.mapValues { factors in

--- a/Sources/SwiftFusion/Inference/ScalarJacobianFactor.swift
+++ b/Sources/SwiftFusion/Inference/ScalarJacobianFactor.swift
@@ -1,0 +1,44 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import PenguinStructures
+
+/// A Gaussian factor that scales its input by a scalar.
+public struct ScalarJacobianFactor<ErrorVector: EuclideanVectorN>: NewGaussianFactor {
+  public typealias Variables = Tuple1<ErrorVector>
+
+  public let edges: Variables.Indices
+  public let scalar: Double
+
+  public func errorVector(at x: Variables) -> ErrorVector {
+    return scalar * x.head
+  }
+
+  public func error(at x: Tuple1<ErrorVector>) -> Double {
+    return errorVector(at: x).squaredNorm
+  }
+
+  public func errorVector_linearComponent(_ x: Variables) -> ErrorVector {
+    return errorVector(at: x)
+  }
+
+  public func errorVector_linearComponent_adjoint(_ y: ErrorVector) -> Variables {
+    return Tuple1(scalar * y)
+  }
+
+  public typealias Linearization = Self
+  public func linearized(at x: Tuple1<ErrorVector>) -> ScalarJacobianFactor<ErrorVector> {
+    return self
+  }
+}

--- a/Sources/SwiftFusion/Inference/VariableAssignments.swift
+++ b/Sources/SwiftFusion/Inference/VariableAssignments.swift
@@ -54,7 +54,7 @@ public struct VariableAssignments {
 
   /// Stores `value` as the assignment of a new variable, and returns the new variable's id.
   public mutating func store<T: Differentiable>(_ value: T) -> TypedID<T, Int>
-    where T.TangentVector: EuclideanVector
+    where T.TangentVector: EuclideanVectorN
   {
     let perTypeID = storage[
       ObjectIdentifier(T.self),
@@ -68,7 +68,7 @@ public struct VariableAssignments {
   }
 
   /// Stores `value` as the assignment of a new variable, and returns the new variable's id.
-  public mutating func store<T: EuclideanVector>(_ value: T) -> TypedID<T, Int> {
+  public mutating func store<T: EuclideanVectorN>(_ value: T) -> TypedID<T, Int> {
     let perTypeID = storage[
       ObjectIdentifier(T.self),
       default: AnyArrayBuffer(ArrayBuffer<VectorArrayStorage<T>>())

--- a/Tests/SwiftFusionTests/Inference/NewGaussianFactorGraphTests.swift
+++ b/Tests/SwiftFusionTests/Inference/NewGaussianFactorGraphTests.swift
@@ -1,0 +1,56 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import TensorFlow
+import XCTest
+
+import PenguinStructures
+@testable import SwiftFusion
+
+class NewGaussianFactorGraphTests: XCTestCase {
+  /// Adds some scalar jacobians and tests that the resulting graph produces the correct error
+  /// vectors.
+  func testAddScalarJacobians() {
+    var x = VariableAssignments()
+    let id1 = x.store(Vector2(1, 2))
+    let id2 = x.store(Vector2(3, 4))
+    let id3 = x.store(Vector3(5, 6, 7))
+
+    var jacobians = NewGaussianFactorGraph(storage: [:], zeroValues: x.tangentVectorZeros)
+    jacobians.addScalarJacobians(10)
+
+    let errorVectors = jacobians.errorVectors(at: x)
+    XCTAssertEqual(
+      errorVectors[0, factorType: ScalarJacobianFactor<Vector2>.self], Vector2(10, 20))
+    XCTAssertEqual(
+      errorVectors[1, factorType: ScalarJacobianFactor<Vector2>.self], Vector2(30, 40))
+    XCTAssertEqual(
+      errorVectors[0, factorType: ScalarJacobianFactor<Vector3>.self], Vector3(50, 60, 70))
+
+    let linearComponent = jacobians.errorVectors_linearComponent(at: x)
+    XCTAssertEqual(
+      linearComponent[0, factorType: ScalarJacobianFactor<Vector2>.self], Vector2(10, 20))
+    XCTAssertEqual(
+      linearComponent[1, factorType: ScalarJacobianFactor<Vector2>.self], Vector2(30, 40))
+    XCTAssertEqual(
+      linearComponent[0, factorType: ScalarJacobianFactor<Vector3>.self], Vector3(50, 60, 70))
+
+    let linearComponent_adjoint =
+      jacobians.errorVectors_linearComponent_adjoint(linearComponent)
+    XCTAssertEqual(linearComponent_adjoint[id1], Vector2(100, 200))
+    XCTAssertEqual(linearComponent_adjoint[id2], Vector2(300, 400))
+    XCTAssertEqual(linearComponent_adjoint[id3], Vector3(500, 600, 700))
+  }
+}

--- a/Tests/SwiftFusionTests/Inference/ValuesStorageTests.swift
+++ b/Tests/SwiftFusionTests/Inference/ValuesStorageTests.swift
@@ -19,10 +19,10 @@ import XCTest
 import PenguinStructures
 @testable import SwiftFusion
 
-fileprivate typealias VectorArray<Element: EuclideanVector> =
+fileprivate typealias VectorArray<Element: EuclideanVectorN> =
   ArrayBuffer<VectorArrayStorage<Element>>
 fileprivate typealias DifferentiableArray<Element: Differentiable>
-  = ArrayBuffer<DifferentiableArrayStorage<Element>> where Element.TangentVector: EuclideanVector
+  = ArrayBuffer<DifferentiableArrayStorage<Element>> where Element.TangentVector: EuclideanVectorN
 
 class ValuesStorageTests: XCTestCase {
   


### PR DESCRIPTION
This implements the `addScalarJacobians` method, which lets you add scalar jacobians over all variables to any gaussian factor graph.

Eventually it would probably be good to have a more general-purpose API instead, like:
```
let jacobians = factorGraph.inputVariableIds.map { id in
  ScalarJacobianFactor(id, scalar: 0.1)
}
factorGraph.add(jacobians)
```

But for now I think this method does what you need.