### PR TITLE
add documentation about jacobians and specializations

### DIFF
--- a/Sources/SwiftFusion/Inference/FactorsStorage.swift
+++ b/Sources/SwiftFusion/Inference/FactorsStorage.swift
@@ -275,8 +275,18 @@ extension ArrayStorageImplementation where Element: NewGaussianFactor {
   }
 
   /// Returns the results of the factors' linear functions at the given point.
+  // For reasonable performance, this must be specialized for all gaussian factor types that are
+  // used in inner loops.
+  @_specialize(where Self == GaussianFactorArrayStorage<ScalarJacobianFactor<Vector1>>)
+  @_specialize(where Self == GaussianFactorArrayStorage<ScalarJacobianFactor<Vector2>>)
+  @_specialize(where Self == GaussianFactorArrayStorage<ScalarJacobianFactor<Vector3>>)
+  @_specialize(where Self == GaussianFactorArrayStorage<ScalarJacobianFactor<Vector4>>)
+  @_specialize(where Self == GaussianFactorArrayStorage<ScalarJacobianFactor<Vector5>>)
+  @_specialize(where Self == GaussianFactorArrayStorage<ScalarJacobianFactor<Vector6>>)
   @_specialize(where Self == GaussianFactorArrayStorage<JacobianFactor3x3_1>)
   @_specialize(where Self == GaussianFactorArrayStorage<JacobianFactor3x3_2>)
+  @_specialize(where Self == GaussianFactorArrayStorage<JacobianFactor6x6_1>)
+  @_specialize(where Self == GaussianFactorArrayStorage<JacobianFactor6x6_2>)
   func errorVector_linearComponent_(_ x: VariableAssignments) -> AnyArrayBuffer<AnyVectorStorage> {
     return AnyArrayBuffer(errorVector_linearComponent(x))
   }
@@ -286,8 +296,18 @@ extension ArrayStorageImplementation where Element: NewGaussianFactor {
   ///
   /// Precondition: `errorVectorsStart` points to memory with at least `count` initialized
   /// `Element.ErrorVector`s.
+  // For reasonable performance, this must be specialized for all gaussian factor types that are
+  // used in inner loops.
+  @_specialize(where Self == GaussianFactorArrayStorage<ScalarJacobianFactor<Vector1>>)
+  @_specialize(where Self == GaussianFactorArrayStorage<ScalarJacobianFactor<Vector2>>)
+  @_specialize(where Self == GaussianFactorArrayStorage<ScalarJacobianFactor<Vector3>>)
+  @_specialize(where Self == GaussianFactorArrayStorage<ScalarJacobianFactor<Vector4>>)
+  @_specialize(where Self == GaussianFactorArrayStorage<ScalarJacobianFactor<Vector5>>)
+  @_specialize(where Self == GaussianFactorArrayStorage<ScalarJacobianFactor<Vector6>>)
   @_specialize(where Self == GaussianFactorArrayStorage<JacobianFactor3x3_1>)
   @_specialize(where Self == GaussianFactorArrayStorage<JacobianFactor3x3_2>)
+  @_specialize(where Self == GaussianFactorArrayStorage<JacobianFactor6x6_1>)
+  @_specialize(where Self == GaussianFactorArrayStorage<JacobianFactor6x6_2>)
   func errorVector_linearComponent_adjoint_(
     _ errorVectorsStart: UnsafeRawPointer,
     into result: inout VariableAssignments

--- a/Sources/SwiftFusion/Inference/NewBetweenFactor.swift
+++ b/Sources/SwiftFusion/Inference/NewBetweenFactor.swift
@@ -15,6 +15,10 @@
 import PenguinStructures
 
 /// A factor that specifies a difference between two poses.
+///
+/// `JacobianRows` specifies the `Rows` parameter of the Jacobian of this factor. See the
+/// documentation on `NewJacobianFactor.jacobian` for more information. Use the typealiases below to
+/// avoid specifying this type parameter every time you create an instance.
 public struct NewBetweenFactor<Pose: LieGroup, JacobianRows: FixedSizeArray>:
   NewLinearizableFactor
   where JacobianRows.Element == Tuple2<Pose.TangentVector, Pose.TangentVector>
@@ -52,4 +56,8 @@ public struct NewBetweenFactor<Pose: LieGroup, JacobianRows: FixedSizeArray>:
   }
 }
 
+/// A between factor on `Pose2`.
 public typealias NewBetweenFactor2 = NewBetweenFactor<Pose2, Array3<Tuple2<Vector3, Vector3>>>
+
+/// A between factor on `Pose3`.
+public typealias NewBetweenFactor3 = NewBetweenFactor<Pose3, Array6<Tuple2<Vector6, Vector6>>>

--- a/Sources/SwiftFusion/Inference/NewJacobianFactor.swift
+++ b/Sources/SwiftFusion/Inference/NewJacobianFactor.swift
@@ -23,6 +23,11 @@ public struct NewJacobianFactor<
   public typealias Variables = Rows.Element
 
   /// The Jacobian matrix, as a fixed size array of rows.
+  ///
+  /// The `jacobian` has one row per element of the `ErrorVector`, and each row is a vector in the
+  /// vector space of adjacent variables. For example, if `ErrorVector == Vector3` and
+  /// `Variables == Tuple2<Vector3, Vector3>`, then `Rows == Array3<Tuple2<Vector3, Vector3>>`. See
+  /// the typealiases below for more examples.
   public let jacobian: Rows
 
   /// The error vector.
@@ -79,3 +84,9 @@ public typealias JacobianFactor3x3_1 = NewJacobianFactor<Array3<Tuple1<Vector3>>
 
 /// A Jacobian factor with 2 3-dimensional inputs and a 3-dimensional error vector.
 public typealias JacobianFactor3x3_2 = NewJacobianFactor<Array3<Tuple2<Vector3, Vector3>>, Vector3>
+
+/// A Jacobian factor with 1 6-dimensional input and a 6-dimensional error vector.
+public typealias JacobianFactor6x6_1 = NewJacobianFactor<Array6<Tuple1<Vector6>>, Vector6>
+
+/// A Jacobian factor with 2 6-dimensional inputs and a 6-dimensional error vector.
+public typealias JacobianFactor6x6_2 = NewJacobianFactor<Array6<Tuple2<Vector6, Vector6>>, Vector6>

--- a/Sources/SwiftFusion/Inference/NewPriorFactor.swift
+++ b/Sources/SwiftFusion/Inference/NewPriorFactor.swift
@@ -15,6 +15,10 @@
 import PenguinStructures
 
 /// A factor that specifies a prior on a pose.
+///
+/// `JacobianRows` specifies the `Rows` parameter of the Jacobian of this factor. See the
+/// documentation on `NewJacobianFactor.jacobian` for more information. Use the typealiases below to
+/// avoid specifying this type parameter every time you create an instance.
 public struct NewPriorFactor<Pose: LieGroup, JacobianRows: FixedSizeArray>:
   NewLinearizableFactor
   where JacobianRows.Element == Tuple1<Pose.TangentVector>
@@ -51,4 +55,8 @@ public struct NewPriorFactor<Pose: LieGroup, JacobianRows: FixedSizeArray>:
   }
 }
 
+/// A prior factor on a `Pose2`.
 public typealias NewPriorFactor2 = NewPriorFactor<Pose2, Array3<Tuple1<Vector3>>>
+
+/// A prior factor on a `Pose3`.
+public typealias NewPriorFactor3 = NewPriorFactor<Pose3, Array6<Tuple1<Vector6>>>

--- a/Sources/SwiftFusion/Inference/ValuesStorage.swift
+++ b/Sources/SwiftFusion/Inference/ValuesStorage.swift
@@ -286,13 +286,27 @@ extension ArrayStorageImplementation where Element: EuclideanVectorN {
   /// Adds the vector starting at `otherStart` to `self`.
   ///
   /// Precondition: `otherStart` points to memory with at least `count` initialized `Element`s.
+  // For reasonable performance, this must be specialized for all vector types that are used in
+  // inner loops.
+  @_specialize(where Self == VectorArrayStorage<Vector1>)
+  @_specialize(where Self == VectorArrayStorage<Vector2>)
   @_specialize(where Self == VectorArrayStorage<Vector3>)
+  @_specialize(where Self == VectorArrayStorage<Vector4>)
+  @_specialize(where Self == VectorArrayStorage<Vector5>)
+  @_specialize(where Self == VectorArrayStorage<Vector6>)
   func add_(_ otherStart: UnsafeRawPointer) {
     add(UnsafeBufferPointer(start: otherStart.assumingMemoryBound(to: Element.self), count: count))
   }
   
   /// Scales each element of `self` by `scalar`.
+  // For reasonable performance, this must be specialized for all vector types that are used in
+  // inner loops.
+  @_specialize(where Self == VectorArrayStorage<Vector1>)
+  @_specialize(where Self == VectorArrayStorage<Vector2>)
   @_specialize(where Self == VectorArrayStorage<Vector3>)
+  @_specialize(where Self == VectorArrayStorage<Vector4>)
+  @_specialize(where Self == VectorArrayStorage<Vector5>)
+  @_specialize(where Self == VectorArrayStorage<Vector6>)
   func scale_(by scalar: Double) {
     withUnsafeMutableBufferPointer { b in
       b.indices.forEach { i in b[i] *= scalar }
@@ -304,7 +318,14 @@ extension ArrayStorageImplementation where Element: EuclideanVectorN {
   /// This is the sum of the dot products of corresponding elements.
   ///
   /// Precondition: `otherStart` points to memory with at least `count` initialized `Element`s.
+  // For reasonable performance, this must be specialized for all vector types that are used in
+  // inner loops.
+  @_specialize(where Self == VectorArrayStorage<Vector1>)
+  @_specialize(where Self == VectorArrayStorage<Vector2>)
   @_specialize(where Self == VectorArrayStorage<Vector3>)
+  @_specialize(where Self == VectorArrayStorage<Vector4>)
+  @_specialize(where Self == VectorArrayStorage<Vector5>)
+  @_specialize(where Self == VectorArrayStorage<Vector6>)
   func dot_(_ otherStart: UnsafeRawPointer) -> Double {
     return dot(
       UnsafeBufferPointer(start: otherStart.assumingMemoryBound(to: Element.self), count: count)


### PR DESCRIPTION
I realized that it might not be clear how to get the prior and between factors working with Pose3. The `JacobianRows` type parameter is non obvious and not documented. So I added some doc comments about that.

Also I added some specializations that you will need for Pose3SLAM to be fast, and comments about them.