### PR TITLE
fix LM convergence

### DIFF
--- a/Sources/SwiftFusion/Inference/NewFactorGraph.swift
+++ b/Sources/SwiftFusion/Inference/NewFactorGraph.swift
@@ -56,6 +56,16 @@ public struct NewFactorGraph {
     return storage.values.lazy.map { $0.errors(at: x).reduce(0, +) }.reduce(0, +)
   }
 
+  /// Returns the total error, at `x`, of all the linearizable factors.
+  public func linearizableError(at x: VariableAssignments) -> Double {
+    return storage.values.reduce(0) { (result, factors) in
+      guard let linearizableFactors = factors.cast(to: AnyLinearizableFactorStorage.self) else {
+        return result
+      }
+      return result + linearizableFactors.errors(at: x).reduce(0, +)
+    }
+  }
+
   /// Returns the error vectors, at `x`, of all the linearizable factors.
   public func errorVectors(at x: VariableAssignments) -> AllVectors {
     return AllVectors(storage: storage.compactMapValues { factors in


### PR DESCRIPTION
Fixes some problems with LM convergence in some cases:
* LM was calling CGLS with precision 0, which caused numerical errors to get really big when CGLS tried to optimize things beyond a sensible precision. I changed the precision to 1e-10. (Maybe it should be configurable).
* LM was comparing nonlinear error with linearized error to calculate "model fidelity". LM was using `graph.errors(at: x)` to calculate nonlinear error. But `graph.errors(at: x)` includes errors from discrete factors that do not appear in the linearized error, so it's not comparable with the linearized error. I added `graph.linearizableErrors(at: x)` that computes nonlinear errors for all the linearizable factors.