### PR TITLE
add Pose3 custom Adjoint, to make Pose3SLAM faster

### DIFF
--- a/Sources/Benchmarks/Pose3SLAM.swift
+++ b/Sources/Benchmarks/Pose3SLAM.swift
@@ -48,8 +48,8 @@ let pose3SLAM = BenchmarkSuite(name: "Pose3SLAM") { suite in
     }
   }
   
-  var gridDataset =  try! G2OReader.G2ONewFactorGraph(g2oFile3D: try! cachedDataset("pose3example.txt"))
-  // Uses `NewFactorGraph` on the GTSAM pose3example dataset.
+  var sphere2500Dataset =  try! G2OReader.G2ONewFactorGraph(g2oFile3D: try! cachedDataset("sphere2500.g2o"))
+  // Uses `NewFactorGraph` on the GTSAM sphere2500 dataset.
   // The solvers are configured to run for a constant number of *LM steps*, except when the LM solver is
   // unable to progress even with maximum lambda.
   // The linear solver is 200 iterations of CGLS.
@@ -57,8 +57,8 @@ let pose3SLAM = BenchmarkSuite(name: "Pose3SLAM") { suite in
     "NewFactorGraph, sphere2500, 30 LM steps, 200 CGLS steps",
     settings: Iterations(1)
   ) {
-    var val = gridDataset.initialGuess
-    var graph = gridDataset.graph
+    var val = sphere2500Dataset.initialGuess
+    var graph = sphere2500Dataset.graph
     
     graph.store(NewPriorFactor3(TypedID(0), Pose3(Rot3.fromTangent(Vector3.zero), Vector3.zero)))
     

--- a/Sources/Benchmarks/Pose3SLAM.swift
+++ b/Sources/Benchmarks/Pose3SLAM.swift
@@ -49,7 +49,7 @@ let pose3SLAM = BenchmarkSuite(name: "Pose3SLAM") { suite in
   }
   
   var sphere2500Dataset =  try! G2OReader.G2ONewFactorGraph(g2oFile3D: try! cachedDataset("sphere2500.g2o"))
-  // Uses `NewFactorGraph` on the GTSAM sphere2500 dataset.
+  // Uses `NewFactorGraph` on the sphere2500 dataset.
   // The solvers are configured to run for a constant number of *LM steps*, except when the LM solver is
   // unable to progress even with maximum lambda.
   // The linear solver is 200 iterations of CGLS.

--- a/Sources/SwiftFusion/Geometry/Pose3.swift
+++ b/Sources/SwiftFusion/Geometry/Pose3.swift
@@ -204,7 +204,7 @@ extension Pose3Coordinate {
     let d = Pose3Coordinate.decomposed(tangentVector: v)
     return Pose3Coordinate.tangentVector(
       DecomposedTangentVector(
-        w: rot.unrotate(d.w) - rot.unrotate(t.cross(d.v)),
+        w: rot.unrotate(d.w - t.cross(d.v)),
         v: rot.unrotate(d.v)
       )
     )

--- a/Sources/SwiftFusion/Geometry/Pose3.swift
+++ b/Sources/SwiftFusion/Geometry/Pose3.swift
@@ -186,6 +186,31 @@ extension Pose3Coordinate: ManifoldCoordinate {
 
 }
 
+/// Methods related to the Lie group structure.
+extension Pose3Coordinate {
+  @differentiable(wrt: v)
+  public func Adjoint(_ v: Vector6) -> Vector6 {
+    let d = Pose3Coordinate.decomposed(tangentVector: v)
+    let rotW = rot.rotate(d.w)
+    return Pose3Coordinate.tangentVector(
+      DecomposedTangentVector(
+        w: rotW,
+        v: t.cross(rotW) + rot.rotate(d.v)
+      )
+    )
+  }
+
+  public func AdjointTranspose(_ v: Vector6) -> Vector6 {
+    let d = Pose3Coordinate.decomposed(tangentVector: v)
+    return Pose3Coordinate.tangentVector(
+      DecomposedTangentVector(
+        w: rot.unrotate(d.w) - rot.unrotate(t.cross(d.v)),
+        v: rot.unrotate(d.v)
+      )
+    )
+  }
+}
+
 extension Pose3: CustomStringConvertible {
   public var description: String {
     "Pose3(rot: \(coordinate.rot), t: \(coordinate.t))"

--- a/Tests/SwiftFusionTests/Geometry/Pose3Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Pose3Tests.swift
@@ -128,4 +128,32 @@ final class Pose3Tests: XCTestCase {
     let pose_1 = val[1, as: Pose3.self]
     assertAllKeyPathEqual(pose_1, p1, accuracy: 1e-2)
   }
+
+  /// Tests that the custom implementation of `Adjoint` is correct.
+  func testAdjoint() {
+    for _ in 0..<10 {
+      let pose = Pose3.fromTangent(Vector6(Tensor<Double>(randomNormal: [6])))
+      for v in Pose3.TangentVector.standardBasis {
+        assertEqual(
+          pose.Adjoint(v).tensor,
+          pose.coordinate.defaultAdjoint(v).tensor,
+          accuracy: 1e-10
+        )
+      }
+    }
+  }
+
+  /// Tests that the custom implementation of `AdjointTranspose` is correct.
+  func testAdjointTranspose() {
+    for _ in 0..<10 {
+      let pose = Pose3.fromTangent(Vector6(Tensor<Double>(randomNormal: [6])))
+      for v in Pose3.TangentVector.standardBasis {
+        assertEqual(
+          pose.AdjointTranspose(v).tensor,
+          pose.coordinate.defaultAdjointTranspose(v).tensor,
+          accuracy: 1e-10
+        )
+      }
+    }
+  }
 }


### PR DESCRIPTION
I changed the Pose3SLAM benchmark to use sphere2500 instead of pose3example because pose3example is so small that I was getting very noisy benchmark results.

Results from the sphere2500 benchmark:
* Before: 108s
* After: 20s