### PR TITLE
Migrate to new ArrayBuffer

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/saeta/penguin.git",
         "state": {
           "branch": "master",
-          "revision": "1586b9b88628fb772e7b1d6e79185dcf5e3d2c6d",
+          "revision": "4ea37a85ab75ddd5f02c395b9da535d6cbd66f20",
           "version": null
         }
       },
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/google/swift-benchmark.git",
         "state": {
           "branch": "master",
-          "revision": "66262f4f85cc2cd319f4aaae33368a14ea1c1dd9",
+          "revision": "3d24a938ea553a3977cfbf8199d42839c9061c3f",
           "version": null
         }
       },

--- a/Sources/SwiftFusion/Inference/PenguinExtensions.swift
+++ b/Sources/SwiftFusion/Inference/PenguinExtensions.swift
@@ -1,0 +1,55 @@
+// TODO: Move all these to Penguin.
+
+import PenguinStructures
+
+extension AnyArrayBuffer {
+  /// Appends `x`, returning the index of the appended element.
+  ///
+  /// - Requires: `self.elementType == T.self`.
+  mutating func unsafelyAppend<T>(_ x: T) -> Int {
+    unsafelyMutate(assumingElementType: Type<T>()) { $0.append(x) }
+  }
+}
+
+/// An `AnyArrayBuffer` dispatcher for elements that are not statically known to support any
+/// operations.
+// We can't use `AnyObject` for this because the bitcast at [1] fails with "Swift runtime failure:
+// Can't unsafeBitCast between types of different sizes" when trying to cast an `AnyArrayBuffer`
+// of some other dispatch to an `AnyArrayBuffer<AnyObject>`.
+//
+// [1] https://github.com/saeta/penguin/blob/47980eb5630ebfd7bc2a88a4a7a60a050dd01b0a/Sources/PenguinStructures/AnyArrayBuffer.swift#L64
+class AnyElementDispatch {}
+
+/// A type-erased array that is not statically known to support any operations.
+typealias AnyElementArrayBuffer = AnyArrayBuffer<AnyElementDispatch>
+
+extension AnyArrayBuffer where Dispatch == AnyElementDispatch {
+  /// Creates an instance from a typed buffer of `Element`
+  init<Element>(_ src: ArrayBuffer<Element>) {
+    self.init(
+      storage: src.storage,
+      dispatch: AnyElementDispatch.self)
+  }
+}
+
+extension ArrayBuffer {
+  /// Creates an instance with the given `count`, and capacity at least
+  /// `minimumCapacity`, and elements initialized by `initializeElements`,
+  /// which is passed the address of the (uninitialized) first element.
+  ///
+  /// - Requires: `initializeElements` initializes exactly `count` contiguous
+  ///   elements starting with the address it is passed.
+  public init(
+    count: Int,
+    minimumCapacity: Int = 0,
+    initializeElements:
+      (_ uninitializedElements: UnsafeMutablePointer<Element>) -> Void
+  ) {
+    // Work around the fact that `ArrayBuffer.init(storage:)` doesn't exist. We can just set
+    // `storage` directly without calling a different initializer first when we move this
+    // implementation to penguin.
+    self.init(minimumCapacity: 0)
+    self.storage = .init(
+      count: count, minimumCapacity: minimumCapacity, initializeElements: initializeElements)
+  }
+}

--- a/Tests/SwiftFusionTests/Inference/VariableAssignmentsTests.swift
+++ b/Tests/SwiftFusionTests/Inference/VariableAssignmentsTests.swift
@@ -1,0 +1,93 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import TensorFlow
+import XCTest
+
+import PenguinStructures
+import SwiftFusion
+
+class VariableAssignmentsTests: XCTestCase {
+  func testStoreAndSubscript() {
+    var x = VariableAssignments()
+
+    let intID = x.store(1)
+    XCTAssertEqual(x[intID], 1)
+
+    let doubleID = x.store(2.0)
+    XCTAssertEqual(x[doubleID], 2.0)
+
+    let vectorID = x.store(Vector2(3, 4))
+    XCTAssertEqual(x[vectorID], Vector2(3, 4))
+  }
+
+  func testTangentVectorZeros() {
+    var x = VariableAssignments()
+    _ = x.store(1)
+    _ = x.store(Vector1(2))
+    _ = x.store(Vector2(3, 4))
+
+    let t = x.tangentVectorZeros
+    // TODO: Assert that there are only 2 elements when there is some API for count.
+    XCTAssertEqual(t[TypedID<Vector1, Int>(0)], Vector1(0))
+    XCTAssertEqual(t[TypedID<Vector2, Int>(0)], Vector2(0, 0))
+  }
+
+  func testMove() {
+    var x = VariableAssignments()
+    _ = x.store(1)
+    let v1ID = x.store(Vector1(2))
+    let v2ID = x.store(Vector2(3, 4))
+
+    var t = VariableAssignments()
+    _ = t.store(Vector1(10))
+    _ = t.store(Vector2(20, 20))
+
+    x.move(along: t)
+    XCTAssertEqual(x[v1ID], Vector1(12))
+    XCTAssertEqual(x[v2ID], Vector2(23, 24))
+  }
+
+  func testSquaredNorm() {
+    var x = VariableAssignments()
+    _ = x.store(Vector1(2))
+    _ = x.store(Vector2(3, 4))
+    XCTAssertEqual(x.squaredNorm, 29)
+  }
+
+  func testScalarMultiply() {
+    var x = VariableAssignments()
+    let v1ID = x.store(Vector1(2))
+    let v2ID = x.store(Vector2(3, 4))
+
+    let r = 10 * x
+    XCTAssertEqual(r[v1ID], Vector1(20))
+    XCTAssertEqual(r[v2ID], Vector2(30, 40))
+  }
+
+  func testPlus() {
+    var x = VariableAssignments()
+    let v1ID = x.store(Vector1(2))
+    let v2ID = x.store(Vector2(3, 4))
+
+    var t = VariableAssignments()
+    _ = t.store(Vector1(10))
+    _ = t.store(Vector2(20, 20))
+
+    let r = x + t
+    XCTAssertEqual(r[v1ID], Vector1(12))
+    XCTAssertEqual(r[v2ID], Vector2(23, 24))
+  }
+}


### PR DESCRIPTION
Migrates everything to the new `ArrayBuffer` interface from https://github.com/saeta/penguin/pull/82.

The boilerplate in `ValuesStorage` and `FactorsStorage` feels simpler now, which is good!

Benchmarks before:
```
swift build -c release -Xswiftc -cross-module-optimization && .build/release/SwiftFusionBenchmarks --filter NewFactorGraph
name                                                                   time           std        iterations
-----------------------------------------------------------------------------------------------------------
Pose2SLAM.NewFactorGraph, Intel, 10 Gauss-Newton steps, 500 CGLS steps  456.792364 ms ±   0.00 %          1
Pose3SLAM.NewFactorGraph, sphere2500, 30 LM steps, 200 CGLS steps      5922.074432 ms ±   0.00 %          1
```

Benchmarks after:
```
swift build -c release -Xswiftc -cross-module-optimization && .build/release/SwiftFusionBenchmarks --filter NewFactorGraph
name                                                                   time           std        iterations
-----------------------------------------------------------------------------------------------------------
Pose2SLAM.NewFactorGraph, Intel, 10 Gauss-Newton steps, 500 CGLS steps  446.596137 ms ±   0.00 %          1
Pose3SLAM.NewFactorGraph, sphere2500, 30 LM steps, 200 CGLS steps      4950.754052 ms ±   0.00 %          1
```