### PR TITLE
speed up the new factor graphs

### DIFF
--- a/Sources/SwiftFusion/Core/EuclideanVectorN.swift
+++ b/Sources/SwiftFusion/Core/EuclideanVectorN.swift
@@ -6,3 +6,31 @@ public protocol EuclideanVectorN: EuclideanVector {
   /// A standard basis of vectors.
   static var standardBasis: [Self] { get }
 }
+
+extension EuclideanVectorN {
+  /// Returns the result of calling `body` on the scalars of `self`.
+  func withUnsafeBufferPointer<R>(
+    _ body: (UnsafeBufferPointer<Double>) throws -> R
+  ) rethrows -> R {
+    return try withUnsafePointer(to: self) { p in
+      try body(
+          UnsafeBufferPointer<Double>(
+              start: UnsafeRawPointer(p)
+                  .assumingMemoryBound(to: Double.self),
+              count: Self.dimension))
+    }
+  }
+
+  /// Returns the result of calling `body` on the scalars of `self`.
+  mutating func withUnsafeMutableBufferPointer<R>(
+    _ body: (UnsafeMutableBufferPointer<Double>) throws -> R
+  ) rethrows -> R {
+    return try withUnsafeMutablePointer(to: &self) { p in
+      try body(
+          UnsafeMutableBufferPointer<Double>(
+              start: UnsafeMutableRawPointer(p)
+                  .assumingMemoryBound(to: Double.self),
+              count: Self.dimension))
+    }
+  }
+}

--- a/Sources/SwiftFusion/Inference/FactorsStorage.swift
+++ b/Sources/SwiftFusion/Inference/FactorsStorage.swift
@@ -118,6 +118,20 @@ protocol AnyLinearizableFactorStorageImplementation: AnyLinearizableFactorStorag
 /// APIs that depend on `LinearizableFactor` `Element` type.
 extension ArrayStorageImplementation where Element: NewLinearizableFactor {
   /// Returns the error vectors of the factors given the values of the adjacent variables.
+  @_specialize(where Self == LinearizableFactorArrayStorage<NewPriorFactor2>)
+  @_specialize(where Self == LinearizableFactorArrayStorage<NewPriorFactor3>)
+  @_specialize(where Self == LinearizableFactorArrayStorage<NewBetweenFactor2>)
+  @_specialize(where Self == LinearizableFactorArrayStorage<NewBetweenFactor3>)
+  @_specialize(where Self == GaussianFactorArrayStorage<ScalarJacobianFactor<Vector1>>)
+  @_specialize(where Self == GaussianFactorArrayStorage<ScalarJacobianFactor<Vector2>>)
+  @_specialize(where Self == GaussianFactorArrayStorage<ScalarJacobianFactor<Vector3>>)
+  @_specialize(where Self == GaussianFactorArrayStorage<ScalarJacobianFactor<Vector4>>)
+  @_specialize(where Self == GaussianFactorArrayStorage<ScalarJacobianFactor<Vector5>>)
+  @_specialize(where Self == GaussianFactorArrayStorage<ScalarJacobianFactor<Vector6>>)
+  @_specialize(where Self == GaussianFactorArrayStorage<JacobianFactor3x3_1>)
+  @_specialize(where Self == GaussianFactorArrayStorage<JacobianFactor3x3_2>)
+  @_specialize(where Self == GaussianFactorArrayStorage<JacobianFactor6x6_1>)
+  @_specialize(where Self == GaussianFactorArrayStorage<JacobianFactor6x6_2>)
   func errorVectors(at x: VariableAssignments)
     -> ArrayBuffer<VectorArrayStorage<Element.ErrorVector>>
   {
@@ -131,6 +145,10 @@ extension ArrayStorageImplementation where Element: NewLinearizableFactor {
   }
 
   /// Returns the linearized factors at the given values.
+  @_specialize(where Self == LinearizableFactorArrayStorage<NewPriorFactor2>)
+  @_specialize(where Self == LinearizableFactorArrayStorage<NewPriorFactor3>)
+  @_specialize(where Self == LinearizableFactorArrayStorage<NewBetweenFactor2>)
+  @_specialize(where Self == LinearizableFactorArrayStorage<NewBetweenFactor3>)
   func linearized(at x: VariableAssignments)
     -> ArrayBuffer<GaussianFactorArrayStorage<Element.Linearization>>
   {
@@ -248,8 +266,8 @@ extension ArrayStorageImplementation where Element: NewGaussianFactor {
   {
     Element.Variables.withVariableBufferBaseUnsafePointers(x) { varsBufs in
       withUnsafeMutableBufferPointer { factors in
-        ArrayBuffer(factors.map { factor in
-          factor.errorVector_linearComponent(Element.Variables(varsBufs, indices: factor.edges))
+        ArrayBuffer(factors.lazy.map { f in
+          f.errorVector_linearComponent(Element.Variables(varsBufs, indices: f.edges))
         })
       }
     }

--- a/Sources/SwiftFusionBenchmarks/Pose2SLAM.swift
+++ b/Sources/SwiftFusionBenchmarks/Pose2SLAM.swift
@@ -29,7 +29,7 @@ let pose2SLAM = BenchmarkSuite(name: "Pose2SLAM") { suite in
   // The linear solver is 100 iterations of CGLS.
   suite.benchmark(
     "NonlinearFactorGraph, Intel, 5 Gauss-Newton steps, 100 CGLS steps",
-    settings: Iterations(1)
+    settings: Iterations(1), TimeUnit(.ms)
   ) {
     var val = intelDataset.initialGuess
     for _ in 0..<5 {
@@ -58,7 +58,7 @@ let pose2SLAM = BenchmarkSuite(name: "Pose2SLAM") { suite in
   // The linear solver is 500 iterations of CGLS.
   suite.benchmark(
     "NewFactorGraph, Intel, 10 Gauss-Newton steps, 500 CGLS steps",
-    settings: Iterations(1)
+    settings: Iterations(1), TimeUnit(.ms)
   ) {
     var x = intelDatasetNew.initialGuess
     var graph = intelDatasetNew.graph

--- a/Sources/SwiftFusionBenchmarks/Pose3SLAM.swift
+++ b/Sources/SwiftFusionBenchmarks/Pose3SLAM.swift
@@ -27,7 +27,7 @@ let pose3SLAM = BenchmarkSuite(name: "Pose3SLAM") { suite in
   // The linear solver is 200 iterations of CGLS.
   suite.benchmark(
     "NonlinearFactorGraph, Pose3Example, 40 Gauss-Newton steps, 200 CGLS steps",
-    settings: Iterations(1)
+    settings: Iterations(1), TimeUnit(.ms)
   ) {
     var val = gridDataset_old.initialGuess
     gridDataset_old.graph += PriorFactor(0, Pose3())
@@ -55,7 +55,7 @@ let pose3SLAM = BenchmarkSuite(name: "Pose3SLAM") { suite in
   // The linear solver is 200 iterations of CGLS.
   suite.benchmark(
     "NewFactorGraph, sphere2500, 30 LM steps, 200 CGLS steps",
-    settings: Iterations(1)
+    settings: Iterations(1), TimeUnit(.ms)
   ) {
     var val = sphere2500Dataset.initialGuess
     var graph = sphere2500Dataset.graph


### PR DESCRIPTION
Adds more specializations, and changes some particularly hot code to use pointers instead of collections.

Makes Pose2SLAM ~4x faster and Pose3SLAM ~3x faster.

Before:
```
swift build -c release -Xswiftc -cross-module-optimization && .build/release/Benchmarks --filter NewFactorGraph
name                                                                    time             std        iterations
--------------------------------------------------------------------------------------------------------------
Pose2SLAM: NewFactorGraph, Intel, 10 Gauss-Newton steps, 500 CGLS steps  1868228204.0 ns ±   0.00 %          1
Pose3SLAM: NewFactorGraph, sphere2500, 30 LM steps, 200 CGLS steps      19669232876.0 ns ±   0.00 %          1
```

After:
```
swift build -c release -Xswiftc -cross-module-optimization && .build/release/Benchmarks --filter NewFactorGraph
name                                                                    time            std        iterations
-------------------------------------------------------------------------------------------------------------
Pose2SLAM: NewFactorGraph, Intel, 10 Gauss-Newton steps, 500 CGLS steps  444424233.0 ns ±   0.00 %          1
Pose3SLAM: NewFactorGraph, sphere2500, 30 LM steps, 200 CGLS steps      6116728990.0 ns ±   0.00 %          1
```