### PR TITLE
trap NaNs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
         uses: actions/checkout@master
       - name: Install toolchain
         run: |
-          wget https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2020-05-26-a-osx.pkg
-          sudo installer -pkg swift-tensorflow-DEVELOPMENT-2020-05-26-a-osx.pkg -target /
+          wget https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.10/rc1/swift-tensorflow-RELEASE-0.10-osx.pkg
+          sudo installer -pkg swift-tensorflow-RELEASE-0.10-osx.pkg -target /
           echo "::set-env name=PATH::/Library/Developer/Toolchains/swift-latest/usr/bin:${PATH}"
       - name: Build
         run: swift build -v

--- a/Sources/SwiftFusion/Core/TrappingDouble.swift
+++ b/Sources/SwiftFusion/Core/TrappingDouble.swift
@@ -25,12 +25,14 @@ public struct TrappingDouble: AdditiveArithmetic, Differentiable, Equatable {
   }
 }
 
+#if TRAPPING_DOUBLE
 /// A wrapper for `Double` that traps instead of allowing `NaN`.
 ///
 /// This typealias makes it easier to use unmodified existing code with `TrappingDouble`.
 ///
 /// If you really need the normal Swift `Double`, use `Swift.Double` to circumvent this typealias.
 public typealias Double = TrappingDouble
+#endif
 
 // The rest of this file provides conformances and functions that make the interface to
 // `TrappingDouble` very close to the interface to `Double`.

--- a/Sources/SwiftFusion/Core/TrappingDouble.swift
+++ b/Sources/SwiftFusion/Core/TrappingDouble.swift
@@ -1,0 +1,232 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import PythonKit
+import TensorFlow
+
+/// A wrapper for `Double` that traps instead of allowing `NaN`.
+public struct TrappingDouble: AdditiveArithmetic, Differentiable, Equatable {
+  public var value: Swift.Double
+
+  public init(_ value: Swift.Double) {
+    assert(!value.isNaN)
+    self.value = value
+  }
+}
+
+/// A wrapper for `Double` that traps instead of allowing `NaN`.
+///
+/// This typealias makes it easier to use unmodified existing code with `TrappingDouble`.
+///
+/// If you really need the normal Swift `Double`, use `Swift.Double` to circumvent this typealias.
+public typealias Double = TrappingDouble
+
+// The rest of this file provides conformances and functions that make the interface to
+// `TrappingDouble` very close to the interface to `Double`.
+
+extension TrappingDouble: BinaryFloatingPoint {
+  public typealias RawSignificand = Swift.Double.RawSignificand
+  public typealias RawExponent = Swift.Double.RawExponent
+
+  public static var exponentBitCount: Int { Swift.Double.exponentBitCount }
+  public static var significandBitCount: Int { Swift.Double.significandBitCount }
+  public var exponentBitPattern: Self.RawExponent { value.exponentBitPattern }
+  public var significandBitPattern: Self.RawSignificand { value.significandBitPattern }
+  public var binade: Self { Self(value.binade) }
+  public var significandWidth: Int { value.significandWidth }
+  public typealias Exponent = Swift.Double.Exponent
+  public typealias Stride = Swift.Double.Stride
+  public typealias Magnitude = Self
+
+  public mutating func formSquareRoot() { value.formSquareRoot() }
+  public mutating func addProduct(_ lhs: Self, _ rhs: Self) { value.addProduct(lhs.value, rhs.value) }
+  public var nextUp: Self { Self(value.nextUp) }
+  public func isEqual(to other: Self) -> Bool { value.isEqual(to: other.value) }
+  public func isLess(than other: Self) -> Bool { value.isLess(than: other.value) }
+  public func isLessThanOrEqualTo(_ other: Self) -> Bool { value.isLessThanOrEqualTo(other.value) }
+  public var isNormal: Bool { value.isNormal }
+  public var isFinite: Bool { value.isFinite }
+  public var isZero: Bool { value.isZero }
+  public var isSubnormal: Bool { value.isSubnormal }
+  public var isInfinite: Bool { value.isInfinite }
+  public var isNaN: Bool { value.isNaN }
+  public var isSignalingNaN: Bool { value.isSignalingNaN }
+  public var isCanonical: Bool { value.isCanonical }
+  public func distance(to other: Self) -> Self.Stride { value.distance(to: other.value) }
+  public func advanced(by n: Swift.Double.Stride) -> Self { Self(value.advanced(by: n)) }
+  public var magnitude: Self { Self(value.magnitude) }
+
+  public static var nan: Self { Self(Swift.Double.nan) }
+  public static var signalingNaN: Self { Self(Swift.Double.signalingNaN) }
+  public static var infinity: Self { Self(Swift.Double.infinity) }
+  public static var greatestFiniteMagnitude: Self { Self(Swift.Double.greatestFiniteMagnitude) }
+  public var ulp: Self { Self(value.ulp) }
+  public static var leastNormalMagnitude: Self { Self(Swift.Double.leastNormalMagnitude) }
+  public static var leastNonzeroMagnitude: Self { Self(Swift.Double.leastNonzeroMagnitude) }
+  public var sign: FloatingPointSign { value.sign }
+  public var exponent: Self.Exponent { value.exponent }
+  public var significand: Self { Self(value.significand) }
+  public mutating func formRemainder(dividingBy other: Self) { value.formRemainder(dividingBy: other.value) }
+  public mutating func formTruncatingRemainder(dividingBy other: Self) { value.formTruncatingRemainder(dividingBy: other.value) }
+
+  public init(sign: FloatingPointSign, exponentBitPattern: Self.RawExponent, significandBitPattern: Self.RawSignificand) {
+    self.value = Swift.Double(sign: sign, exponentBitPattern: exponentBitPattern, significandBitPattern: significandBitPattern)
+  }
+  public init(sign: FloatingPointSign, exponent: Self.Exponent, significand: Self) {
+    self.value = Swift.Double(sign: sign, exponent: exponent, significand: significand.value)
+  }
+
+  public mutating func round(_ rule: FloatingPointRoundingRule) { value.round(rule) }
+}
+
+extension TrappingDouble: ElementaryFunctions {}
+
+extension TrappingDouble: TensorFlowFloatingPoint {
+  public var xlaScalarWrapper: XLAScalarWrapper { return value.xlaScalarWrapper }
+  public static var xlaTensorScalarTypeRawValue: UInt32 { return Swift.Double.xlaTensorScalarTypeRawValue }
+  @inlinable
+  public static var tensorFlowDataType: TensorDataType { return Swift.Double.tensorFlowDataType }
+}
+
+extension TrappingDouble: PythonConvertible {
+  public var pythonObject: PythonObject { value.pythonObject }
+}
+
+extension TrappingDouble: Comparable {
+  public static func < (_ lhs: Self, _ rhs: Self) -> Bool {
+    return lhs.value < rhs.value
+  }
+}
+
+extension TrappingDouble: ExpressibleByFloatLiteral {
+  public init(floatLiteral: Swift.Double) {
+    self.init(floatLiteral)
+  }
+}
+
+extension TrappingDouble: ExpressibleByIntegerLiteral {
+  public init(integerLiteral: Int) {
+    self.init(Swift.Double(integerLiteral))
+  }
+}
+
+extension TrappingDouble: CustomStringConvertible {
+  public var description: String {
+    return "\(value)"
+  }
+}
+
+extension TrappingDouble {
+  init?<S: StringProtocol>(_ text: S) {
+    guard let value = Swift.Double(text) else {
+      return nil
+    }
+    self.init(value)
+  }
+
+  @differentiable
+  public static func + (_ lhs: Self, _ rhs: Self) -> Self {
+    return Self(lhs.value + rhs.value)
+  }
+
+  @differentiable
+  public static func - (_ lhs: Self, _ rhs: Self) -> Self {
+    return Self(lhs.value - rhs.value)
+  }
+
+  @differentiable
+  public static func += (_ lhs: inout Self, _ rhs: Self) {
+    lhs.value += rhs.value
+  }
+
+  @differentiable
+  public static func -= (_ lhs: inout Self, _ rhs: Self) {
+    lhs.value -= rhs.value
+  }
+
+  @differentiable
+  public static prefix func - (_ v: Self) -> Self {
+    return Self(-v.value)
+  }
+
+  @differentiable
+  public static func * (_ lhs: Self, _ rhs: Self) -> Self {
+    return Self(lhs.value * rhs.value)
+  }
+
+  @differentiable
+  public static func / (_ lhs: Self, _ rhs: Self) -> Self {
+    return Self(lhs.value / rhs.value)
+  }
+
+  @differentiable
+  public static func *= (_ lhs: inout Self, _ rhs: Self) {
+    lhs.value *= rhs.value
+  }
+
+  @differentiable
+  public static func /= (_ lhs: inout Self, _ rhs: Self) {
+    lhs.value /= rhs.value
+  }
+
+  public static var ulpOfOne: Self {
+    return Self(Swift.Double.ulpOfOne)
+  }
+
+  public static var pi: Self {
+    return Self(Swift.Double.pi)
+  }
+}
+
+public func abs(_ x: TrappingDouble) -> TrappingDouble {
+  return TrappingDouble(abs(x.value))
+}
+
+public func log(_ x: TrappingDouble) -> TrappingDouble {
+  return TrappingDouble(log(x.value))
+}
+
+@differentiable
+public func sin(_ x: TrappingDouble) -> TrappingDouble {
+  return TrappingDouble(sin(x.value))
+}
+
+@differentiable
+public func cos(_ x: TrappingDouble) -> TrappingDouble {
+  return TrappingDouble(cos(x.value))
+}
+
+@differentiable
+public func asin(_ x: TrappingDouble) -> TrappingDouble {
+  return TrappingDouble(asin(x.value))
+}
+
+@differentiable
+public func acos(_ x: TrappingDouble) -> TrappingDouble {
+  return TrappingDouble(acos(x.value))
+}
+
+public func atan2(_ x: TrappingDouble, _ y: TrappingDouble) -> TrappingDouble {
+  return TrappingDouble(atan2(x.value, y.value))
+}
+
+@differentiable
+public func tan(_ x: TrappingDouble) -> TrappingDouble {
+  return TrappingDouble(tan(x.value))
+}
+
+public func sqrt(_ x: TrappingDouble) -> TrappingDouble {
+  return TrappingDouble(sqrt(x.value))
+}
+

--- a/Sources/SwiftFusion/Optimizers/LM.swift
+++ b/Sources/SwiftFusion/Optimizers/LM.swift
@@ -62,7 +62,7 @@ public struct LM {
       print("[LM OUTER] initial error = \(old_error)")
     }
     
-    var lambda = 1e-6
+    var lambda: Double = 1e-6
     var inner_iter_step = 0
     var inner_success = false
     var all_done = false

--- a/Sources/SwiftFusion/Optimizers/NLCG.swift
+++ b/Sources/SwiftFusion/Optimizers/NLCG.swift
@@ -47,9 +47,13 @@ public class NLCG<Model: Differentiable & KeyPathIterable>
 
     // perform the golden section search algorithm to decide the the optimal step size
     // detail refer to http://en.wikipedia.org/wiki/Golden_section_search
-    let phi = 0.5 * (1.0 + sqrt(5.0)), resphi = 2.0 - phi, tau = 1e-5
+    let phi: Double = 0.5 * (1.0 + sqrt(5.0))
+    let resphi: Double = 2.0 - phi
+    let tau: Double = 1e-5
     
-    var minStep = -1.0 / g, maxStep = 0.0, newStep = minStep + (maxStep - minStep) / (phi + 1.0);
+    var minStep: Double = -1.0 / g
+    var maxStep: Double = 0.0
+    var newStep: Double = minStep + (maxStep - minStep) / (phi + 1.0)
 
     var newValues = currentValues
     newValues.move(along: newStep * gradient)

--- a/Tests/SwiftFusionTests/Core/EuclideanVectorTests.swift
+++ b/Tests/SwiftFusionTests/Core/EuclideanVectorTests.swift
@@ -183,7 +183,11 @@ extension EuclideanVectorTests {
   func testDot() {
     let v1 = makeVector(from: 1, stride: 1)
     let v2 = makeVector(from: 2, stride: 1)
-    let expectedDot = (0..<Self.dimension).map { Double(($0 + 1) * ($0 + 2)) }.reduce(0, +)
+    let expectedDot = (0..<Self.dimension).reduce(into: 0) { (r: inout Double, i: Int) in
+      let x = Double(i) + 1
+      let y = Double(i) + 2
+      r += x * y
+    }
     XCTAssertEqual(v1.dot(v2), expectedDot)
 
     let (value, g) = valueWithGradient(at: v1, v2) { $0.dot($1) }
@@ -207,7 +211,10 @@ extension EuclideanVectorTests {
   /// Tests the value and derivative of `squaredNorm`.
   func testSquaredNorm() {
     let v1 = makeVector(from: 1, stride: 1)
-    let expectedSquaredNorm = (0..<Self.dimension).map { Double(($0 + 1) * ($0 + 1)) }.reduce(0, +)
+    let expectedSquaredNorm = (0..<Self.dimension).reduce(into: 0) { (r: inout Double, i: Int) in
+      let x = Double(i) + 1
+      r += x * x
+    }
     XCTAssertEqual(v1.squaredNorm, expectedSquaredNorm)
 
     let (value, g) = valueWithGradient(at: v1) { $0.squaredNorm }
@@ -218,7 +225,10 @@ extension EuclideanVectorTests {
   /// Tests the value and derivative of `norm`.
   func testNorm() {
     let v1 = makeVector(from: 1, stride: 1)
-    let expectedNorm = (0..<Self.dimension).map { Double(($0 + 1) * ($0 + 1)) }.reduce(0, +).squareRoot()
+    let expectedNorm = (0..<Self.dimension).reduce(into: 0) { (r: inout Double, i: Int) in
+      let x = Double(i) + 1
+      r += x * x
+    }.squareRoot()
     XCTAssertEqual(v1.norm, expectedNorm)
 
     let (value, g) = valueWithGradient(at: v1) { $0.norm }

--- a/Tests/SwiftFusionTests/Core/TensorFlowMatrixTests.swift
+++ b/Tests/SwiftFusionTests/Core/TensorFlowMatrixTests.swift
@@ -7,10 +7,10 @@ class TensorFlowMatrixTests: XCTestCase {
     //--------------------------------------------------------------------------
     // testConcat
     func testConcat() {
-        let t1 = Tensor(shape: [2, 3], scalars: (1...6).map { Double($0) })
-        let t2 = Tensor(shape: [2, 3], scalars: (7...12).map { Double($0) })
+        let t1 = Tensor<Double>(shape: [2, 3], scalars: (1...6).map { Double($0) })
+        let t2 = Tensor<Double>(shape: [2, 3], scalars: (7...12).map { Double($0) })
         let c1 = t1.concatenated(with: t2)
-        let c1Expected = Tensor([
+        let c1Expected = Tensor<Double>([
             1,  2,  3,
             4,  5,  6,
             7,  8,  9,
@@ -20,7 +20,7 @@ class TensorFlowMatrixTests: XCTestCase {
         XCTAssert(c1.flattened() == c1Expected)
         
         let c2 = t1.concatenated(with: t2, alongAxis: 1)
-        let c2Expected = Tensor([
+        let c2Expected = Tensor<Double>([
             1, 2, 3,  7,  8,  9,
             4, 5, 6, 10, 11, 12
         ])
@@ -34,7 +34,7 @@ class TensorFlowMatrixTests: XCTestCase {
         let range = 0..<6
         let matrix = Tensor(shape: [3, 2], scalars: (range).map { Double($0) })
         let values = log(matrix).flattened()
-        let expected = Tensor(range.map { Foundation.log(Double($0)) })
+        let expected = Tensor(range.map { log(Double($0)) })
         assertEqual(values, expected, accuracy: 1e-8)
     }
     

--- a/Tests/SwiftFusionTests/Core/TrappingDoubleTests.swift
+++ b/Tests/SwiftFusionTests/Core/TrappingDoubleTests.swift
@@ -20,8 +20,8 @@ import SwiftFusion
 class TrappingDoubleTests: XCTestCase {
   /// Tests simple `TrappingDouble` operations.
   func testOperations() {
-    let x: Double = 1.0
-    let y: Double = 2.0
+    let x: TrappingDouble = 1.0
+    let y: TrappingDouble = 2.0
     XCTAssertEqual(y + x, 3.0)
     XCTAssertEqual(y - x, 1.0)
   }
@@ -32,6 +32,6 @@ class TrappingDoubleTests: XCTestCase {
   /// `XCTSkipIf` line and run this test to manually verify the trapping behavior.
   func testTrap() throws {
     try XCTSkipIf(true)
-    let _: Double = .infinity - .infinity
+    let _: TrappingDouble = .infinity - .infinity
   }
 }

--- a/Tests/SwiftFusionTests/Core/TrappingDoubleTests.swift
+++ b/Tests/SwiftFusionTests/Core/TrappingDoubleTests.swift
@@ -1,0 +1,37 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+import PenguinStructures
+import SwiftFusion
+
+class TrappingDoubleTests: XCTestCase {
+  /// Tests simple `TrappingDouble` operations.
+  func testOperations() {
+    let x: Double = 1.0
+    let y: Double = 2.0
+    XCTAssertEqual(y + x, 3.0)
+    XCTAssertEqual(y - x, 1.0)
+  }
+
+  /// Tests that `TrappingDouble` traps on `NaN`s.
+  ///
+  /// There is no way to assert that a trap happens, so this test is skipped. You can remove the
+  /// `XCTSkipIf` line and run this test to manually verify the trapping behavior.
+  func testTrap() throws {
+    try XCTSkipIf(true)
+    let _: Double = .infinity - .infinity
+  }
+}

--- a/Tests/SwiftFusionTests/Geometry/Pose2Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Pose2Tests.swift
@@ -103,8 +103,6 @@ final class Pose2Tests: XCTestCase {
 
   /// test convergence for a simple Pose2SLAM
   func testPose2SLAM() {
-    let pi = 3.1415926
-
     let dumpjson = { (p: Pose2) -> String in
       "[ \(p.t.x), \(p.t.y), \(p.rot.theta)]"
     }
@@ -112,9 +110,9 @@ final class Pose2Tests: XCTestCase {
     // Initial estimate for poses
     let p1T0 = Pose2(Rot2(0.2), Vector2(0.5, 0.0))
     let p2T0 = Pose2(Rot2(-0.2), Vector2(2.3, 0.1))
-    let p3T0 = Pose2(Rot2(pi / 2), Vector2(4.1, 0.1))
-    let p4T0 = Pose2(Rot2(pi), Vector2(4.0, 2.0))
-    let p5T0 = Pose2(Rot2(-pi / 2), Vector2(2.1, 2.1))
+    let p3T0 = Pose2(Rot2(.pi / 2), Vector2(4.1, 0.1))
+    let p4T0 = Pose2(Rot2(.pi), Vector2(4.0, 2.0))
+    let p5T0 = Pose2(Rot2(-.pi / 2), Vector2(2.1, 2.1))
 
     var map = [p1T0, p2T0, p3T0, p4T0, p5T0]
 
@@ -125,9 +123,9 @@ final class Pose2Tests: XCTestCase {
 
         // Odometry measurements
         let p2T1 = between(between(map[1], map[0]), Pose2(2.0, 0.0, 0.0))
-        let p3T2 = between(between(map[2], map[1]), Pose2(2.0, 0.0, pi / 2))
-        let p4T3 = between(between(map[3], map[2]), Pose2(2.0, 0.0, pi / 2))
-        let p5T4 = between(between(map[4], map[3]), Pose2(2.0, 0.0, pi / 2))
+        let p3T2 = between(between(map[2], map[1]), Pose2(2.0, 0.0, .pi / 2))
+        let p4T3 = between(between(map[3], map[2]), Pose2(2.0, 0.0, .pi / 2))
+        let p5T4 = between(between(map[4], map[3]), Pose2(2.0, 0.0, .pi / 2))
 
         // Sum through the errors
         let error = self.e_pose2(p2T1) + self.e_pose2(p3T2) + self.e_pose2(p4T3) + self.e_pose2(p5T4)

--- a/Tests/SwiftFusionTests/Geometry/Pose3Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Pose3Tests.swift
@@ -66,7 +66,7 @@ final class Pose3Tests: XCTestCase {
   /// Vehicle at p0 is looking towards y axis (X-axis points towards world y)
   func circlePose3(numPoses: Int = 8, radius: Double = 1.0) -> Values {
     var values = Values()
-    var theta = 0.0
+    var theta: Double = 0.0
     let dtheta = 2.0 * .pi / Double(numPoses)
     let gRo = Rot3(0, 1, 0, 1, 0, 0, 0, 0, -1)
     for i in 0..<numPoses {
@@ -100,7 +100,7 @@ final class Pose3Tests: XCTestCase {
 
     // Create initial config
     var val = Values()
-    let s = 0.10
+    let s: Double = 0.10
     val.insert(0, p0)
     val.insert(1, hexagon[1, as: Pose3.self].retract(Vector6(s * Tensor<Double>(randomNormal: [6]))))
     val.insert(2, hexagon[2, as: Pose3.self].retract(Vector6(s * Tensor<Double>(randomNormal: [6]))))

--- a/Tests/SwiftFusionTests/Geometry/Rot3Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Rot3Tests.swift
@@ -111,7 +111,7 @@ final class Rot3Tests: XCTestCase {
   
   func testExpmap() {
     let axis = Vector3(0, 1, 0)  // rotation around Y
-    let angle = 3.14 / 4.0
+    let angle: Double = 3.14 / 4.0
     let v = angle * axis
     let expected = Matrix3(0.707388, 0, 0.706825, 0, 1, 0, -0.706825, 0, 0.707388)
     
@@ -123,7 +123,7 @@ final class Rot3Tests: XCTestCase {
   
   func testExpmapNearZero() {
     let axis = Vector3(0, 1, 0)  // rotation around Y
-    let angle = 0.0
+    let angle: Double = 0.0
     let v = angle * axis
     let expected = Rot3()
     

--- a/Tests/SwiftFusionTests/Inference/FactorGraphTests.swift
+++ b/Tests/SwiftFusionTests/Inference/FactorGraphTests.swift
@@ -92,7 +92,7 @@ class FactorGraphTests: XCTestCase {
   func circlePose3(numPoses: Int = 8, radius: Double = 1.0) -> (Array<TypedID<Pose3, Int>>, VariableAssignments) {
     var ids: Array<TypedID<Pose3, Int>> = []
     var values = VariableAssignments()
-    var theta = 0.0
+    var theta: Double = 0.0
     let dtheta = 2.0 * .pi / Double(numPoses)
     let gRo = Rot3(0, 1, 0, 1, 0, 0, 0, 0, -1)
     for _ in 0..<numPoses {
@@ -114,7 +114,7 @@ class FactorGraphTests: XCTestCase {
     
     var x = VariableAssignments()
     
-    let s = 0.10
+    let s: Double = 0.10
     let id0 = x.store(p0)
     let id1 = x.store(hexagon[hexagonId[1]].retract(Vector6(s * Tensor<Double>(randomNormal: [6]))))
     let id2 = x.store(hexagon[hexagonId[2]].retract(Vector6(s * Tensor<Double>(randomNormal: [6]))))
@@ -159,7 +159,7 @@ class FactorGraphTests: XCTestCase {
     for _ in 0..<attemptCount {
       var x = VariableAssignments()
       
-      let s = 0.9
+      let s: Double = 0.9
       let id0 = x.store(p0)
       let id1 = x.store(hexagon[hexagonId[1]].retract(Vector6(s * Tensor(randomNormal: [6]))))
       let id2 = x.store(hexagon[hexagonId[2]].retract(Vector6(s * Tensor(randomNormal: [6]))))

--- a/Tests/SwiftFusionTests/MCMC/MCMCTests.swift
+++ b/Tests/SwiftFusionTests/MCMC/MCMCTests.swift
@@ -26,7 +26,7 @@ class MCMCTests: XCTestCase {
     
     // Run the sampler for 2500 steps, discarding the first 500 asa burn-in
     let num_results = 2000
-    let initial_state = 1.0
+    let initial_state: Double = 1.0
     let num_burnin_steps = 500
     let samples = sampleChain(num_results, initial_state, kernel, num_burnin_steps)
     


### PR DESCRIPTION
On Friday, we discussed the problem of figuring out where `NaN`s are happening. This is one of the solutions we discussed.

Adds a `TrappingDouble` that traps when there is a `NaN`, and typealiases `Double` to `TrappingDouble`. (Maybe this typealias should be commented out or controlled by an `#if` flag that is off by default, so that we don't have a weird nonstandard `Double` all the time. People debugging `NaN`s can enable the typealias locally.)

A few changes to other pieces of code were necessary to make this compile because `TrappingDouble` isn't a perfect drop in replacement for `Double`.