### PR TITLE
change TypedID<X, Int> to TypedID<X>

### DIFF
--- a/Sources/SwiftFusion/Datasets/G2OReader.swift
+++ b/Sources/SwiftFusion/Datasets/G2OReader.swift
@@ -51,7 +51,7 @@ public enum G2OReader {
     /// The initial guess.
     public var initialGuess = VariableAssignments()
 
-    public var variableId = Array<TypedID<Pose, Int>>()
+    public var variableId = Array<TypedID<Pose>>()
     
     /// The factor graph representing the measurements.
     public var graph = FactorGraph()

--- a/Sources/SwiftFusion/Inference/BetweenFactor.swift
+++ b/Sources/SwiftFusion/Inference/BetweenFactor.swift
@@ -28,7 +28,7 @@ public struct BetweenFactor<Pose: LieGroup, JacobianRows: FixedSizeArray>:
   public let edges: Variables.Indices
   public let difference: Pose
 
-  public init(_ startId: TypedID<Pose, Int>, _ endId: TypedID<Pose, Int>, _ difference: Pose) {
+  public init(_ startId: TypedID<Pose>, _ endId: TypedID<Pose>, _ difference: Pose) {
     self.edges = Tuple2(startId, endId)
     self.difference = difference
   }

--- a/Sources/SwiftFusion/Inference/BetweenFactorAlternative.swift
+++ b/Sources/SwiftFusion/Inference/BetweenFactorAlternative.swift
@@ -24,7 +24,7 @@ public struct BetweenFactorAlternative<JacobianRows: FixedSizeArray>:
   public let edges: Variables.Indices
   public let difference: Pose3
 
-  public init(_ startId: TypedID<Pose3, Int>, _ endId: TypedID<Pose3, Int>, _ difference: Pose3) {
+  public init(_ startId: TypedID<Pose3>, _ endId: TypedID<Pose3>, _ difference: Pose3) {
     self.edges = Tuple2(startId, endId)
     self.difference = difference
   }

--- a/Sources/SwiftFusion/Inference/Factor.swift
+++ b/Sources/SwiftFusion/Inference/Factor.swift
@@ -144,7 +144,7 @@ extension Tuple: VariableTuple where Tail: VariableTuple {
   public typealias UnsafePointers = Tuple<UnsafePointer<Head>, Tail.UnsafePointers>
   public typealias UnsafeMutablePointers =
     Tuple<UnsafeMutablePointer<Head>, Tail.UnsafeMutablePointers>
-  public typealias Indices = Tuple<TypedID<Head, Int>, Tail.Indices>
+  public typealias Indices = Tuple<TypedID<Head>, Tail.Indices>
 
   public static func withVariableBufferBaseUnsafePointers<R>(
     _ variableAssignments: VariableAssignments,
@@ -211,10 +211,10 @@ extension Empty: DifferentiableVariableTuple {
 
 extension Tuple: DifferentiableVariableTuple
 where Head: Differentiable, Tail: DifferentiableVariableTuple {
-  typealias TangentIndices = Tuple<TypedID<Head.TangentVector, Int>, Tail.TangentIndices>
+  typealias TangentIndices = Tuple<TypedID<Head.TangentVector>, Tail.TangentIndices>
   static func linearized(_ indices: Indices) -> TangentIndices {
     TangentIndices(
-      head: TypedID<Head.TangentVector, Int>(indices.head.perTypeID),
+      head: TypedID<Head.TangentVector>(indices.head.perTypeID),
       tail: Tail.linearized(indices.tail)
     )
   }

--- a/Sources/SwiftFusion/Inference/PriorFactor.swift
+++ b/Sources/SwiftFusion/Inference/PriorFactor.swift
@@ -28,7 +28,7 @@ public struct PriorFactor<Pose: LieGroup, JacobianRows: FixedSizeArray>:
   public let edges: Variables.Indices
   public let prior: Pose
 
-  public init(_ id: TypedID<Pose, Int>, _ prior: Pose) {
+  public init(_ id: TypedID<Pose>, _ prior: Pose) {
     self.edges = Tuple1(id)
     self.prior = prior
   }

--- a/Sources/SwiftFusion/Inference/ValuesStorage.swift
+++ b/Sources/SwiftFusion/Inference/ValuesStorage.swift
@@ -85,7 +85,7 @@ extension ArrayStorage where Element: EuclideanVectorN {
   /// Returns Jacobians that scale each element by `scalar`.
   func jacobians(scalar: Double) -> AnyGaussianFactorArrayBuffer {
     AnyGaussianFactorArrayBuffer(ArrayBuffer(enumerated().lazy.map { (i, _) in
-      ScalarJacobianFactor(edges: Tuple1(TypedID<Element, Int>(i)), scalar: scalar)
+      ScalarJacobianFactor(edges: Tuple1(TypedID<Element>(i)), scalar: scalar)
     }))
   }
 }

--- a/Sources/SwiftFusion/Inference/VariableAssignments.swift
+++ b/Sources/SwiftFusion/Inference/VariableAssignments.swift
@@ -17,16 +17,14 @@ import PenguinStructures
 /// An identifier of a given abstract value with the value's type attached
 ///
 /// - Parameter Value: the type of value this ID refers to.
-/// - Parameter PerTypeID: a type that, given `Value`, identifies a given
-///   logical value of that type.
 ///
 /// Note: This is just a temporary placeholder until we get the real `TypedID` in penguin.
-public struct TypedID<Value, PerTypeID: Equatable>: Equatable {
+public struct TypedID<Value>: Equatable {
   /// A specifier of which logical value of type `value` is being identified.
-  public let perTypeID: PerTypeID
+  public let perTypeID: Int
 
   /// Creates an instance indicating the given logical value of type `Value`.
-  public init(_ perTypeID: PerTypeID) { self.perTypeID = perTypeID }
+  public init(_ perTypeID: Int) { self.perTypeID = perTypeID }
 }
 
 /// Assignments of values to factor graph variables.
@@ -43,7 +41,7 @@ public struct VariableAssignments {
   }
 
   /// Stores `value` as the assignment of a new variable, and returns the new variable's id.
-  public mutating func store<T>(_ value: T) -> TypedID<T, Int> {
+  public mutating func store<T>(_ value: T) -> TypedID<T> {
     let perTypeID = storage[
       ObjectIdentifier(T.self),
       default: AnyElementArrayBuffer(ArrayBuffer<T>())
@@ -52,7 +50,7 @@ public struct VariableAssignments {
   }
 
   /// Stores `value` as the assignment of a new variable, and returns the new variable's id.
-  public mutating func store<T: Differentiable>(_ value: T) -> TypedID<T, Int>
+  public mutating func store<T: Differentiable>(_ value: T) -> TypedID<T>
     where T.TangentVector: EuclideanVectorN
   {
     let perTypeID = storage[
@@ -65,7 +63,7 @@ public struct VariableAssignments {
   }
 
   /// Stores `value` as the assignment of a new variable, and returns the new variable's id.
-  public mutating func store<T: EuclideanVectorN>(_ value: T) -> TypedID<T, Int> {
+  public mutating func store<T: EuclideanVectorN>(_ value: T) -> TypedID<T> {
     let perTypeID = storage[
       ObjectIdentifier(T.self),
       // Note: This is a safe upcast.
@@ -81,7 +79,7 @@ public struct VariableAssignments {
   }
 
   /// Accesses the stored value with the given ID.
-  public subscript<T>(id: TypedID<T, Int>) -> T {
+  public subscript<T>(id: TypedID<T>) -> T {
     _read {
       let array = storage[ObjectIdentifier(T.self), default: Self.noSuchType]
       yield ArrayBuffer<T>(unsafelyDowncasting: array)

--- a/Tests/SwiftFusionTests/Inference/FactorGraphTests.swift
+++ b/Tests/SwiftFusionTests/Inference/FactorGraphTests.swift
@@ -22,8 +22,8 @@ import SwiftFusion
 class FactorGraphTests: XCTestCase {
   /// Tests that we can read factors from a factor graph.
   func testGetFactors() {
-    let pose1ID = TypedID<Pose2, Int>(0)
-    let pose2ID = TypedID<Pose2, Int>(1)
+    let pose1ID = TypedID<Pose2>(0)
+    let pose2ID = TypedID<Pose2>(1)
 
     var graph = FactorGraph()
     graph.store(PriorFactor2(pose1ID, Pose2(1, 2, 3)))
@@ -89,8 +89,8 @@ class FactorGraphTests: XCTestCase {
   /// |    |
   /// z-->xZ--> Y  (z pointing towards viewer, Z pointing away from viewer)
   /// Vehicle at p0 is looking towards y axis (X-axis points towards world y)
-  func circlePose3(numPoses: Int = 8, radius: Double = 1.0) -> (Array<TypedID<Pose3, Int>>, VariableAssignments) {
-    var ids: Array<TypedID<Pose3, Int>> = []
+  func circlePose3(numPoses: Int = 8, radius: Double = 1.0) -> (Array<TypedID<Pose3>>, VariableAssignments) {
+    var ids: Array<TypedID<Pose3>> = []
     var values = VariableAssignments()
     var theta: Double = 0.0
     let dtheta = 2.0 * .pi / Double(numPoses)

--- a/Tests/SwiftFusionTests/Inference/FactorTests.swift
+++ b/Tests/SwiftFusionTests/Inference/FactorTests.swift
@@ -71,8 +71,8 @@ fileprivate typealias SwitchingMotionModelFactor2 =
 // - two motion factors with possible motions [Pose2(1, 1, 0), Pose2(0, 0, 1)]
 fileprivate struct ExampleFactorGraph {
   var initialGuess = VariableAssignments()
-  var motionLabelIDs = [TypedID<Int, Int>]()
-  var poseIDs = [TypedID<Pose2, Int>]()
+  var motionLabelIDs = [TypedID<Int>]()
+  var poseIDs = [TypedID<Pose2>]()
 
   var priorFactors = AnyLinearizableFactorArrayBuffer(ArrayBuffer<PriorFactor2>())
   var motionFactors = AnyLinearizableFactorArrayBuffer(ArrayBuffer<SwitchingMotionModelFactor2>())

--- a/Tests/SwiftFusionTests/Inference/VariableAssignmentsTests.swift
+++ b/Tests/SwiftFusionTests/Inference/VariableAssignmentsTests.swift
@@ -44,8 +44,8 @@ class VariableAssignmentsTests: XCTestCase {
 
     let t = x.tangentVectorZeros
     // TODO: Assert that there are only 2 elements when there is some API for count.
-    XCTAssertEqual(t[TypedID<Vector1, Int>(0)], Vector1(0))
-    XCTAssertEqual(t[TypedID<Vector2, Int>(0)], Vector2(0, 0))
+    XCTAssertEqual(t[TypedID<Vector1>(0)], Vector1(0))
+    XCTAssertEqual(t[TypedID<Vector2>(0)], Vector2(0, 0))
   }
 
   func testMove() {


### PR DESCRIPTION
We never use anything other than `Int` as the second type parameter, so we can remove it to make it easier to type.