### PR TITLE
add method for getting factors from factor graph

### DIFF
--- a/Sources/SwiftFusion/Inference/FactorGraph.swift
+++ b/Sources/SwiftFusion/Inference/FactorGraph.swift
@@ -55,6 +55,14 @@ public struct FactorGraph {
     ].unsafelyAppend(factor)
   }
 
+  /// Returns the factors of type `T`.
+  public func factors<T>(type _: T.Type) -> ArrayBuffer<T> {
+    guard let anyArrayBuffer = storage[ObjectIdentifier(T.self)] else {
+      return ArrayBuffer<T>()
+    }
+    return ArrayBuffer(unsafelyDowncasting: anyArrayBuffer)
+  }
+
   /// Returns the total error, at `x`, of all the factors.
   public func error(at x: VariableAssignments) -> Double {
     return storage.values.lazy.map { $0.errors(at: x).reduce(0, +) }.reduce(0, +)

--- a/Sources/SwiftFusion/Inference/VariableAssignments.swift
+++ b/Sources/SwiftFusion/Inference/VariableAssignments.swift
@@ -21,7 +21,7 @@ import PenguinStructures
 ///   logical value of that type.
 ///
 /// Note: This is just a temporary placeholder until we get the real `TypedID` in penguin.
-public struct TypedID<Value, PerTypeID: Equatable> {
+public struct TypedID<Value, PerTypeID: Equatable>: Equatable {
   /// A specifier of which logical value of type `value` is being identified.
   public let perTypeID: PerTypeID
 

--- a/Tests/SwiftFusionTests/Inference/FactorGraphTests.swift
+++ b/Tests/SwiftFusionTests/Inference/FactorGraphTests.swift
@@ -20,6 +20,37 @@ import PenguinStructures
 import SwiftFusion
 
 class FactorGraphTests: XCTestCase {
+  /// Tests that we can read factors from a factor graph.
+  func testGetFactors() {
+    let pose1ID = TypedID<Pose2, Int>(0)
+    let pose2ID = TypedID<Pose2, Int>(1)
+
+    var graph = FactorGraph()
+    graph.store(PriorFactor2(pose1ID, Pose2(1, 2, 3)))
+    graph.store(PriorFactor2(pose2ID, Pose2(4, 5, 6)))
+    graph.store(BetweenFactor2(pose1ID, pose2ID, Pose2(7, 8, 9)))
+
+    XCTAssertEqual(
+      graph.factors(type: PriorFactor2.self).map { $0.edges },
+      [Tuple1(pose1ID), Tuple1(pose2ID)]
+    )
+    XCTAssertEqual(
+      graph.factors(type: PriorFactor2.self).map { $0.prior },
+      [Pose2(1, 2, 3), Pose2(4, 5, 6)]
+    )
+
+    XCTAssertEqual(
+      graph.factors(type: BetweenFactor2.self).map { $0.edges },
+      [Tuple2(pose1ID, pose2ID)]
+    )
+    XCTAssertEqual(
+      graph.factors(type: BetweenFactor2.self).map { $0.difference },
+      [Pose2(7, 8, 9)]
+    )
+
+    XCTAssertEqual(graph.factors(type: PriorFactor3.self).count, 0)
+  }
+
   func testSimplePose2SLAM() {
     var x = VariableAssignments()
     let pose1ID = x.store(Pose2(Rot2(0.2), Vector2(0.5, 0.0)))


### PR DESCRIPTION
Example usage:
```
for f in graph.factors(type: PriorFactor2.self) {
  print(f)
}
```