### PR TITLE
reduce linearization boilerplate

### DIFF
--- a/Examples/Pose3SLAMG2O/main.swift
+++ b/Examples/Pose3SLAMG2O/main.swift
@@ -133,7 +133,7 @@ func main() {
   var val = problem.initialGuess
   var graph = problem.graph
   
-  graph.store(PriorFactor3(TypedID(0), Pose3(Rot3.fromTangent(Vector3.zero), Vector3.zero)))
+  graph.store(PriorFactor(TypedID(0), Pose3(Rot3.fromTangent(Vector3.zero), Vector3.zero)))
   
   var optimizer = LM(precision: 1e-1, max_iteration: 100)
   

--- a/Sources/SwiftFusion/Datasets/G2OReader.swift
+++ b/Sources/SwiftFusion/Datasets/G2OReader.swift
@@ -65,7 +65,7 @@ public enum G2OReader {
           assert(typedID.perTypeID == id)
           variableId.append(typedID)
         case .measurement(frameIndex: let id1, measuredIndex: let id2, pose: let difference):
-          graph.store(BetweenFactor2(TypedID(id1), TypedID(id2), difference))
+          graph.store(BetweenFactor(TypedID(id1), TypedID(id2), difference))
         }
       }
     }
@@ -80,9 +80,9 @@ public enum G2OReader {
           variableId.append(typedID)
         case .measurement(frameIndex: let id1, measuredIndex: let id2, pose: let difference):
           if chordal {
-            graph.store(BetweenFactorAlternative3(TypedID(id1), TypedID(id2), difference))
+            graph.store(BetweenFactorAlternative(TypedID(id1), TypedID(id2), difference))
           } else {
-            graph.store(BetweenFactor3(TypedID(id1), TypedID(id2), difference))
+            graph.store(BetweenFactor(TypedID(id1), TypedID(id2), difference))
           }
         }
       }

--- a/Sources/SwiftFusion/Inference/AllVectors.swift
+++ b/Sources/SwiftFusion/Inference/AllVectors.swift
@@ -67,7 +67,7 @@ extension AllVectors {
   }
 
   /// Returns the `ErrorVector` from the `perFactorID`-th factor of type `F`.
-  public subscript<F: LinearizableFactor>(_ perFactorID: Int, factorType _: F.Type) -> F.ErrorVector {
+  public subscript<F: VectorFactor>(_ perFactorID: Int, factorType _: F.Type) -> F.ErrorVector {
     let array = storage[ObjectIdentifier(F.self)].unsafelyUnwrapped
     return ArrayBuffer<F.ErrorVector>(unsafelyDowncasting: array).withUnsafeBufferPointer { b in
       b[perFactorID]

--- a/Sources/SwiftFusion/Inference/BetweenFactor.swift
+++ b/Sources/SwiftFusion/Inference/BetweenFactor.swift
@@ -15,14 +15,7 @@
 import PenguinStructures
 
 /// A factor that specifies a difference between two poses.
-///
-/// `JacobianRows` specifies the `Rows` parameter of the Jacobian of this factor. See the
-/// documentation on `JacobianFactor.jacobian` for more information. Use the typealiases below to
-/// avoid specifying this type parameter every time you create an instance.
-public struct BetweenFactor<Pose: LieGroup, JacobianRows: FixedSizeArray>:
-  LinearizableFactor
-  where JacobianRows.Element == Tuple2<Pose.TangentVector, Pose.TangentVector>
-{
+public struct BetweenFactor<Pose: LieGroup>: LinearizableFactor {
   public typealias Variables = Tuple2<Pose, Pose>
 
   public let edges: Variables.Indices
@@ -46,18 +39,8 @@ public struct BetweenFactor<Pose: LieGroup, JacobianRows: FixedSizeArray>:
     return errorVector(at: x).squaredNorm
   }
 
+  @differentiable
   public func errorVector(at x: Variables) -> Pose.TangentVector {
     return errorVector(x.head, x.tail.head)
   }
-
-  public typealias Linearization = JacobianFactor<JacobianRows, ErrorVector>
-  public func linearized(at x: Variables) -> Linearization {
-    Linearization(linearizing: errorVector, at: x, edges: edges)
-  }
 }
-
-/// A between factor on `Pose2`.
-public typealias BetweenFactor2 = BetweenFactor<Pose2, Array3<Tuple2<Vector3, Vector3>>>
-
-/// A between factor on `Pose3`.
-public typealias BetweenFactor3 = BetweenFactor<Pose3, Array6<Tuple2<Vector6, Vector6>>>

--- a/Sources/SwiftFusion/Inference/BetweenFactorAlternative.swift
+++ b/Sources/SwiftFusion/Inference/BetweenFactorAlternative.swift
@@ -15,10 +15,7 @@
 import PenguinStructures
 
 /// A BetweenFactor alternative that uses the Chordal (Frobenious) norm on rotation for Pose3
-public struct BetweenFactorAlternative<JacobianRows: FixedSizeArray>:
-  LinearizableFactor
-  where JacobianRows.Element == Tuple2<Pose3.TangentVector, Pose3.TangentVector>
-{
+public struct BetweenFactorAlternative: LinearizableFactor {
   public typealias Variables = Tuple2<Pose3, Pose3>
 
   public let edges: Variables.Indices
@@ -44,13 +41,9 @@ public struct BetweenFactorAlternative<JacobianRows: FixedSizeArray>:
     return errorVector(at: x).squaredNorm
   }
 
+  @differentiable
   public func errorVector(at x: Variables) -> ErrorVector {
     return errorVector(x.head, x.tail.head)
-  }
-
-  public typealias Linearization = JacobianFactor<JacobianRows, ErrorVector>
-  public func linearized(at x: Variables) -> Linearization {
-    Linearization(linearizing: errorVector, at: x, edges: edges)
   }
 }
 
@@ -65,6 +58,3 @@ public typealias JacobianFactor12x6_1 = JacobianFactor<Array12<Tuple1<Vector6>>,
 
 /// A Jacobian factor with 2 6-dimensional inputs and a 12-dimensional error vector.
 public typealias JacobianFactor12x6_2 = JacobianFactor<Array12<Tuple2<Vector6, Vector6>>, Vector12>
-
-/// A between factor on `Pose3`.
-public typealias BetweenFactorAlternative3 = BetweenFactorAlternative<Array12<Tuple2<Vector6, Vector6>>>

--- a/Sources/SwiftFusion/Inference/Factor.swift
+++ b/Sources/SwiftFusion/Inference/Factor.swift
@@ -22,34 +22,63 @@ public protocol Factor {
   /// The IDs of the variables adjacent to this factor.
   var edges: Variables.Indices { get }
 
-  /// Returns the error given the values of the adjacent variables.
+  /// Returns the error at `x`.
+  ///
+  /// This is typically interpreted as negative log-likelihood.
   func error(at x: Variables) -> Double
 }
 
-/// A factor with an error vector, which can be linearized around any point.
-public protocol LinearizableFactor: Factor {
+/// A factor whose `error` is a function of a vector-valued `errorVector` function.
+public protocol VectorFactor: Factor {
   /// The type of the error vector.
   // TODO: Add a description of what an error vector is.
   associatedtype ErrorVector: EuclideanVectorN
 
-  /// Returns the error vector given the values of the adjacent variables.
+  /// Returns the error vector at `x`.
   func errorVector(at x: Variables) -> ErrorVector
 
-  /// The type of the linearized factor.
-  associatedtype Linearization: GaussianFactor
+  /// A factor whose variables are the `Differentiable` subset of `Self`'s variables.
+  associatedtype LinearizableComponent: LinearizableFactor
+  where LinearizableComponent.ErrorVector == ErrorVector
 
-  /// Returns a factor whose `errorVector` linearly approximates `self`'s `errorVector` around the
-  /// given point.
-  func linearized(at x: Variables) -> Linearization
+  /// Returns the linearizable component of `self` at `x`, and returns the `Differentiable` subset
+  /// of `x`.
+  func linearizableComponent(at x: Variables)
+    -> (LinearizableComponent, LinearizableComponent.Variables)
 }
 
+/// A factor whose `errorVector` function is linearizable with respect to all the variables.
+public protocol LinearizableFactor: VectorFactor
+where Variables: DifferentiableVariableTuple, Variables.TangentVector: EuclideanVectorN
+{
+  /// Returns the error vector given the values of the adjacent variables.
+  @differentiable
+  func errorVector(at x: Variables) -> ErrorVector
+}
+
+extension LinearizableFactor {
+  public func linearizableComponent(at x: Variables) -> (Self, Variables) {
+    return (self, x)
+  }
+}
+
+/// Do not use this; it is a workaround for a Swift compiler limitation.
+public protocol GaussianFactor_: Factor where Variables: EuclideanVectorN {}
+
 /// A factor whose `errorVector` is a linear function of the variables, plus a constant.
-public protocol GaussianFactor: LinearizableFactor where Variables: EuclideanVectorN {
+public protocol GaussianFactor: LinearizableFactor, GaussianFactor_ {
   /// The linear component of `errorVector`.
   func errorVector_linearComponent(_ x: Variables) -> ErrorVector
 
   /// The adjoint (aka "transpose" or "dual") of the linear component of `errorVector`.
   func errorVector_linearComponent_adjoint(_ y: ErrorVector) -> Variables
+}
+
+/// A linear approximation of a linearizable factor.
+public protocol LinearApproximationFactor: GaussianFactor {
+  /// Creates a factor that linearly approximates `f` at `x`.
+  init<F: LinearizableFactor>(linearizing f: F, at x: F.Variables)
+  where F.Variables.TangentVector == Variables, F.ErrorVector == ErrorVector
 }
 
 // MARK: - `VariableTuple`.
@@ -193,27 +222,23 @@ extension Tuple: VariableTuple where Tail: VariableTuple {
 }
 
 /// Tuple of differentiable variable types suitable for a factor.
-protocol DifferentiableVariableTuple: VariableTuple {
-  /// A tuple of `TypedID`s referring to variables adjacent to a factor.
-  associatedtype TangentIndices: TupleProtocol
-
+public protocol DifferentiableVariableTuple: Differentiable & VariableTuple
+where TangentVector: DifferentiableVariableTuple {
   /// Returns the indices of the linearized variables corresponding to `indices` in the linearized
   /// factor graph.
-  static func linearized(_ indices: Indices) -> TangentIndices
+  static func linearized(_ indices: Indices) -> TangentVector.Indices
 }
 
 extension Empty: DifferentiableVariableTuple {
-  typealias TangentIndices = Self
-  static func linearized(_ indices: Indices) -> TangentIndices {
+  public static func linearized(_ indices: Indices) -> TangentVector.Indices {
     indices
   }
 }
 
 extension Tuple: DifferentiableVariableTuple
 where Head: Differentiable, Tail: DifferentiableVariableTuple {
-  typealias TangentIndices = Tuple<TypedID<Head.TangentVector, Int>, Tail.TangentIndices>
-  static func linearized(_ indices: Indices) -> TangentIndices {
-    TangentIndices(
+  public static func linearized(_ indices: Indices) -> TangentVector.Indices {
+    TangentVector.Indices(
       head: TypedID<Head.TangentVector, Int>(indices.head.perTypeID),
       tail: Tail.linearized(indices.tail)
     )

--- a/Sources/SwiftFusion/Inference/FactorGraph.swift
+++ b/Sources/SwiftFusion/Inference/FactorGraph.swift
@@ -36,12 +36,12 @@ public struct FactorGraph {
   }
 
   /// Stores `factor` in the graph.
-  public mutating func store<T: LinearizableFactor>(_ factor: T) {
+  public mutating func store<T: VectorFactor>(_ factor: T) {
     _ = storage[
       ObjectIdentifier(T.self),
       default: AnyFactorArrayBuffer(
         // Note: This is a safe upcast.
-        unsafelyCasting: AnyLinearizableFactorArrayBuffer(ArrayBuffer<T>()))
+        unsafelyCasting: AnyVectorFactorArrayBuffer(ArrayBuffer<T>()))
     ].unsafelyAppend(factor)
   }
 
@@ -71,7 +71,7 @@ public struct FactorGraph {
   /// Returns the total error, at `x`, of all the linearizable factors.
   public func linearizableError(at x: VariableAssignments) -> Double {
     return storage.values.reduce(0) { (result, factors) in
-      guard let linearizableFactors = AnyLinearizableFactorArrayBuffer(factors) else {
+      guard let linearizableFactors = AnyVectorFactorArrayBuffer(factors) else {
         return result
       }
       return result + linearizableFactors.errors(at: x).reduce(0, +)
@@ -81,7 +81,7 @@ public struct FactorGraph {
   /// Returns the error vectors, at `x`, of all the linearizable factors.
   public func errorVectors(at x: VariableAssignments) -> AllVectors {
     return AllVectors(storage: storage.compactMapValues { factors in
-      guard let linearizableFactors = AnyLinearizableFactorArrayBuffer(factors) else {
+      guard let linearizableFactors = AnyVectorFactorArrayBuffer(factors) else {
         return nil
       }
       return AnyArrayBuffer(linearizableFactors.errorVectors(at: x))
@@ -103,7 +103,7 @@ public struct FactorGraph {
   public func linearized(at x: VariableAssignments) -> GaussianFactorGraph {
     return GaussianFactorGraph(
       storage: storage.compactMapValues { factors in
-        AnyLinearizableFactorArrayBuffer(factors)?.linearized(at: x)
+        AnyVectorFactorArrayBuffer(factors)?.linearized(at: x)
       },
       zeroValues: x.tangentVectorZeros
     )

--- a/Sources/SwiftFusion/Inference/FactorsStorage.swift
+++ b/Sources/SwiftFusion/Inference/FactorsStorage.swift
@@ -29,9 +29,9 @@ extension ArrayStorage where Element: Factor {
   }
 }
 
-// MARK: - Algorithms on arrays of `LinearizableFactor`s.
+// MARK: - Algorithms on arrays of `VectorFactor`s.
 
-extension ArrayStorage where Element: LinearizableFactor {
+extension ArrayStorage where Element: VectorFactor {
   /// Returns the error vectors, at `x`, of the factors.
   func errorVectors(at x: VariableAssignments) -> ArrayBuffer<Element.ErrorVector> {
     Element.Variables.withVariableBufferBaseUnsafePointers(x) { varsBufs in
@@ -42,10 +42,16 @@ extension ArrayStorage where Element: LinearizableFactor {
   }
 
   /// Returns the linearized factors at `x`.
-  func linearized(at x: VariableAssignments) -> ArrayBuffer<Element.Linearization> {
+  func linearized<Linearization: LinearApproximationFactor>(at x: VariableAssignments)
+    -> ArrayBuffer<Linearization>
+  where Linearization.Variables == Element.LinearizableComponent.Variables.TangentVector,
+        Linearization.ErrorVector == Element.ErrorVector
+  {
     Element.Variables.withVariableBufferBaseUnsafePointers(x) { varsBufs in
       .init(lazy.map { f in
-        f.linearized(at: Element.Variables(varsBufs, indices: f.edges))
+        let (fLinearizable, xLinearizable) =
+          f.linearizableComponent(at: Element.Variables(varsBufs, indices: f.edges))
+        return Linearization(linearizing: fLinearizable, at: xLinearizable)
       })
     }
   }
@@ -54,6 +60,15 @@ extension ArrayStorage where Element: LinearizableFactor {
 // MARK: - Algorithms on arrays of `GaussianFactor`s.
 
 extension ArrayStorage where Element: GaussianFactor {
+  /// Returns the error vectors, at `x`, of the factors.
+  func errorVectors(at x: VariableAssignments) -> ArrayBuffer<Element.ErrorVector> {
+    Element.Variables.withVariableBufferBaseUnsafePointers(x) { varsBufs in
+      .init(lazy.map { f in
+        f.errorVector(at: Element.Variables(varsBufs, indices: f.edges))
+      })
+    }
+  }
+
   /// Returns the linear component of `errorVectors` at `x`.
   func errorVectors_linearComponent(_ x: VariableAssignments) -> ArrayBuffer<Element.ErrorVector> {
     Element.Variables.withVariableBufferBaseUnsafePointers(x) { varsBufs in
@@ -112,7 +127,7 @@ class FactorArrayDispatch: AnyElementDispatch {
   /// Returns the errors, at `x`, of the factors in `storage`.
   ///
   /// - Requires: `storage` is the address of an `ArrayStorage` whose `Element` has a
-  ///   subclass-specific `LinearizableFactor` type.
+  ///   subclass-specific `VectorFactor` type.
   class func errors(_ storage: UnsafeRawPointer, at x: VariableAssignments) -> [Double] {
     fatalError("implement as in FactorArrayDispatch_")
   }
@@ -147,47 +162,51 @@ extension AnyArrayBuffer where Dispatch: FactorArrayDispatch {
   }
 }
 
-// MARK: - Type-erased arrays of `LinearizableFactor`s.
+// MARK: - Type-erased arrays of `VectorFactor`s.
 
-typealias AnyLinearizableFactorArrayBuffer = AnyArrayBuffer<LinearizableFactorArrayDispatch>
+typealias AnyVectorFactorArrayBuffer = AnyArrayBuffer<VectorFactorArrayDispatch>
 
-/// An `AnyArrayBuffer` dispatcher that provides algorithm implementations for `LinearizableFactor`
+/// An `AnyArrayBuffer` dispatcher that provides algorithm implementations for `VectorFactor`
 /// elements.
-class LinearizableFactorArrayDispatch: FactorArrayDispatch {
+class VectorFactorArrayDispatch: FactorArrayDispatch {
   /// Returns the error vectors, at `x`, of the factors in `storage`.
   ///
   /// - Requires: `storage` is the address of an `ArrayStorage` whose `Element` has a
-  ///   subclass-specific `LinearizableFactor` type.
+  ///   subclass-specific `VectorFactor` type.
   class func errorVectors(_ storage: UnsafeRawPointer, at x: VariableAssignments)
     -> AnyVectorArrayBuffer
   {
-    fatalError("implement as in LinearizableFactorArrayDispatch_")
+    fatalError("implement as in VectorFactorArrayDispatch_")
   }
 
   /// Returns the linearizations, at `x`, of the factors in `storage`.
   ///
   /// - Requires: `storage` is the address of an `ArrayStorage` whose `Element` has a
-  ///   subclass-specific `LinearizableFactor` type.
+  ///   subclass-specific `VectorFactor` type.
   class func linearized(_ storage: UnsafeRawPointer, at x: VariableAssignments)
     -> AnyGaussianFactorArrayBuffer
   {
-    fatalError("implement as in LinearizableFactorArrayDispatch_")
+    fatalError("implement as in VectorFactorArrayDispatch_")
   }
 }
 
 /// An `AnyArrayBuffer` dispatcher that provides algorithm implementations for a
-/// specific `LinearizableFactor` element type.
-class LinearizableFactorArrayDispatch_<Element: LinearizableFactor>
-  : LinearizableFactorArrayDispatch, AnyArrayDispatch
+/// specific `VectorFactor` element type.
+class VectorFactorArrayDispatch_<
+  Element: VectorFactor,
+  Linearization: LinearApproximationFactor
+>: VectorFactorArrayDispatch, AnyArrayDispatch
+where Linearization.Variables == Element.LinearizableComponent.Variables.TangentVector,
+      Linearization.ErrorVector == Element.ErrorVector
 {
   /// Returns the errors, at `x`, of the factors in `storage`.
   ///
   /// - Requires: `storage` is the address of an `ArrayStorage<Element>`.
-  @_specialize(where Element == BetweenFactor2)
-  @_specialize(where Element == BetweenFactor3)
-  @_specialize(where Element == BetweenFactorAlternative3)
-  @_specialize(where Element == PriorFactor2)
-  @_specialize(where Element == PriorFactor3)
+  @_specialize(where Element == BetweenFactor<Pose2>, Linearization == JacobianFactor3x3_2)
+  @_specialize(where Element == BetweenFactor<Pose3>, Linearization == JacobianFactor6x6_2)
+  @_specialize(where Element == BetweenFactorAlternative, Linearization == JacobianFactor12x6_2)
+  @_specialize(where Element == PriorFactor<Pose2>, Linearization == JacobianFactor3x3_1)
+  @_specialize(where Element == PriorFactor<Pose3>, Linearization == JacobianFactor6x6_1)
   override class func errors(_ storage: UnsafeRawPointer, at x: VariableAssignments) -> [Double] {
     asStorage(storage).errors(at: x)
   }
@@ -195,11 +214,11 @@ class LinearizableFactorArrayDispatch_<Element: LinearizableFactor>
   /// Returns the error vectors, at `x`, of the factors in `storage`.
   ///
   /// - Requires: `storage` is the address of an `ArrayStorage<Element>`.
-  @_specialize(where Element == BetweenFactor2)
-  @_specialize(where Element == BetweenFactor3)
-  @_specialize(where Element == BetweenFactorAlternative3)
-  @_specialize(where Element == PriorFactor2)
-  @_specialize(where Element == PriorFactor3)
+  @_specialize(where Element == BetweenFactor<Pose2>, Linearization == JacobianFactor3x3_2)
+  @_specialize(where Element == BetweenFactor<Pose3>, Linearization == JacobianFactor6x6_2)
+  @_specialize(where Element == BetweenFactorAlternative, Linearization == JacobianFactor12x6_2)
+  @_specialize(where Element == PriorFactor<Pose2>, Linearization == JacobianFactor3x3_1)
+  @_specialize(where Element == PriorFactor<Pose3>, Linearization == JacobianFactor6x6_1)
   override class func errorVectors(_ storage: UnsafeRawPointer, at x: VariableAssignments)
     -> AnyVectorArrayBuffer
   {
@@ -209,28 +228,128 @@ class LinearizableFactorArrayDispatch_<Element: LinearizableFactor>
   /// Returns the linearizations, at `x`, of the factors in `storage`.
   ///
   /// - Requires: `storage` is the address of an `ArrayStorage<Element>`.
-  @_specialize(where Element == BetweenFactor2)
-  @_specialize(where Element == BetweenFactor3)
-  @_specialize(where Element == BetweenFactorAlternative3)
-  @_specialize(where Element == PriorFactor2)
-  @_specialize(where Element == PriorFactor3)
+  @_specialize(where Element == BetweenFactor<Pose2>, Linearization == JacobianFactor3x3_2)
+  @_specialize(where Element == BetweenFactor<Pose3>, Linearization == JacobianFactor6x6_2)
+  @_specialize(where Element == BetweenFactorAlternative, Linearization == JacobianFactor12x6_2)
+  @_specialize(where Element == PriorFactor<Pose2>, Linearization == JacobianFactor3x3_1)
+  @_specialize(where Element == PriorFactor<Pose3>, Linearization == JacobianFactor6x6_1)
   override class func linearized(_ storage: UnsafeRawPointer, at x: VariableAssignments)
     -> AnyGaussianFactorArrayBuffer
   {
-    .init(asStorage(storage).linearized(at: x))
+    .init(asStorage(storage).linearized(at: x) as ArrayBuffer<Linearization>)
   }
 }
 
-extension AnyArrayBuffer where Dispatch == LinearizableFactorArrayDispatch {
+extension AnyArrayBuffer where Dispatch == VectorFactorArrayDispatch {
   /// Creates an instance from a typed buffer of `Element`
-  init<Element: LinearizableFactor>(_ src: ArrayBuffer<Element>) {
-    self.init(
-      storage: src.storage,
-      dispatch: LinearizableFactorArrayDispatch_<Element>.self)
+  init<Element: VectorFactor>(_ src: ArrayBuffer<Element>) {
+    let dispatch: VectorFactorArrayDispatch.Type
+    switch Element.ErrorVector.dimension {
+    case 1:
+      dispatch = VectorFactorArrayDispatch_<
+        Element,
+        JacobianFactor<
+          Array1<Element.LinearizableComponent.Variables.TangentVector>,
+          Element.ErrorVector
+        >
+      >.self
+    case 2:
+      dispatch = VectorFactorArrayDispatch_<
+        Element,
+        JacobianFactor<
+          Array2<Element.LinearizableComponent.Variables.TangentVector>,
+          Element.ErrorVector
+        >
+      >.self
+    case 3:
+      dispatch = VectorFactorArrayDispatch_<
+        Element,
+        JacobianFactor<
+          Array3<Element.LinearizableComponent.Variables.TangentVector>,
+          Element.ErrorVector
+        >
+      >.self
+    case 4:
+      dispatch = VectorFactorArrayDispatch_<
+        Element,
+        JacobianFactor<
+          Array4<Element.LinearizableComponent.Variables.TangentVector>,
+          Element.ErrorVector
+        >
+      >.self
+    case 5:
+      dispatch = VectorFactorArrayDispatch_<
+        Element,
+        JacobianFactor<
+          Array5<Element.LinearizableComponent.Variables.TangentVector>,
+          Element.ErrorVector
+        >
+      >.self
+    case 6:
+      dispatch = VectorFactorArrayDispatch_<
+        Element,
+        JacobianFactor<
+          Array6<Element.LinearizableComponent.Variables.TangentVector>,
+          Element.ErrorVector
+        >
+      >.self
+    case 7:
+      dispatch = VectorFactorArrayDispatch_<
+        Element,
+        JacobianFactor<
+          Array7<Element.LinearizableComponent.Variables.TangentVector>,
+          Element.ErrorVector
+        >
+      >.self
+    case 8:
+      dispatch = VectorFactorArrayDispatch_<
+        Element,
+        JacobianFactor<
+          Array8<Element.LinearizableComponent.Variables.TangentVector>,
+          Element.ErrorVector
+        >
+      >.self
+    case 9:
+      dispatch = VectorFactorArrayDispatch_<
+        Element,
+        JacobianFactor<
+          Array9<Element.LinearizableComponent.Variables.TangentVector>,
+          Element.ErrorVector
+        >
+      >.self
+    case 10:
+      dispatch = VectorFactorArrayDispatch_<
+        Element,
+        JacobianFactor<
+          Array10<Element.LinearizableComponent.Variables.TangentVector>,
+          Element.ErrorVector
+        >
+      >.self
+    case 11:
+      dispatch = VectorFactorArrayDispatch_<
+        Element,
+        JacobianFactor<
+          Array11<Element.LinearizableComponent.Variables.TangentVector>,
+          Element.ErrorVector
+        >
+      >.self
+    case 12:
+      dispatch = VectorFactorArrayDispatch_<
+        Element,
+        JacobianFactor<
+          Array12<Element.LinearizableComponent.Variables.TangentVector>,
+          Element.ErrorVector
+        >
+      >.self
+    default:
+      fatalError("ErrorVector dimension \(Element.ErrorVector.dimension) not implemented")
+    }
+
+    self.init(storage: src.storage, dispatch: dispatch)
   }
 }
 
-extension AnyArrayBuffer where Dispatch: LinearizableFactorArrayDispatch {
+extension AnyArrayBuffer where Dispatch: VectorFactorArrayDispatch {
   /// Returns the error vectors, at `x`, of the factors.
   func errorVectors(at x: VariableAssignments) -> AnyVectorArrayBuffer {
     withUnsafePointer(to: storage) { dispatch.errorVectors($0, at: x) }
@@ -248,7 +367,7 @@ typealias AnyGaussianFactorArrayBuffer = AnyArrayBuffer<GaussianFactorArrayDispa
 
 /// An `AnyArrayBuffer` dispatcher that provides algorithm implementations for `GaussianFactor`
 /// elements.
-class GaussianFactorArrayDispatch: LinearizableFactorArrayDispatch {
+class GaussianFactorArrayDispatch: VectorFactorArrayDispatch {
   /// Returns the linear component of `errorVectors` at `x`.
   ///
   /// - Requires: `storage` is the address of an `ArrayStorage` whose `Element` has a
@@ -359,7 +478,9 @@ class GaussianFactorArrayDispatch_<Element: GaussianFactor>
   override class func linearized(_ storage: UnsafeRawPointer, at x: VariableAssignments)
     -> AnyGaussianFactorArrayBuffer
   {
-    .init(asStorage(storage).linearized(at: x))
+    // Gaussian factors are linearizations of themselves, so we can just return the factors
+    // unmodified.
+    .init(ArrayBuffer(asStorage(storage)))
   }
 
   /// Returns the linear component of `errorVectors` at `x`.
@@ -439,6 +560,11 @@ extension AnyArrayBuffer where Dispatch == GaussianFactorArrayDispatch {
 }
 
 extension AnyArrayBuffer where Dispatch: GaussianFactorArrayDispatch {
+  /// Returns the error vectors, at `x`, of the factors.
+  func errorVectors(at x: VariableAssignments) -> AnyVectorArrayBuffer {
+    withUnsafePointer(to: storage) { dispatch.errorVectors($0, at: x) }
+  }
+
   /// Returns the linear component of `errorVectors` at `x`.
   func errorVectors_linearComponent(_ x: VariableAssignments) -> AnyVectorArrayBuffer {
     withUnsafePointer(to: storage) { dispatch.errorVectors_linearComponent($0, x) }

--- a/Sources/SwiftFusion/Inference/PriorFactor.swift
+++ b/Sources/SwiftFusion/Inference/PriorFactor.swift
@@ -15,14 +15,7 @@
 import PenguinStructures
 
 /// A factor that specifies a prior on a pose.
-///
-/// `JacobianRows` specifies the `Rows` parameter of the Jacobian of this factor. See the
-/// documentation on `JacobianFactor.jacobian` for more information. Use the typealiases below to
-/// avoid specifying this type parameter every time you create an instance.
-public struct PriorFactor<Pose: LieGroup, JacobianRows: FixedSizeArray>:
-  LinearizableFactor
-  where JacobianRows.Element == Tuple1<Pose.TangentVector>
-{
+public struct PriorFactor<Pose: LieGroup>: LinearizableFactor {
   public typealias Variables = Tuple1<Pose>
 
   public let edges: Variables.Indices
@@ -45,18 +38,8 @@ public struct PriorFactor<Pose: LieGroup, JacobianRows: FixedSizeArray>:
     return errorVector(at: x).squaredNorm
   }
 
+  @differentiable
   public func errorVector(at x: Variables) -> Pose.TangentVector {
     return errorVector(x.head)
   }
-
-  public typealias Linearization = JacobianFactor<JacobianRows, ErrorVector>
-  public func linearized(at x: Variables) -> Linearization {
-    Linearization(linearizing: errorVector, at: x, edges: edges)
-  }
 }
-
-/// A prior factor on a `Pose2`.
-public typealias PriorFactor2 = PriorFactor<Pose2, Array3<Tuple1<Vector3>>>
-
-/// A prior factor on a `Pose3`.
-public typealias PriorFactor3 = PriorFactor<Pose3, Array6<Tuple1<Vector6>>>

--- a/Sources/SwiftFusion/Inference/ScalarJacobianFactor.swift
+++ b/Sources/SwiftFusion/Inference/ScalarJacobianFactor.swift
@@ -21,6 +21,12 @@ public struct ScalarJacobianFactor<ErrorVector: EuclideanVectorN>: GaussianFacto
   public let edges: Variables.Indices
   public let scalar: Double
 
+  public init(edges: Variables.Indices, scalar: Double) {
+    self.edges = edges
+    self.scalar = scalar
+  }
+
+  @differentiable
   public func errorVector(at x: Variables) -> ErrorVector {
     return scalar * x.head
   }
@@ -35,10 +41,5 @@ public struct ScalarJacobianFactor<ErrorVector: EuclideanVectorN>: GaussianFacto
 
   public func errorVector_linearComponent_adjoint(_ y: ErrorVector) -> Variables {
     return Tuple1(scalar * y)
-  }
-
-  public typealias Linearization = Self
-  public func linearized(at x: Tuple1<ErrorVector>) -> ScalarJacobianFactor<ErrorVector> {
-    return self
   }
 }

--- a/Sources/SwiftFusionBenchmarks/Pose2SLAM.swift
+++ b/Sources/SwiftFusionBenchmarks/Pose2SLAM.swift
@@ -62,7 +62,7 @@ let pose2SLAM = BenchmarkSuite(name: "Pose2SLAM") { suite in
   ) {
     var x = intelDataset.initialGuess
     var graph = intelDataset.graph
-    graph.store(PriorFactor2(TypedID(0), Pose2(0, 0, 0)))
+    graph.store(PriorFactor(TypedID(0), Pose2(0, 0, 0)))
 
     for _ in 0..<10 {
       let linearized = graph.linearized(at: x)

--- a/Sources/SwiftFusionBenchmarks/Pose3SLAM.swift
+++ b/Sources/SwiftFusionBenchmarks/Pose3SLAM.swift
@@ -60,7 +60,7 @@ let pose3SLAM = BenchmarkSuite(name: "Pose3SLAM") { suite in
     var val = sphere2500Dataset.initialGuess
     var graph = sphere2500Dataset.graph
     
-    graph.store(PriorFactor3(TypedID(0), Pose3(Rot3.fromTangent(Vector3.zero), Vector3.zero)))
+    graph.store(PriorFactor(TypedID(0), Pose3(Rot3.fromTangent(Vector3.zero), Vector3.zero)))
     
     var optimizer = LM()
     optimizer.verbosity = .SUMMARY

--- a/Tests/SwiftFusionTests/Inference/FactorGraphTests.swift
+++ b/Tests/SwiftFusionTests/Inference/FactorGraphTests.swift
@@ -26,29 +26,29 @@ class FactorGraphTests: XCTestCase {
     let pose2ID = TypedID<Pose2, Int>(1)
 
     var graph = FactorGraph()
-    graph.store(PriorFactor2(pose1ID, Pose2(1, 2, 3)))
-    graph.store(PriorFactor2(pose2ID, Pose2(4, 5, 6)))
-    graph.store(BetweenFactor2(pose1ID, pose2ID, Pose2(7, 8, 9)))
+    graph.store(PriorFactor(pose1ID, Pose2(1, 2, 3)))
+    graph.store(PriorFactor(pose2ID, Pose2(4, 5, 6)))
+    graph.store(BetweenFactor(pose1ID, pose2ID, Pose2(7, 8, 9)))
 
     XCTAssertEqual(
-      graph.factors(type: PriorFactor2.self).map { $0.edges },
+      graph.factors(type: PriorFactor<Pose2>.self).map { $0.edges },
       [Tuple1(pose1ID), Tuple1(pose2ID)]
     )
     XCTAssertEqual(
-      graph.factors(type: PriorFactor2.self).map { $0.prior },
+      graph.factors(type: PriorFactor<Pose2>.self).map { $0.prior },
       [Pose2(1, 2, 3), Pose2(4, 5, 6)]
     )
 
     XCTAssertEqual(
-      graph.factors(type: BetweenFactor2.self).map { $0.edges },
+      graph.factors(type: BetweenFactor<Pose2>.self).map { $0.edges },
       [Tuple2(pose1ID, pose2ID)]
     )
     XCTAssertEqual(
-      graph.factors(type: BetweenFactor2.self).map { $0.difference },
+      graph.factors(type: BetweenFactor<Pose2>.self).map { $0.difference },
       [Pose2(7, 8, 9)]
     )
 
-    XCTAssertEqual(graph.factors(type: PriorFactor3.self).count, 0)
+    XCTAssertEqual(graph.factors(type: PriorFactor<Pose3>.self).count, 0)
   }
 
   func testSimplePose2SLAM() {
@@ -60,11 +60,11 @@ class FactorGraphTests: XCTestCase {
     let pose5ID = x.store(Pose2(Rot2(-.pi / 2), Vector2(2.1, 2.1)))
 
     var graph = FactorGraph()
-    graph.store(BetweenFactor2(pose2ID, pose1ID, Pose2(2.0, 0.0, .pi / 2)))
-    graph.store(BetweenFactor2(pose3ID, pose2ID, Pose2(2.0, 0.0, .pi / 2)))
-    graph.store(BetweenFactor2(pose4ID, pose3ID, Pose2(2.0, 0.0, .pi / 2)))
-    graph.store(BetweenFactor2(pose5ID, pose4ID, Pose2(2.0, 0.0, .pi / 2)))
-    graph.store(PriorFactor2(pose1ID, Pose2(0, 0, 0)))
+    graph.store(BetweenFactor(pose2ID, pose1ID, Pose2(2.0, 0.0, .pi / 2)))
+    graph.store(BetweenFactor(pose3ID, pose2ID, Pose2(2.0, 0.0, .pi / 2)))
+    graph.store(BetweenFactor(pose4ID, pose3ID, Pose2(2.0, 0.0, .pi / 2)))
+    graph.store(BetweenFactor(pose5ID, pose4ID, Pose2(2.0, 0.0, .pi / 2)))
+    graph.store(PriorFactor(pose1ID, Pose2(0, 0, 0)))
 
     for _ in 0..<3 {
       let linearized = graph.linearized(at: x)
@@ -123,15 +123,15 @@ class FactorGraphTests: XCTestCase {
     let id5 = x.store(hexagon[hexagonId[5]].retract(Vector6(s * Tensor<Double>(randomNormal: [6]))))
     
     var fg = FactorGraph()
-    fg.store(PriorFactor3(id0, p0))
+    fg.store(PriorFactor(id0, p0))
     let delta: Pose3 = between(p0, p1)
 
-    fg.store(BetweenFactor3(id0, id1, delta))
-    fg.store(BetweenFactor3(id1, id2, delta))
-    fg.store(BetweenFactor3(id2, id3, delta))
-    fg.store(BetweenFactor3(id3, id4, delta))
-    fg.store(BetweenFactor3(id4, id5, delta))
-    fg.store(BetweenFactor3(id5, id0, delta))
+    fg.store(BetweenFactor(id0, id1, delta))
+    fg.store(BetweenFactor(id1, id2, delta))
+    fg.store(BetweenFactor(id2, id3, delta))
+    fg.store(BetweenFactor(id3, id4, delta))
+    fg.store(BetweenFactor(id4, id5, delta))
+    fg.store(BetweenFactor(id5, id0, delta))
 
     // optimize
     for _ in 0..<16 {
@@ -168,15 +168,15 @@ class FactorGraphTests: XCTestCase {
       let id5 = x.store(hexagon[hexagonId[5]].retract(Vector6(s * Tensor(randomNormal: [6]))))
       
       var fg = FactorGraph()
-      fg.store(PriorFactor3(id0, p0))
+      fg.store(PriorFactor(id0, p0))
       let delta: Pose3 = between(p0, p1)
 
-      fg.store(BetweenFactorAlternative3(id0, id1, delta))
-      fg.store(BetweenFactorAlternative3(id1, id2, delta))
-      fg.store(BetweenFactorAlternative3(id2, id3, delta))
-      fg.store(BetweenFactorAlternative3(id3, id4, delta))
-      fg.store(BetweenFactorAlternative3(id4, id5, delta))
-      fg.store(BetweenFactorAlternative3(id5, id0, delta))
+      fg.store(BetweenFactorAlternative(id0, id1, delta))
+      fg.store(BetweenFactorAlternative(id1, id2, delta))
+      fg.store(BetweenFactorAlternative(id2, id3, delta))
+      fg.store(BetweenFactorAlternative(id3, id4, delta))
+      fg.store(BetweenFactorAlternative(id4, id5, delta))
+      fg.store(BetweenFactorAlternative(id5, id0, delta))
 
       // optimize
       for _ in 0..<16 {

--- a/Tests/SwiftFusionTests/Inference/FactorTests.swift
+++ b/Tests/SwiftFusionTests/Inference/FactorTests.swift
@@ -20,10 +20,7 @@ import PenguinStructures
 @testable import SwiftFusion
 
 /// A factor that switches between different linear motions based on an integer label.
-fileprivate struct SwitchingMotionModelFactor<Pose: LieGroup, JacobianRows: FixedSizeArray>:
-  LinearizableFactor
-  where JacobianRows.Element == Tuple2<Pose.TangentVector, Pose.TangentVector>
-{
+fileprivate struct SwitchingMotionModelFactor<Pose: LieGroup>: VectorFactor {
   typealias Variables = Tuple3<Int, Pose, Pose>
 
   let edges: Variables.Indices
@@ -47,18 +44,14 @@ fileprivate struct SwitchingMotionModelFactor<Pose: LieGroup, JacobianRows: Fixe
     return errorVector(x.head, x.tail.head, x.tail.tail.head)
   }
 
-  typealias Linearization = JacobianFactor<JacobianRows, ErrorVector>
-  func linearized(at x: Variables) -> Linearization {
-    Linearization(
-      linearizing: { errorVector(x.head, $0.head, $0.tail.head) },
-      at: x.tail,
-      edges: edges.tail
-    )
+  func linearizableComponent(at x: Variables)
+    -> (BetweenFactor<Pose>, BetweenFactor<Pose>.Variables)
+  {
+    let a = BetweenFactor(edges.tail.head, edges.tail.tail.head, motions[x.head])
+    let b = x.tail
+    return (a, b)
   }
 }
-
-fileprivate typealias SwitchingMotionModelFactor2 =
-  SwitchingMotionModelFactor<Pose2, Array3<Tuple2<Vector3, Vector3>>>
 
 // A switching motion model factor graph.
 //
@@ -74,8 +67,8 @@ fileprivate struct ExampleFactorGraph {
   var motionLabelIDs = [TypedID<Int, Int>]()
   var poseIDs = [TypedID<Pose2, Int>]()
 
-  var priorFactors = AnyLinearizableFactorArrayBuffer(ArrayBuffer<PriorFactor2>())
-  var motionFactors = AnyLinearizableFactorArrayBuffer(ArrayBuffer<SwitchingMotionModelFactor2>())
+  var priorFactors = AnyVectorFactorArrayBuffer(ArrayBuffer<PriorFactor<Pose2>>())
+  var motionFactors = AnyVectorFactorArrayBuffer(ArrayBuffer<SwitchingMotionModelFactor<Pose2>>())
 
   init() {
     // Set up the initial guess.
@@ -89,13 +82,13 @@ fileprivate struct ExampleFactorGraph {
 
     // Set up the factor graph.
 
-    _ = priorFactors.unsafelyAppend(PriorFactor2(poseIDs[0], Pose2(0, 0, 0)))
+    _ = priorFactors.unsafelyAppend(PriorFactor(poseIDs[0], Pose2(0, 0, 0)))
 
-    _ = motionFactors.unsafelyAppend(SwitchingMotionModelFactor2(
+    _ = motionFactors.unsafelyAppend(SwitchingMotionModelFactor(
       edges: Tuple3(motionLabelIDs[0], poseIDs[0], poseIDs[1]),
       motions: [Pose2(1, 1, 0), Pose2(0, 0, 1)]
     ))
-    _ = motionFactors.unsafelyAppend(SwitchingMotionModelFactor2(
+    _ = motionFactors.unsafelyAppend(SwitchingMotionModelFactor(
       edges: Tuple3(motionLabelIDs[1], poseIDs[1], poseIDs[2]),
       motions: [Pose2(1, 1, 0), Pose2(0, 0, 1)]
     ))

--- a/Tests/SwiftFusionTests/Optimizers/LMTests.swift
+++ b/Tests/SwiftFusionTests/Optimizers/LMTests.swift
@@ -15,11 +15,11 @@ final class LMTests: XCTestCase {
     let pose5ID = x.store(Pose2(Rot2(-.pi / 2), Vector2(2.1, 2.1)))
 
     var graph = FactorGraph()
-    graph.store(BetweenFactor2(pose2ID, pose1ID, Pose2(2.0, 0.0, .pi / 2)))
-    graph.store(BetweenFactor2(pose3ID, pose2ID, Pose2(2.0, 0.0, .pi / 2)))
-    graph.store(BetweenFactor2(pose4ID, pose3ID, Pose2(2.0, 0.0, .pi / 2)))
-    graph.store(BetweenFactor2(pose5ID, pose4ID, Pose2(2.0, 0.0, .pi / 2)))
-    graph.store(PriorFactor2(pose1ID, Pose2(0, 0, 0)))
+    graph.store(BetweenFactor(pose2ID, pose1ID, Pose2(2.0, 0.0, .pi / 2)))
+    graph.store(BetweenFactor(pose3ID, pose2ID, Pose2(2.0, 0.0, .pi / 2)))
+    graph.store(BetweenFactor(pose4ID, pose3ID, Pose2(2.0, 0.0, .pi / 2)))
+    graph.store(BetweenFactor(pose5ID, pose4ID, Pose2(2.0, 0.0, .pi / 2)))
+    graph.store(PriorFactor(pose1ID, Pose2(0, 0, 0)))
 
     var optimizer = LM(precision: 1e-3, max_iteration: 10)
     optimizer.verbosity = .TRYLAMBDA


### PR DESCRIPTION
Eliminates the `JacobianRows` generic parameter and `linearized` method boilerplate from factor definitions. See `BetweenFactor.swift` for an example.

**How `linearized` was eliminated:**

For factors whose variables are all differentiable, `linearized` is unnecessary because can linearize the factor by differentiating a `@differentiable` `errorVector` method

So I changed `LinearizedFactor` to require that all its variables are differentiable.

To allow for factors with a mix of discrete and differentiable variables, I added a new `VectorFactor` in the factor refinement hierarchy. This factor has a `linearizableComponent` method for "partially applying" the factor to its nondifferentiable variables so that you can linearize with respect to all the other variables using `LinearizedFactor`.

**How `JacobianRows` was eliminated:**

I made `VectorFactorArrayDispatch` responsible for deciding the jacobian type.