### PR TITLE
quick and simple fixed size matrix

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/saeta/penguin.git",
         "state": {
           "branch": "master",
-          "revision": "4ea37a85ab75ddd5f02c395b9da535d6cbd66f20",
+          "revision": "f8734043301cd842f11813c6be0b13eae3a29623",
           "version": null
         }
       },

--- a/Sources/SwiftFusion/Core/EuclideanVectorN.swift
+++ b/Sources/SwiftFusion/Core/EuclideanVectorN.swift
@@ -33,4 +33,23 @@ extension EuclideanVectorN {
               count: Self.dimension))
     }
   }
+
+  /// Accesses the scalar at `i`.
+  subscript(i: Int) -> Double {
+    _read {
+      boundsCheck(i)
+      yield withUnsafeBufferPointer { $0.baseAddress.unsafelyUnwrapped[i] }
+    }
+    _modify {
+      boundsCheck(i)
+      defer { _fixLifetime(self) }
+      yield &withUnsafeMutableBufferPointer { $0.baseAddress }.unsafelyUnwrapped[i]
+    }
+  }
+
+  /// Traps with a suitable error message if `i` is not the position of an
+  /// element in `self`.
+  private func boundsCheck(_ i: Int) {
+    precondition(i >= 0 && i < Self.dimension, "index out of range")
+  }
 }

--- a/Sources/SwiftFusion/Core/FixedSizeMatrix.swift
+++ b/Sources/SwiftFusion/Core/FixedSizeMatrix.swift
@@ -1,0 +1,92 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import PenguinStructures
+
+/// A matrix whose dimensions are known at compile time.
+///
+/// Stored as a fixed-size array of rows, where the rows are `EuclideanVectorN`. For example,
+/// - `FixedSizeMatrix<Array3<Vector2>>`: A 3x2 matrix, where each row is a `Vector2`.
+/// - `FixedSizeMatrix<Array3<Tuple2<Vector2, Vector3>>`: A 3x5 matrix, where each row is a
+///   `Tuple2<Vector2, Vector3>`.
+public struct FixedSizeMatrix<Rows: Equatable & FixedSizeArray> where Rows.Element: EuclideanVectorN {
+  public var rows: Rows
+
+  /// The count of rows.
+  public static var rowCount: Int { return Rows.count }
+
+  /// The count of columns.
+  public static var columnCount: Int { return Rows.Element.dimension }
+
+  /// Accesses the element at `row`, `column`.
+  public subscript(row: Int, column: Int) -> Double {
+    _read {
+      yield rows[row][column]
+    }
+    _modify {
+      yield &rows[row][column]
+    }
+  }
+}
+
+extension FixedSizeMatrix: Equatable {}
+
+extension FixedSizeMatrix {
+  /// Creates a matrix with `elements`.
+  ///
+  /// Requires: `elements.count == Self.rowCount * Self.columnCount`.
+  public init<C: Collection>(_ elements: C) where C.Element == Double {
+    self.rows = Rows((0..<Rows.count).lazy.map { i in
+      Rows.Element(elements.dropFirst(i * Self.columnCount))
+    })
+  }
+
+  /// The identity matrix.
+  ///
+  /// - Requires: `Self` is a square matrix. e.g. `Self.rowCount == Self.columnCount`.
+  public static var identity: Self {
+    precondition(Self.rowCount == Self.columnCount)
+    var r = Self.zero
+    for i in 0..<Self.rowCount {
+      r[i, i] = 1
+    }
+    return r
+  }
+}
+
+extension FixedSizeMatrix: AdditiveArithmetic {
+  public static func + (_ lhs: Self, _ rhs: Self) -> Self {
+    var result = lhs
+    for i in 0..<Self.rowCount {
+      for j in 0..<Self.columnCount {
+        result[i, j] += rhs[i, j]
+      }
+    }
+    return result
+  }
+
+  public static func - (_ lhs: Self, _ rhs: Self) -> Self {
+    var result = lhs
+    for i in 0..<Self.rowCount {
+      for j in 0..<Self.columnCount {
+        result[i, j] -= rhs[i, j]
+      }
+    }
+    return result
+  }
+
+  public static var zero: Self {
+    return Self(rows: Rows((0..<Rows.count).lazy.map { _ in Rows.Element.zero }))
+  }
+}

--- a/Tests/SwiftFusionTests/Core/FixedSizeMatrixTests.swift
+++ b/Tests/SwiftFusionTests/Core/FixedSizeMatrixTests.swift
@@ -1,0 +1,90 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+import PenguinStructures
+import SwiftFusion
+
+/// A 3x2 matrix, where each row is a `Vector2`.
+fileprivate typealias Matrix3x2 = FixedSizeMatrix<Array3<Vector2>>
+
+/// A 3x3 matrix, where each row is a `Vector3`.
+fileprivate typealias Matrix3x3 = FixedSizeMatrix<Array3<Vector3>>
+
+/// A 3x5 matrix, where each row is a `Tuple2<Vector2, Vector3>`
+fileprivate typealias Matrix3x2_3x3 = FixedSizeMatrix<Array3<Tuple2<Vector2, Vector3>>>
+
+class FixedSizeMatrixTests: XCTestCase {
+  func testRowColumnCount() {
+    XCTAssertEqual(Matrix3x2.rowCount, 3)
+    XCTAssertEqual(Matrix3x2.columnCount, 2)
+    XCTAssertEqual(Matrix3x2_3x3.rowCount, 3)
+    XCTAssertEqual(Matrix3x2_3x3.columnCount, 5)
+  }
+
+  func testZero() {
+    let m1 = Matrix3x2.zero
+    for i in 0..<3 {
+      for j in 0..<2 {
+        XCTAssertEqual(m1[i, j], 0)
+      }
+    }
+
+    let m2 = Matrix3x2_3x3.zero
+    for i in 0..<3 {
+      for j in 0..<5 {
+        XCTAssertEqual(m2[i, j], 0)
+      }
+    }
+  }
+
+  func testIdentity() {
+    let m1 = Matrix3x3.identity
+    for i in 0..<3 {
+      for j in 0..<3 {
+        XCTAssertEqual(m1[i, j], i == j ? 1 : 0)
+      }
+    }
+  }
+
+  func testInitElements() {
+    let m1 = Matrix3x2([
+      1, 2,
+      10, 20,
+      100, 200
+    ])
+    XCTAssertEqual(m1[0, 0], 1)
+    XCTAssertEqual(m1[0, 1], 2)
+    XCTAssertEqual(m1[1, 0], 10)
+    XCTAssertEqual(m1[1, 1], 20)
+    XCTAssertEqual(m1[2, 0], 100)
+    XCTAssertEqual(m1[2, 1], 200)
+  }
+
+  func testAdd() {
+    let m1 = Matrix3x2([0, 1, 2, 3, 4, 5])
+    let m2 = Matrix3x2([0, 10, 20, 30, 40, 50])
+    let expected = Matrix3x2([0, 11, 22, 33, 44, 55])
+    XCTAssertEqual(m1 + m2, expected)
+  }
+
+  func testSubtract() {
+    let m1 = Matrix3x2([0, 11, 22, 33, 44, 55])
+    let m2 = Matrix3x2([0, 1, 2, 3, 4, 5])
+    let expected = Matrix3x2([0, 10, 20, 30, 40, 50])
+    XCTAssertEqual(m1 - m2, expected)
+  }
+
+}


### PR DESCRIPTION
Implements a `FixedSizeMatrix` supporting the operations described in https://github.com/borglab/SwiftFusion/issues/105.

This is pretty quick and dirty, just to get something useful working.

Let me know if it's missing anything or if there are more operations you'd like. Do you need differentiability? I'm happy to add anything you need :)