### PR TITLE
fixed-arity protocols that reduce boilerplate

### DIFF
--- a/Examples/Pose3SLAMG2O/main.swift
+++ b/Examples/Pose3SLAMG2O/main.swift
@@ -144,7 +144,7 @@ func main() {
   var val = problem.initialGuess
   var graph = problem.graph
   
-  graph.store(PriorFactor3(TypedID(0), Pose3()))
+  graph.store(PriorFactor(TypedID(0), Pose3()))
   
   if useChordalInitialization {
     val = ChordalInitialization.GetInitializations(graph: graph, ids: problem.variableId)

--- a/Sources/SwiftFusion/Datasets/G2OReader.swift
+++ b/Sources/SwiftFusion/Datasets/G2OReader.swift
@@ -65,7 +65,7 @@ public enum G2OReader {
           assert(typedID.perTypeID == id)
           variableId.append(typedID)
         case .measurement(frameIndex: let id1, measuredIndex: let id2, pose: let difference):
-          graph.store(BetweenFactor2(TypedID(id1), TypedID(id2), difference))
+          graph.store(BetweenFactor(TypedID(id1), TypedID(id2), difference))
         }
       }
     }
@@ -80,9 +80,9 @@ public enum G2OReader {
           variableId.append(typedID)
         case .measurement(frameIndex: let id1, measuredIndex: let id2, pose: let difference):
           if chordal {
-            graph.store(BetweenFactorAlternative3(TypedID(id1), TypedID(id2), difference))
+            graph.store(BetweenFactorAlternative(TypedID(id1), TypedID(id2), difference))
           } else {
-            graph.store(BetweenFactor3(TypedID(id1), TypedID(id2), difference))
+            graph.store(BetweenFactor(TypedID(id1), TypedID(id2), difference))
           }
         }
       }

--- a/Sources/SwiftFusion/Inference/AllVectors.swift
+++ b/Sources/SwiftFusion/Inference/AllVectors.swift
@@ -77,7 +77,7 @@ extension AllVectors {
   }
 
   /// Returns the `ErrorVector` from the `perFactorID`-th factor of type `F`.
-  public subscript<F: LinearizableFactor>(_ perFactorID: Int, factorType _: F.Type) -> F.ErrorVector {
+  public subscript<F: VectorFactor>(_ perFactorID: Int, factorType _: F.Type) -> F.ErrorVector {
     let array = storage[ObjectIdentifier(F.self)].unsafelyUnwrapped
     return ArrayBuffer<F.ErrorVector>(unsafelyDowncasting: array).withUnsafeBufferPointer { b in
       b[perFactorID]

--- a/Sources/SwiftFusion/Inference/BetweenFactor.swift
+++ b/Sources/SwiftFusion/Inference/BetweenFactor.swift
@@ -15,9 +15,7 @@
 import PenguinStructures
 
 /// A factor that specifies a difference between two poses.
-public struct BetweenFactor<Pose: LieGroup>: LinearizableFactor {
-  public typealias Variables = Tuple2<Pose, Pose>
-
+public struct BetweenFactor<Pose: LieGroup>: LinearizableFactor2 {
   public let edges: Variables.Indices
   public let difference: Pose
 
@@ -26,21 +24,9 @@ public struct BetweenFactor<Pose: LieGroup>: LinearizableFactor {
     self.difference = difference
   }
 
-  public typealias ErrorVector = Pose.TangentVector
-  public func errorVector(_ start: Pose, _ end: Pose) -> ErrorVector {
+  @differentiable
+  public func errorVector(_ start: Pose, _ end: Pose) -> Pose.TangentVector {
     let actualMotion = between(start, end)
     return difference.localCoordinate(actualMotion)
-  }
-
-  // Note: All the remaining code in this factor is boilerplate that we can eventually eliminate
-  // with sugar.
-  
-  public func error(at x: Variables) -> Double {
-    return 0.5 * errorVector(at: x).squaredNorm
-  }
-
-  @differentiable
-  public func errorVector(at x: Variables) -> Pose.TangentVector {
-    return errorVector(x.head, x.tail.head)
   }
 }

--- a/Sources/SwiftFusion/Inference/BetweenFactor.swift
+++ b/Sources/SwiftFusion/Inference/BetweenFactor.swift
@@ -15,14 +15,7 @@
 import PenguinStructures
 
 /// A factor that specifies a difference between two poses.
-///
-/// `JacobianRows` specifies the `Rows` parameter of the Jacobian of this factor. See the
-/// documentation on `JacobianFactor.jacobian` for more information. Use the typealiases below to
-/// avoid specifying this type parameter every time you create an instance.
-public struct BetweenFactor<Pose: LieGroup, JacobianRows: FixedSizeArray>:
-  LinearizableFactor
-  where JacobianRows.Element == Tuple2<Pose.TangentVector, Pose.TangentVector>
-{
+public struct BetweenFactor<Pose: LieGroup>: LinearizableFactor {
   public typealias Variables = Tuple2<Pose, Pose>
 
   public let edges: Variables.Indices
@@ -46,18 +39,8 @@ public struct BetweenFactor<Pose: LieGroup, JacobianRows: FixedSizeArray>:
     return 0.5 * errorVector(at: x).squaredNorm
   }
 
+  @differentiable
   public func errorVector(at x: Variables) -> Pose.TangentVector {
     return errorVector(x.head, x.tail.head)
   }
-
-  public typealias Linearization = JacobianFactor<JacobianRows, ErrorVector>
-  public func linearized(at x: Variables) -> Linearization {
-    Linearization(linearizing: errorVector, at: x, edges: edges)
-  }
 }
-
-/// A between factor on `Pose2`.
-public typealias BetweenFactor2 = BetweenFactor<Pose2, Array3<Tuple2<Vector3, Vector3>>>
-
-/// A between factor on `Pose3`.
-public typealias BetweenFactor3 = BetweenFactor<Pose3, Array6<Tuple2<Vector6, Vector6>>>

--- a/Sources/SwiftFusion/Inference/BetweenFactorAlternative.swift
+++ b/Sources/SwiftFusion/Inference/BetweenFactorAlternative.swift
@@ -15,10 +15,7 @@
 import PenguinStructures
 
 /// A BetweenFactor alternative that uses the Chordal (Frobenious) norm on rotation for Pose3
-public struct BetweenFactorAlternative<JacobianRows: FixedSizeArray>:
-  LinearizableFactor
-  where JacobianRows.Element == Tuple2<Pose3.TangentVector, Pose3.TangentVector>
-{
+public struct BetweenFactorAlternative: LinearizableFactor {
   public typealias Variables = Tuple2<Pose3, Pose3>
 
   public let edges: Variables.Indices
@@ -47,13 +44,9 @@ public struct BetweenFactorAlternative<JacobianRows: FixedSizeArray>:
     return 0.5 * errorVector(at: x).squaredNorm
   }
 
+  @differentiable
   public func errorVector(at x: Variables) -> ErrorVector {
     return errorVector(x.head, x.tail.head)
-  }
-
-  public typealias Linearization = JacobianFactor<JacobianRows, ErrorVector>
-  public func linearized(at x: Variables) -> Linearization {
-    Linearization(linearizing: errorVector, at: x, edges: edges)
   }
 }
 
@@ -68,6 +61,3 @@ public typealias JacobianFactor12x6_1 = JacobianFactor<Array12<Tuple1<Vector6>>,
 
 /// A Jacobian factor with 2 6-dimensional inputs and a 12-dimensional error vector.
 public typealias JacobianFactor12x6_2 = JacobianFactor<Array12<Tuple2<Vector6, Vector6>>, Vector12>
-
-/// A between factor on `Pose3`.
-public typealias BetweenFactorAlternative3 = BetweenFactorAlternative<Array12<Tuple2<Vector6, Vector6>>>

--- a/Sources/SwiftFusion/Inference/BetweenFactorAlternative.swift
+++ b/Sources/SwiftFusion/Inference/BetweenFactorAlternative.swift
@@ -15,9 +15,7 @@
 import PenguinStructures
 
 /// A BetweenFactor alternative that uses the Chordal (Frobenious) norm on rotation for Pose3
-public struct BetweenFactorAlternative: LinearizableFactor {
-  public typealias Variables = Tuple2<Pose3, Pose3>
-
+public struct BetweenFactorAlternative: LinearizableFactor2 {
   public let edges: Variables.Indices
   public let difference: Pose3
 
@@ -26,8 +24,8 @@ public struct BetweenFactorAlternative: LinearizableFactor {
     self.difference = difference
   }
 
-  public typealias ErrorVector = Vector12
-  public func errorVector(_ start: Pose3, _ end: Pose3) -> ErrorVector {
+  @differentiable
+  public func errorVector(_ start: Pose3, _ end: Pose3) -> Vector12 {
     let actualMotion = between(start, end)
     let R = actualMotion.coordinate.rot.coordinate.R + (-1) * difference.rot.coordinate.R
     let t = actualMotion.t - difference.t
@@ -35,18 +33,6 @@ public struct BetweenFactorAlternative: LinearizableFactor {
     // TODO(fan): Discuss with Marc why this would lead to failing CI
     // return Vector12(R[0, 0], R[0, 1], R[0, 2], R[1, 0], R[1, 1], R[1, 2], R[2, 0], R[2, 1], R[2, 2], t.x, t.y, t.z)
     return Vector12(R.s00, R.s01, R.s02, R.s10, R.s11, R.s12, R.s20, R.s21, R.s22, t.x, t.y, t.z)
-  }
-
-  // Note: All the remaining code in this factor is boilerplate that we can eventually eliminate
-  // with sugar.
-  
-  public func error(at x: Variables) -> Double {
-    return 0.5 * errorVector(at: x).squaredNorm
-  }
-
-  @differentiable
-  public func errorVector(at x: Variables) -> ErrorVector {
-    return errorVector(x.head, x.tail.head)
   }
 }
 

--- a/Sources/SwiftFusion/Inference/ChordalInitialization.swift
+++ b/Sources/SwiftFusion/Inference/ChordalInitialization.swift
@@ -18,11 +18,8 @@ import TensorFlow
 /// A relaxed version of the Rot3 between that uses the Chordal (Frobenious) norm on rotation
 /// Please refer to Carlone15icra (Initialization Techniques for 3D SLAM: a Survey on Rotation Estimation and its Use in Pose Graph Optimization)
 /// for explanation.
-public struct RelaxedRotationFactorRot3: LinearizableFactor
+public struct RelaxedRotationFactorRot3: LinearizableFactor2
 {
-  public typealias Variables = Tuple2<Matrix3, Matrix3>
-  public typealias JacobianRows = Array9<Tuple2<Matrix3.TangentVector, Matrix3.TangentVector>>
-  
   public let edges: Variables.Indices
   public let difference: Matrix3
   
@@ -39,26 +36,11 @@ public struct RelaxedRotationFactorRot3: LinearizableFactor
     let R1h = matmul(R12, R2.transposed()).transposed()
     return (R1h - R1).vec
   }
-  
-  // Note: All the remaining code in this factor is boilerplate that we can eventually eliminate
-  // with sugar.
-  
-  public func error(at x: Variables) -> Double {
-    return 0.5 * errorVector(at: x).squaredNorm
-  }
-  
-  @differentiable
-  public func errorVector(at x: Variables) -> ErrorVector {
-    return errorVector(x.head, x.tail.head)
-  }
 }
 
 /// A factor for the anchor in chordal initialization
-public struct RelaxedAnchorFactorRot3: LinearizableFactor
+public struct RelaxedAnchorFactorRot3: LinearizableFactor1
 {
-  public typealias Variables = Tuple1<Matrix3>
-  public typealias JacobianRows = Array9<Tuple1<Matrix3.TangentVector>>
-  
   public let edges: Variables.Indices
   public let prior: Matrix3
   
@@ -72,18 +54,6 @@ public struct RelaxedAnchorFactorRot3: LinearizableFactor
   @differentiable
   public func errorVector(_ val: Matrix3) -> ErrorVector {
     (val - prior).vec
-  }
-  
-  // Note: All the remaining code in this factor is boilerplate that we can eventually eliminate
-  // with sugar.
-  
-  public func error(at x: Variables) -> Double {
-    return 0.5 * errorVector(at: x).squaredNorm
-  }
-  
-  @differentiable
-  public func errorVector(at x: Variables) -> ErrorVector {
-    return errorVector(x.head)
   }
 }
 

--- a/Sources/SwiftFusion/Inference/Factor.swift
+++ b/Sources/SwiftFusion/Inference/Factor.swift
@@ -22,34 +22,63 @@ public protocol Factor {
   /// The IDs of the variables adjacent to this factor.
   var edges: Variables.Indices { get }
 
-  /// Returns the error given the values of the adjacent variables.
+  /// Returns the error at `x`.
+  ///
+  /// This is typically interpreted as negative log-likelihood.
   func error(at x: Variables) -> Double
 }
 
-/// A factor with an error vector, which can be linearized around any point.
-public protocol LinearizableFactor: Factor {
+/// A factor whose `error` is a function of a vector-valued `errorVector` function.
+public protocol VectorFactor: Factor {
   /// The type of the error vector.
   // TODO: Add a description of what an error vector is.
   associatedtype ErrorVector: EuclideanVectorN
 
-  /// Returns the error vector given the values of the adjacent variables.
+  /// Returns the error vector at `x`.
   func errorVector(at x: Variables) -> ErrorVector
 
-  /// The type of the linearized factor.
-  associatedtype Linearization: GaussianFactor
+  /// A factor whose variables are the `Differentiable` subset of `Self`'s variables.
+  associatedtype LinearizableComponent: LinearizableFactor
+  where LinearizableComponent.ErrorVector == ErrorVector
 
-  /// Returns a factor whose `errorVector` linearly approximates `self`'s `errorVector` around the
-  /// given point.
-  func linearized(at x: Variables) -> Linearization
+  /// Returns the linearizable component of `self` at `x`, and returns the `Differentiable` subset
+  /// of `x`.
+  func linearizableComponent(at x: Variables)
+    -> (LinearizableComponent, LinearizableComponent.Variables)
 }
 
+/// A factor whose `errorVector` function is linearizable with respect to all the variables.
+public protocol LinearizableFactor: VectorFactor
+where Variables: DifferentiableVariableTuple, Variables.TangentVector: EuclideanVectorN
+{
+  /// Returns the error vector given the values of the adjacent variables.
+  @differentiable
+  func errorVector(at x: Variables) -> ErrorVector
+}
+
+extension LinearizableFactor {
+  public func linearizableComponent(at x: Variables) -> (Self, Variables) {
+    return (self, x)
+  }
+}
+
+/// Do not use this; it is a workaround for a Swift compiler limitation.
+public protocol GaussianFactor_: Factor where Variables: EuclideanVectorN {}
+
 /// A factor whose `errorVector` is a linear function of the variables, plus a constant.
-public protocol GaussianFactor: LinearizableFactor where Variables: EuclideanVectorN {
+public protocol GaussianFactor: LinearizableFactor, GaussianFactor_ {
   /// The linear component of `errorVector`.
   func errorVector_linearComponent(_ x: Variables) -> ErrorVector
 
   /// The adjoint (aka "transpose" or "dual") of the linear component of `errorVector`.
   func errorVector_linearComponent_adjoint(_ y: ErrorVector) -> Variables
+}
+
+/// A linear approximation of a linearizable factor.
+public protocol LinearApproximationFactor: GaussianFactor {
+  /// Creates a factor that linearly approximates `f` at `x`.
+  init<F: LinearizableFactor>(linearizing f: F, at x: F.Variables)
+  where F.Variables.TangentVector == Variables, F.ErrorVector == ErrorVector
 }
 
 // MARK: - `VariableTuple`.
@@ -193,27 +222,23 @@ extension Tuple: VariableTuple where Tail: VariableTuple {
 }
 
 /// Tuple of differentiable variable types suitable for a factor.
-protocol DifferentiableVariableTuple: VariableTuple {
-  /// A tuple of `TypedID`s referring to variables adjacent to a factor.
-  associatedtype TangentIndices: TupleProtocol
-
+public protocol DifferentiableVariableTuple: Differentiable & VariableTuple
+where TangentVector: DifferentiableVariableTuple {
   /// Returns the indices of the linearized variables corresponding to `indices` in the linearized
   /// factor graph.
-  static func linearized(_ indices: Indices) -> TangentIndices
+  static func linearized(_ indices: Indices) -> TangentVector.Indices
 }
 
 extension Empty: DifferentiableVariableTuple {
-  typealias TangentIndices = Self
-  static func linearized(_ indices: Indices) -> TangentIndices {
+  public static func linearized(_ indices: Indices) -> TangentVector.Indices {
     indices
   }
 }
 
 extension Tuple: DifferentiableVariableTuple
 where Head: Differentiable, Tail: DifferentiableVariableTuple {
-  typealias TangentIndices = Tuple<TypedID<Head.TangentVector>, Tail.TangentIndices>
-  static func linearized(_ indices: Indices) -> TangentIndices {
-    TangentIndices(
+  public static func linearized(_ indices: Indices) -> TangentVector.Indices {
+    TangentVector.Indices(
       head: TypedID<Head.TangentVector>(indices.head.perTypeID),
       tail: Tail.linearized(indices.tail)
     )

--- a/Sources/SwiftFusion/Inference/FactorBoilerplate.swift
+++ b/Sources/SwiftFusion/Inference/FactorBoilerplate.swift
@@ -1,0 +1,824 @@
+// WARNING: This is a generated file. Do not edit it. Instead, edit the corresponding ".gyb" file.
+// See "generate.sh" in the root of this repository for instructions how to regenerate files.
+
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 1)
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Implements fixed-arity protocols `Factor1`, `VectorFactor1`, `LinearizableFactor1`, `Factor2`,
+/// etc. It takes less boilerplate to conform to these fixed-arity protocols than it does to
+/// conform to the arbitrary-arity protocols `Factor`, `VectorFactor`, and `LinearizableFactor`.
+
+import PenguinStructures
+
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 22)
+
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 33)
+
+// Artifact of Swift weakness.
+/// Do not use this. Use `Factor1` instead.
+public protocol Factor1_ {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 38)
+  /// The 0-th variable type.
+  associatedtype V0
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 41)
+
+  /// Returns the error at the given point.
+  ///
+  /// This is typically interpreted as negative log-likelihood.
+  func error(_: V0) -> Double
+}
+
+/// A factor in a factor graph.
+public protocol Factor1: Factor, Factor1_
+  where Variables == Tuple1<V0> {}
+
+extension Factor1 {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 54)
+  /// The variable vertex for this factor's 0-th variable.
+  public var input0ID: TypedID<V0> { return edges.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 57)
+
+  // Forwarding implementation.
+  public func error(at x: Variables) -> Double {
+    return error(x.head)
+  }
+}
+
+// Artifact of Swift weakness.
+/// Do not use this. Use `VectorFactor1` instead.
+public protocol VectorFactor1_ {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 68)
+  /// The 0-th variable type.
+  associatedtype V0
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 71)
+
+  typealias Variables = Tuple1<V0>
+
+  associatedtype ErrorVector: EuclideanVectorN
+  associatedtype LinearizableComponent: LinearizableFactor
+
+  /// Returns the error vector at the given point.
+  func errorVector(_: V0) -> ErrorVector
+
+  /// Returns the linearizable component of `self` at the given point, and returns the
+  /// `Differentiable` subset of the given variables.
+  func linearizableComponent(_: V0)
+    -> (LinearizableComponent, LinearizableComponent.Variables)
+}
+
+/// A factor whose `error` is a function of a vector-valued `errorVector` function.
+public protocol VectorFactor1: VectorFactor, VectorFactor1_
+  where Variables == Tuple1<V0> {}
+
+extension VectorFactor1 {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 92)
+  /// The variable vertex for this factor's 0-th variable.
+  public var input0ID: TypedID<V0> { return edges.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 95)
+
+  // Implements the error as half the squared norm of the error vector.
+  public func error(at x: Variables) -> Double {
+    return 0.5 * errorVector(at: x).squaredNorm
+  }
+
+  // Forwarding implementation.
+  public func errorVector(at x: Variables) -> ErrorVector {
+    return errorVector(x.head)
+  }
+
+  // Forwarding implementation.
+  public func linearizableComponent(at x: Variables)
+    -> (LinearizableComponent, LinearizableComponent.Variables)
+  {
+    return linearizableComponent(x.head)
+  }
+}
+
+// Artifact of Swift weakness.
+/// Do not use this. Use `LinearizableFactor1` instead.
+public protocol LinearizableFactor1_ {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 118)
+  /// The 0-th variable type.
+  associatedtype V0: Differentiable
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 121)
+
+  typealias Variables = Tuple1<V0>
+  typealias LinearizableComponent = Self
+
+  associatedtype ErrorVector: EuclideanVectorN
+
+  /// Returns the error vector given the values of the adjacent variables.
+  @differentiable
+  func errorVector(_: V0) -> ErrorVector
+}
+
+/// A factor, with 1 variable(s), in a factor graph.
+public protocol LinearizableFactor1: LinearizableFactor, LinearizableFactor1_
+  where Variables == Tuple1<V0>, LinearizableComponent == Self {}
+
+extension LinearizableFactor1 {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 138)
+  /// The variable vertex for this factor's 0-th variable.
+  public var input0ID: TypedID<V0> { return edges.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 141)
+
+  // Implements the error as half the squared norm of the error vector.
+  public func error(at x: Variables) -> Double {
+    return 0.5 * errorVector(at: x).squaredNorm
+  }
+
+  // Forwarding implementation.
+  @differentiable
+  public func errorVector(at x: Variables) -> ErrorVector {
+    return errorVector(x.head)
+  }
+}
+
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 22)
+
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 33)
+
+// Artifact of Swift weakness.
+/// Do not use this. Use `Factor2` instead.
+public protocol Factor2_ {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 38)
+  /// The 0-th variable type.
+  associatedtype V0
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 38)
+  /// The 1-th variable type.
+  associatedtype V1
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 41)
+
+  /// Returns the error at the given point.
+  ///
+  /// This is typically interpreted as negative log-likelihood.
+  func error(_: V0, _: V1) -> Double
+}
+
+/// A factor in a factor graph.
+public protocol Factor2: Factor, Factor2_
+  where Variables == Tuple2<V0, V1> {}
+
+extension Factor2 {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 54)
+  /// The variable vertex for this factor's 0-th variable.
+  public var input0ID: TypedID<V0> { return edges.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 54)
+  /// The variable vertex for this factor's 1-th variable.
+  public var input1ID: TypedID<V1> { return edges.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 57)
+
+  // Forwarding implementation.
+  public func error(at x: Variables) -> Double {
+    return error(x.head, x.tail.head)
+  }
+}
+
+// Artifact of Swift weakness.
+/// Do not use this. Use `VectorFactor2` instead.
+public protocol VectorFactor2_ {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 68)
+  /// The 0-th variable type.
+  associatedtype V0
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 68)
+  /// The 1-th variable type.
+  associatedtype V1
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 71)
+
+  typealias Variables = Tuple2<V0, V1>
+
+  associatedtype ErrorVector: EuclideanVectorN
+  associatedtype LinearizableComponent: LinearizableFactor
+
+  /// Returns the error vector at the given point.
+  func errorVector(_: V0, _: V1) -> ErrorVector
+
+  /// Returns the linearizable component of `self` at the given point, and returns the
+  /// `Differentiable` subset of the given variables.
+  func linearizableComponent(_: V0, _: V1)
+    -> (LinearizableComponent, LinearizableComponent.Variables)
+}
+
+/// A factor whose `error` is a function of a vector-valued `errorVector` function.
+public protocol VectorFactor2: VectorFactor, VectorFactor2_
+  where Variables == Tuple2<V0, V1> {}
+
+extension VectorFactor2 {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 92)
+  /// The variable vertex for this factor's 0-th variable.
+  public var input0ID: TypedID<V0> { return edges.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 92)
+  /// The variable vertex for this factor's 1-th variable.
+  public var input1ID: TypedID<V1> { return edges.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 95)
+
+  // Implements the error as half the squared norm of the error vector.
+  public func error(at x: Variables) -> Double {
+    return 0.5 * errorVector(at: x).squaredNorm
+  }
+
+  // Forwarding implementation.
+  public func errorVector(at x: Variables) -> ErrorVector {
+    return errorVector(x.head, x.tail.head)
+  }
+
+  // Forwarding implementation.
+  public func linearizableComponent(at x: Variables)
+    -> (LinearizableComponent, LinearizableComponent.Variables)
+  {
+    return linearizableComponent(x.head, x.tail.head)
+  }
+}
+
+// Artifact of Swift weakness.
+/// Do not use this. Use `LinearizableFactor2` instead.
+public protocol LinearizableFactor2_ {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 118)
+  /// The 0-th variable type.
+  associatedtype V0: Differentiable
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 118)
+  /// The 1-th variable type.
+  associatedtype V1: Differentiable
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 121)
+
+  typealias Variables = Tuple2<V0, V1>
+  typealias LinearizableComponent = Self
+
+  associatedtype ErrorVector: EuclideanVectorN
+
+  /// Returns the error vector given the values of the adjacent variables.
+  @differentiable
+  func errorVector(_: V0, _: V1) -> ErrorVector
+}
+
+/// A factor, with 2 variable(s), in a factor graph.
+public protocol LinearizableFactor2: LinearizableFactor, LinearizableFactor2_
+  where Variables == Tuple2<V0, V1>, LinearizableComponent == Self {}
+
+extension LinearizableFactor2 {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 138)
+  /// The variable vertex for this factor's 0-th variable.
+  public var input0ID: TypedID<V0> { return edges.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 138)
+  /// The variable vertex for this factor's 1-th variable.
+  public var input1ID: TypedID<V1> { return edges.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 141)
+
+  // Implements the error as half the squared norm of the error vector.
+  public func error(at x: Variables) -> Double {
+    return 0.5 * errorVector(at: x).squaredNorm
+  }
+
+  // Forwarding implementation.
+  @differentiable
+  public func errorVector(at x: Variables) -> ErrorVector {
+    return errorVector(x.head, x.tail.head)
+  }
+}
+
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 22)
+
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 33)
+
+// Artifact of Swift weakness.
+/// Do not use this. Use `Factor3` instead.
+public protocol Factor3_ {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 38)
+  /// The 0-th variable type.
+  associatedtype V0
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 38)
+  /// The 1-th variable type.
+  associatedtype V1
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 38)
+  /// The 2-th variable type.
+  associatedtype V2
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 41)
+
+  /// Returns the error at the given point.
+  ///
+  /// This is typically interpreted as negative log-likelihood.
+  func error(_: V0, _: V1, _: V2) -> Double
+}
+
+/// A factor in a factor graph.
+public protocol Factor3: Factor, Factor3_
+  where Variables == Tuple3<V0, V1, V2> {}
+
+extension Factor3 {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 54)
+  /// The variable vertex for this factor's 0-th variable.
+  public var input0ID: TypedID<V0> { return edges.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 54)
+  /// The variable vertex for this factor's 1-th variable.
+  public var input1ID: TypedID<V1> { return edges.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 54)
+  /// The variable vertex for this factor's 2-th variable.
+  public var input2ID: TypedID<V2> { return edges.tail.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 57)
+
+  // Forwarding implementation.
+  public func error(at x: Variables) -> Double {
+    return error(x.head, x.tail.head, x.tail.tail.head)
+  }
+}
+
+// Artifact of Swift weakness.
+/// Do not use this. Use `VectorFactor3` instead.
+public protocol VectorFactor3_ {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 68)
+  /// The 0-th variable type.
+  associatedtype V0
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 68)
+  /// The 1-th variable type.
+  associatedtype V1
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 68)
+  /// The 2-th variable type.
+  associatedtype V2
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 71)
+
+  typealias Variables = Tuple3<V0, V1, V2>
+
+  associatedtype ErrorVector: EuclideanVectorN
+  associatedtype LinearizableComponent: LinearizableFactor
+
+  /// Returns the error vector at the given point.
+  func errorVector(_: V0, _: V1, _: V2) -> ErrorVector
+
+  /// Returns the linearizable component of `self` at the given point, and returns the
+  /// `Differentiable` subset of the given variables.
+  func linearizableComponent(_: V0, _: V1, _: V2)
+    -> (LinearizableComponent, LinearizableComponent.Variables)
+}
+
+/// A factor whose `error` is a function of a vector-valued `errorVector` function.
+public protocol VectorFactor3: VectorFactor, VectorFactor3_
+  where Variables == Tuple3<V0, V1, V2> {}
+
+extension VectorFactor3 {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 92)
+  /// The variable vertex for this factor's 0-th variable.
+  public var input0ID: TypedID<V0> { return edges.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 92)
+  /// The variable vertex for this factor's 1-th variable.
+  public var input1ID: TypedID<V1> { return edges.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 92)
+  /// The variable vertex for this factor's 2-th variable.
+  public var input2ID: TypedID<V2> { return edges.tail.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 95)
+
+  // Implements the error as half the squared norm of the error vector.
+  public func error(at x: Variables) -> Double {
+    return 0.5 * errorVector(at: x).squaredNorm
+  }
+
+  // Forwarding implementation.
+  public func errorVector(at x: Variables) -> ErrorVector {
+    return errorVector(x.head, x.tail.head, x.tail.tail.head)
+  }
+
+  // Forwarding implementation.
+  public func linearizableComponent(at x: Variables)
+    -> (LinearizableComponent, LinearizableComponent.Variables)
+  {
+    return linearizableComponent(x.head, x.tail.head, x.tail.tail.head)
+  }
+}
+
+// Artifact of Swift weakness.
+/// Do not use this. Use `LinearizableFactor3` instead.
+public protocol LinearizableFactor3_ {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 118)
+  /// The 0-th variable type.
+  associatedtype V0: Differentiable
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 118)
+  /// The 1-th variable type.
+  associatedtype V1: Differentiable
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 118)
+  /// The 2-th variable type.
+  associatedtype V2: Differentiable
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 121)
+
+  typealias Variables = Tuple3<V0, V1, V2>
+  typealias LinearizableComponent = Self
+
+  associatedtype ErrorVector: EuclideanVectorN
+
+  /// Returns the error vector given the values of the adjacent variables.
+  @differentiable
+  func errorVector(_: V0, _: V1, _: V2) -> ErrorVector
+}
+
+/// A factor, with 3 variable(s), in a factor graph.
+public protocol LinearizableFactor3: LinearizableFactor, LinearizableFactor3_
+  where Variables == Tuple3<V0, V1, V2>, LinearizableComponent == Self {}
+
+extension LinearizableFactor3 {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 138)
+  /// The variable vertex for this factor's 0-th variable.
+  public var input0ID: TypedID<V0> { return edges.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 138)
+  /// The variable vertex for this factor's 1-th variable.
+  public var input1ID: TypedID<V1> { return edges.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 138)
+  /// The variable vertex for this factor's 2-th variable.
+  public var input2ID: TypedID<V2> { return edges.tail.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 141)
+
+  // Implements the error as half the squared norm of the error vector.
+  public func error(at x: Variables) -> Double {
+    return 0.5 * errorVector(at: x).squaredNorm
+  }
+
+  // Forwarding implementation.
+  @differentiable
+  public func errorVector(at x: Variables) -> ErrorVector {
+    return errorVector(x.head, x.tail.head, x.tail.tail.head)
+  }
+}
+
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 22)
+
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 33)
+
+// Artifact of Swift weakness.
+/// Do not use this. Use `Factor4` instead.
+public protocol Factor4_ {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 38)
+  /// The 0-th variable type.
+  associatedtype V0
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 38)
+  /// The 1-th variable type.
+  associatedtype V1
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 38)
+  /// The 2-th variable type.
+  associatedtype V2
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 38)
+  /// The 3-th variable type.
+  associatedtype V3
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 41)
+
+  /// Returns the error at the given point.
+  ///
+  /// This is typically interpreted as negative log-likelihood.
+  func error(_: V0, _: V1, _: V2, _: V3) -> Double
+}
+
+/// A factor in a factor graph.
+public protocol Factor4: Factor, Factor4_
+  where Variables == Tuple4<V0, V1, V2, V3> {}
+
+extension Factor4 {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 54)
+  /// The variable vertex for this factor's 0-th variable.
+  public var input0ID: TypedID<V0> { return edges.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 54)
+  /// The variable vertex for this factor's 1-th variable.
+  public var input1ID: TypedID<V1> { return edges.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 54)
+  /// The variable vertex for this factor's 2-th variable.
+  public var input2ID: TypedID<V2> { return edges.tail.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 54)
+  /// The variable vertex for this factor's 3-th variable.
+  public var input3ID: TypedID<V3> { return edges.tail.tail.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 57)
+
+  // Forwarding implementation.
+  public func error(at x: Variables) -> Double {
+    return error(x.head, x.tail.head, x.tail.tail.head, x.tail.tail.tail.head)
+  }
+}
+
+// Artifact of Swift weakness.
+/// Do not use this. Use `VectorFactor4` instead.
+public protocol VectorFactor4_ {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 68)
+  /// The 0-th variable type.
+  associatedtype V0
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 68)
+  /// The 1-th variable type.
+  associatedtype V1
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 68)
+  /// The 2-th variable type.
+  associatedtype V2
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 68)
+  /// The 3-th variable type.
+  associatedtype V3
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 71)
+
+  typealias Variables = Tuple4<V0, V1, V2, V3>
+
+  associatedtype ErrorVector: EuclideanVectorN
+  associatedtype LinearizableComponent: LinearizableFactor
+
+  /// Returns the error vector at the given point.
+  func errorVector(_: V0, _: V1, _: V2, _: V3) -> ErrorVector
+
+  /// Returns the linearizable component of `self` at the given point, and returns the
+  /// `Differentiable` subset of the given variables.
+  func linearizableComponent(_: V0, _: V1, _: V2, _: V3)
+    -> (LinearizableComponent, LinearizableComponent.Variables)
+}
+
+/// A factor whose `error` is a function of a vector-valued `errorVector` function.
+public protocol VectorFactor4: VectorFactor, VectorFactor4_
+  where Variables == Tuple4<V0, V1, V2, V3> {}
+
+extension VectorFactor4 {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 92)
+  /// The variable vertex for this factor's 0-th variable.
+  public var input0ID: TypedID<V0> { return edges.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 92)
+  /// The variable vertex for this factor's 1-th variable.
+  public var input1ID: TypedID<V1> { return edges.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 92)
+  /// The variable vertex for this factor's 2-th variable.
+  public var input2ID: TypedID<V2> { return edges.tail.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 92)
+  /// The variable vertex for this factor's 3-th variable.
+  public var input3ID: TypedID<V3> { return edges.tail.tail.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 95)
+
+  // Implements the error as half the squared norm of the error vector.
+  public func error(at x: Variables) -> Double {
+    return 0.5 * errorVector(at: x).squaredNorm
+  }
+
+  // Forwarding implementation.
+  public func errorVector(at x: Variables) -> ErrorVector {
+    return errorVector(x.head, x.tail.head, x.tail.tail.head, x.tail.tail.tail.head)
+  }
+
+  // Forwarding implementation.
+  public func linearizableComponent(at x: Variables)
+    -> (LinearizableComponent, LinearizableComponent.Variables)
+  {
+    return linearizableComponent(x.head, x.tail.head, x.tail.tail.head, x.tail.tail.tail.head)
+  }
+}
+
+// Artifact of Swift weakness.
+/// Do not use this. Use `LinearizableFactor4` instead.
+public protocol LinearizableFactor4_ {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 118)
+  /// The 0-th variable type.
+  associatedtype V0: Differentiable
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 118)
+  /// The 1-th variable type.
+  associatedtype V1: Differentiable
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 118)
+  /// The 2-th variable type.
+  associatedtype V2: Differentiable
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 118)
+  /// The 3-th variable type.
+  associatedtype V3: Differentiable
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 121)
+
+  typealias Variables = Tuple4<V0, V1, V2, V3>
+  typealias LinearizableComponent = Self
+
+  associatedtype ErrorVector: EuclideanVectorN
+
+  /// Returns the error vector given the values of the adjacent variables.
+  @differentiable
+  func errorVector(_: V0, _: V1, _: V2, _: V3) -> ErrorVector
+}
+
+/// A factor, with 4 variable(s), in a factor graph.
+public protocol LinearizableFactor4: LinearizableFactor, LinearizableFactor4_
+  where Variables == Tuple4<V0, V1, V2, V3>, LinearizableComponent == Self {}
+
+extension LinearizableFactor4 {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 138)
+  /// The variable vertex for this factor's 0-th variable.
+  public var input0ID: TypedID<V0> { return edges.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 138)
+  /// The variable vertex for this factor's 1-th variable.
+  public var input1ID: TypedID<V1> { return edges.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 138)
+  /// The variable vertex for this factor's 2-th variable.
+  public var input2ID: TypedID<V2> { return edges.tail.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 138)
+  /// The variable vertex for this factor's 3-th variable.
+  public var input3ID: TypedID<V3> { return edges.tail.tail.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 141)
+
+  // Implements the error as half the squared norm of the error vector.
+  public func error(at x: Variables) -> Double {
+    return 0.5 * errorVector(at: x).squaredNorm
+  }
+
+  // Forwarding implementation.
+  @differentiable
+  public func errorVector(at x: Variables) -> ErrorVector {
+    return errorVector(x.head, x.tail.head, x.tail.tail.head, x.tail.tail.tail.head)
+  }
+}
+
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 22)
+
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 33)
+
+// Artifact of Swift weakness.
+/// Do not use this. Use `Factor5` instead.
+public protocol Factor5_ {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 38)
+  /// The 0-th variable type.
+  associatedtype V0
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 38)
+  /// The 1-th variable type.
+  associatedtype V1
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 38)
+  /// The 2-th variable type.
+  associatedtype V2
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 38)
+  /// The 3-th variable type.
+  associatedtype V3
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 38)
+  /// The 4-th variable type.
+  associatedtype V4
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 41)
+
+  /// Returns the error at the given point.
+  ///
+  /// This is typically interpreted as negative log-likelihood.
+  func error(_: V0, _: V1, _: V2, _: V3, _: V4) -> Double
+}
+
+/// A factor in a factor graph.
+public protocol Factor5: Factor, Factor5_
+  where Variables == Tuple5<V0, V1, V2, V3, V4> {}
+
+extension Factor5 {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 54)
+  /// The variable vertex for this factor's 0-th variable.
+  public var input0ID: TypedID<V0> { return edges.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 54)
+  /// The variable vertex for this factor's 1-th variable.
+  public var input1ID: TypedID<V1> { return edges.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 54)
+  /// The variable vertex for this factor's 2-th variable.
+  public var input2ID: TypedID<V2> { return edges.tail.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 54)
+  /// The variable vertex for this factor's 3-th variable.
+  public var input3ID: TypedID<V3> { return edges.tail.tail.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 54)
+  /// The variable vertex for this factor's 4-th variable.
+  public var input4ID: TypedID<V4> { return edges.tail.tail.tail.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 57)
+
+  // Forwarding implementation.
+  public func error(at x: Variables) -> Double {
+    return error(x.head, x.tail.head, x.tail.tail.head, x.tail.tail.tail.head, x.tail.tail.tail.tail.head)
+  }
+}
+
+// Artifact of Swift weakness.
+/// Do not use this. Use `VectorFactor5` instead.
+public protocol VectorFactor5_ {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 68)
+  /// The 0-th variable type.
+  associatedtype V0
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 68)
+  /// The 1-th variable type.
+  associatedtype V1
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 68)
+  /// The 2-th variable type.
+  associatedtype V2
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 68)
+  /// The 3-th variable type.
+  associatedtype V3
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 68)
+  /// The 4-th variable type.
+  associatedtype V4
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 71)
+
+  typealias Variables = Tuple5<V0, V1, V2, V3, V4>
+
+  associatedtype ErrorVector: EuclideanVectorN
+  associatedtype LinearizableComponent: LinearizableFactor
+
+  /// Returns the error vector at the given point.
+  func errorVector(_: V0, _: V1, _: V2, _: V3, _: V4) -> ErrorVector
+
+  /// Returns the linearizable component of `self` at the given point, and returns the
+  /// `Differentiable` subset of the given variables.
+  func linearizableComponent(_: V0, _: V1, _: V2, _: V3, _: V4)
+    -> (LinearizableComponent, LinearizableComponent.Variables)
+}
+
+/// A factor whose `error` is a function of a vector-valued `errorVector` function.
+public protocol VectorFactor5: VectorFactor, VectorFactor5_
+  where Variables == Tuple5<V0, V1, V2, V3, V4> {}
+
+extension VectorFactor5 {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 92)
+  /// The variable vertex for this factor's 0-th variable.
+  public var input0ID: TypedID<V0> { return edges.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 92)
+  /// The variable vertex for this factor's 1-th variable.
+  public var input1ID: TypedID<V1> { return edges.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 92)
+  /// The variable vertex for this factor's 2-th variable.
+  public var input2ID: TypedID<V2> { return edges.tail.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 92)
+  /// The variable vertex for this factor's 3-th variable.
+  public var input3ID: TypedID<V3> { return edges.tail.tail.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 92)
+  /// The variable vertex for this factor's 4-th variable.
+  public var input4ID: TypedID<V4> { return edges.tail.tail.tail.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 95)
+
+  // Implements the error as half the squared norm of the error vector.
+  public func error(at x: Variables) -> Double {
+    return 0.5 * errorVector(at: x).squaredNorm
+  }
+
+  // Forwarding implementation.
+  public func errorVector(at x: Variables) -> ErrorVector {
+    return errorVector(x.head, x.tail.head, x.tail.tail.head, x.tail.tail.tail.head, x.tail.tail.tail.tail.head)
+  }
+
+  // Forwarding implementation.
+  public func linearizableComponent(at x: Variables)
+    -> (LinearizableComponent, LinearizableComponent.Variables)
+  {
+    return linearizableComponent(x.head, x.tail.head, x.tail.tail.head, x.tail.tail.tail.head, x.tail.tail.tail.tail.head)
+  }
+}
+
+// Artifact of Swift weakness.
+/// Do not use this. Use `LinearizableFactor5` instead.
+public protocol LinearizableFactor5_ {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 118)
+  /// The 0-th variable type.
+  associatedtype V0: Differentiable
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 118)
+  /// The 1-th variable type.
+  associatedtype V1: Differentiable
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 118)
+  /// The 2-th variable type.
+  associatedtype V2: Differentiable
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 118)
+  /// The 3-th variable type.
+  associatedtype V3: Differentiable
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 118)
+  /// The 4-th variable type.
+  associatedtype V4: Differentiable
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 121)
+
+  typealias Variables = Tuple5<V0, V1, V2, V3, V4>
+  typealias LinearizableComponent = Self
+
+  associatedtype ErrorVector: EuclideanVectorN
+
+  /// Returns the error vector given the values of the adjacent variables.
+  @differentiable
+  func errorVector(_: V0, _: V1, _: V2, _: V3, _: V4) -> ErrorVector
+}
+
+/// A factor, with 5 variable(s), in a factor graph.
+public protocol LinearizableFactor5: LinearizableFactor, LinearizableFactor5_
+  where Variables == Tuple5<V0, V1, V2, V3, V4>, LinearizableComponent == Self {}
+
+extension LinearizableFactor5 {
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 138)
+  /// The variable vertex for this factor's 0-th variable.
+  public var input0ID: TypedID<V0> { return edges.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 138)
+  /// The variable vertex for this factor's 1-th variable.
+  public var input1ID: TypedID<V1> { return edges.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 138)
+  /// The variable vertex for this factor's 2-th variable.
+  public var input2ID: TypedID<V2> { return edges.tail.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 138)
+  /// The variable vertex for this factor's 3-th variable.
+  public var input3ID: TypedID<V3> { return edges.tail.tail.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 138)
+  /// The variable vertex for this factor's 4-th variable.
+  public var input4ID: TypedID<V4> { return edges.tail.tail.tail.tail.head }
+// ###sourceLocation(file: "Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb", line: 141)
+
+  // Implements the error as half the squared norm of the error vector.
+  public func error(at x: Variables) -> Double {
+    return 0.5 * errorVector(at: x).squaredNorm
+  }
+
+  // Forwarding implementation.
+  @differentiable
+  public func errorVector(at x: Variables) -> ErrorVector {
+    return errorVector(x.head, x.tail.head, x.tail.tail.head, x.tail.tail.tail.head, x.tail.tail.tail.tail.head)
+  }
+}
+

--- a/Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb
+++ b/Sources/SwiftFusion/Inference/FactorBoilerplate.swift.gyb
@@ -1,0 +1,154 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Implements fixed-arity protocols `Factor1`, `VectorFactor1`, `LinearizableFactor1`, `Factor2`,
+/// etc. It takes less boilerplate to conform to these fixed-arity protocols than it does to
+/// conform to the arbitrary-arity protocols `Factor`, `VectorFactor`, and `LinearizableFactor`.
+
+import PenguinStructures
+
+% for arity in range(1, 6):
+
+%{
+def repeated(template):
+  if isinstance(template, str):
+    template_str = template
+    template = lambda i: template_str % i
+  return ', '.join([template(i) for i in range(arity)])
+
+def tuple_component(tuple, i):
+  return ''.join([tuple] + ['.tail'] * i + ['.head'])
+}%
+
+// Artifact of Swift weakness.
+/// Do not use this. Use `Factor${arity}` instead.
+public protocol Factor${arity}_ {
+  % for i in range(arity):
+  /// The ${i}-th variable type.
+  associatedtype V${i}
+  % end
+
+  /// Returns the error at the given point.
+  ///
+  /// This is typically interpreted as negative log-likelihood.
+  func error(${repeated('_: V%d')}) -> Double
+}
+
+/// A factor in a factor graph.
+public protocol Factor${arity}: Factor, Factor${arity}_
+  where Variables == Tuple${arity}<${repeated('V%d')}> {}
+
+extension Factor${arity} {
+  % for i in range(arity):
+  /// The variable vertex for this factor's ${i}-th variable.
+  public var input${i}ID: TypedID<V${i}> { return ${tuple_component('edges', i)} }
+  % end
+
+  // Forwarding implementation.
+  public func error(at x: Variables) -> Double {
+    return error(${repeated(lambda i: tuple_component('x', i))})
+  }
+}
+
+// Artifact of Swift weakness.
+/// Do not use this. Use `VectorFactor${arity}` instead.
+public protocol VectorFactor${arity}_ {
+  % for i in range(arity):
+  /// The ${i}-th variable type.
+  associatedtype V${i}
+  % end
+
+  typealias Variables = Tuple${arity}<${repeated('V%d')}>
+
+  associatedtype ErrorVector: EuclideanVectorN
+  associatedtype LinearizableComponent: LinearizableFactor
+
+  /// Returns the error vector at the given point.
+  func errorVector(${repeated('_: V%d')}) -> ErrorVector
+
+  /// Returns the linearizable component of `self` at the given point, and returns the
+  /// `Differentiable` subset of the given variables.
+  func linearizableComponent(${repeated('_: V%d')})
+    -> (LinearizableComponent, LinearizableComponent.Variables)
+}
+
+/// A factor whose `error` is a function of a vector-valued `errorVector` function.
+public protocol VectorFactor${arity}: VectorFactor, VectorFactor${arity}_
+  where Variables == Tuple${arity}<${repeated('V%d')}> {}
+
+extension VectorFactor${arity} {
+  % for i in range(arity):
+  /// The variable vertex for this factor's ${i}-th variable.
+  public var input${i}ID: TypedID<V${i}> { return ${tuple_component('edges', i)} }
+  % end
+
+  // Implements the error as half the squared norm of the error vector.
+  public func error(at x: Variables) -> Double {
+    return 0.5 * errorVector(at: x).squaredNorm
+  }
+
+  // Forwarding implementation.
+  public func errorVector(at x: Variables) -> ErrorVector {
+    return errorVector(${repeated(lambda i: tuple_component('x', i))})
+  }
+
+  // Forwarding implementation.
+  public func linearizableComponent(at x: Variables)
+    -> (LinearizableComponent, LinearizableComponent.Variables)
+  {
+    return linearizableComponent(${repeated(lambda i: tuple_component('x', i))})
+  }
+}
+
+// Artifact of Swift weakness.
+/// Do not use this. Use `LinearizableFactor${arity}` instead.
+public protocol LinearizableFactor${arity}_ {
+  % for i in range(arity):
+  /// The ${i}-th variable type.
+  associatedtype V${i}: Differentiable
+  % end
+
+  typealias Variables = Tuple${arity}<${repeated('V%d')}>
+  typealias LinearizableComponent = Self
+
+  associatedtype ErrorVector: EuclideanVectorN
+
+  /// Returns the error vector given the values of the adjacent variables.
+  @differentiable
+  func errorVector(${repeated('_: V%d')}) -> ErrorVector
+}
+
+/// A factor, with ${arity} variable(s), in a factor graph.
+public protocol LinearizableFactor${arity}: LinearizableFactor, LinearizableFactor${arity}_
+  where Variables == Tuple${arity}<${repeated('V%d')}>, LinearizableComponent == Self {}
+
+extension LinearizableFactor${arity} {
+  % for i in range(arity):
+  /// The variable vertex for this factor's ${i}-th variable.
+  public var input${i}ID: TypedID<V${i}> { return ${tuple_component('edges', i)} }
+  % end
+
+  // Implements the error as half the squared norm of the error vector.
+  public func error(at x: Variables) -> Double {
+    return 0.5 * errorVector(at: x).squaredNorm
+  }
+
+  // Forwarding implementation.
+  @differentiable
+  public func errorVector(at x: Variables) -> ErrorVector {
+    return errorVector(${repeated(lambda i: tuple_component('x', i))})
+  }
+}
+
+% end

--- a/Sources/SwiftFusion/Inference/FactorGraph.swift
+++ b/Sources/SwiftFusion/Inference/FactorGraph.swift
@@ -36,12 +36,12 @@ public struct FactorGraph {
   }
 
   /// Stores `factor` in the graph.
-  public mutating func store<T: LinearizableFactor>(_ factor: T) {
+  public mutating func store<T: VectorFactor>(_ factor: T) {
     _ = storage[
       ObjectIdentifier(T.self),
       default: AnyFactorArrayBuffer(
         // Note: This is a safe upcast.
-        unsafelyCasting: AnyLinearizableFactorArrayBuffer(ArrayBuffer<T>()))
+        unsafelyCasting: AnyVectorFactorArrayBuffer(ArrayBuffer<T>()))
     ].unsafelyAppend(factor)
   }
 
@@ -71,7 +71,7 @@ public struct FactorGraph {
   /// Returns the total error, at `x`, of all the linearizable factors.
   public func linearizableError(at x: VariableAssignments) -> Double {
     return storage.values.reduce(0) { (result, factors) in
-      guard let linearizableFactors = AnyLinearizableFactorArrayBuffer(factors) else {
+      guard let linearizableFactors = AnyVectorFactorArrayBuffer(factors) else {
         return result
       }
       return result + linearizableFactors.errors(at: x).reduce(0, +)
@@ -81,7 +81,7 @@ public struct FactorGraph {
   /// Returns the error vectors, at `x`, of all the linearizable factors.
   public func errorVectors(at x: VariableAssignments) -> AllVectors {
     return AllVectors(storage: storage.compactMapValues { factors in
-      guard let linearizableFactors = AnyLinearizableFactorArrayBuffer(factors) else {
+      guard let linearizableFactors = AnyVectorFactorArrayBuffer(factors) else {
         return nil
       }
       return AnyArrayBuffer(linearizableFactors.errorVectors(at: x))
@@ -103,7 +103,7 @@ public struct FactorGraph {
   public func linearized(at x: VariableAssignments) -> GaussianFactorGraph {
     return GaussianFactorGraph(
       storage: storage.compactMapValues { factors in
-        AnyLinearizableFactorArrayBuffer(factors)?.linearized(at: x)
+        AnyVectorFactorArrayBuffer(factors)?.linearized(at: x)
       },
       zeroValues: x.tangentVectorZeros
     )

--- a/Sources/SwiftFusion/Inference/JacobianFactor.swift
+++ b/Sources/SwiftFusion/Inference/JacobianFactor.swift
@@ -19,7 +19,7 @@ import PenguinStructures
 public struct JacobianFactor<
   Rows: FixedSizeArray,
   ErrorVector: EuclideanVectorN
->: GaussianFactor where Rows.Element: EuclideanVectorN & VariableTuple {
+>: LinearApproximationFactor where Rows.Element: EuclideanVectorN & DifferentiableVariableTuple {
   public typealias Variables = Rows.Element
 
   /// The Jacobian matrix, as a fixed size array of rows.
@@ -43,26 +43,29 @@ public struct JacobianFactor<
     self.edges = edges
   }
 
-  /// Creates a Jacobian factor that linearizes `f` at `x`, and is adjacent to the variables
-  /// identifed by edges.
-  init<Input: Differentiable & DifferentiableVariableTuple>(
-    linearizing f: @differentiable (Input) -> ErrorVector,
-    at x: Input,
-    edges: Input.Indices
-  ) where Input.TangentVector == Variables, Input.TangentIndices == Variables.Indices {
-    let (value, pb) = valueWithPullback(at: x, in: f)
+  /// Creates a factor that linearly approximates `f` at `x`.
+  public init<F: LinearizableFactor>(linearizing f: F, at x: F.Variables)
+  where F.Variables.TangentVector == Variables, F.ErrorVector == ErrorVector {
+    let (value, pb) = valueWithPullback(at: x, in: f.errorVector)
     let rows = Rows(ErrorVector.standardBasis.lazy.map(pb))
     self.jacobian = rows
     self.error = -value
-    self.edges = Input.linearized(edges)
+    self.edges = F.Variables.linearized(f.edges)
   }
 
   public func error(at x: Variables) -> Double {
     return 0.5 * errorVector(at: x).squaredNorm
   }
 
+  @differentiable
   public func errorVector(at x: Variables) -> ErrorVector {
     return errorVector_linearComponent(x) - error
+  }
+
+  @usableFromInline
+  @derivative(of: errorVector)
+  func vjpErrorVector(at x: Variables) -> (value: ErrorVector, pullback: (ErrorVector) -> Variables) {
+    return (errorVector(at: x), errorVector_linearComponent_adjoint)
   }
 
   public func errorVector_linearComponent(_ x: Variables) -> ErrorVector {
@@ -86,11 +89,6 @@ public struct JacobianFactor<
         }
       }
     }
-  }
-
-  public typealias Linearization = Self
-  public func linearized(at x: Variables) -> Self {
-    return self
   }
 }
 

--- a/Sources/SwiftFusion/Inference/PriorFactor.swift
+++ b/Sources/SwiftFusion/Inference/PriorFactor.swift
@@ -15,14 +15,7 @@
 import PenguinStructures
 
 /// A factor that specifies a prior on a pose.
-///
-/// `JacobianRows` specifies the `Rows` parameter of the Jacobian of this factor. See the
-/// documentation on `JacobianFactor.jacobian` for more information. Use the typealiases below to
-/// avoid specifying this type parameter every time you create an instance.
-public struct PriorFactor<Pose: LieGroup, JacobianRows: FixedSizeArray>:
-  LinearizableFactor
-  where JacobianRows.Element == Tuple1<Pose.TangentVector>
-{
+public struct PriorFactor<Pose: LieGroup>: LinearizableFactor {
   public typealias Variables = Tuple1<Pose>
 
   public let edges: Variables.Indices
@@ -45,18 +38,8 @@ public struct PriorFactor<Pose: LieGroup, JacobianRows: FixedSizeArray>:
     return 0.5 * errorVector(at: x).squaredNorm
   }
 
+  @differentiable
   public func errorVector(at x: Variables) -> Pose.TangentVector {
     return errorVector(x.head)
   }
-
-  public typealias Linearization = JacobianFactor<JacobianRows, ErrorVector>
-  public func linearized(at x: Variables) -> Linearization {
-    Linearization(linearizing: errorVector, at: x, edges: edges)
-  }
 }
-
-/// A prior factor on a `Pose2`.
-public typealias PriorFactor2 = PriorFactor<Pose2, Array3<Tuple1<Vector3>>>
-
-/// A prior factor on a `Pose3`.
-public typealias PriorFactor3 = PriorFactor<Pose3, Array6<Tuple1<Vector6>>>

--- a/Sources/SwiftFusion/Inference/PriorFactor.swift
+++ b/Sources/SwiftFusion/Inference/PriorFactor.swift
@@ -15,9 +15,7 @@
 import PenguinStructures
 
 /// A factor that specifies a prior on a pose.
-public struct PriorFactor<Pose: LieGroup>: LinearizableFactor {
-  public typealias Variables = Tuple1<Pose>
-
+public struct PriorFactor<Pose: LieGroup>: LinearizableFactor1 {
   public let edges: Variables.Indices
   public let prior: Pose
 
@@ -26,20 +24,8 @@ public struct PriorFactor<Pose: LieGroup>: LinearizableFactor {
     self.prior = prior
   }
 
-  public typealias ErrorVector = Pose.TangentVector
-  public func errorVector(_ x: Pose) -> ErrorVector {
-    return prior.localCoordinate(x)
-  }
-
-  // Note: All the remaining code in this factor is boilerplate that we can eventually eliminate
-  // with sugar.
-  
-  public func error(at x: Variables) -> Double {
-    return 0.5 * errorVector(at: x).squaredNorm
-  }
-
   @differentiable
-  public func errorVector(at x: Variables) -> Pose.TangentVector {
-    return errorVector(x.head)
+  public func errorVector(_ x: Pose) -> Pose.TangentVector {
+    return prior.localCoordinate(x)
   }
 }

--- a/Sources/SwiftFusion/Inference/ScalarJacobianFactor.swift
+++ b/Sources/SwiftFusion/Inference/ScalarJacobianFactor.swift
@@ -21,6 +21,12 @@ public struct ScalarJacobianFactor<ErrorVector: EuclideanVectorN>: GaussianFacto
   public let edges: Variables.Indices
   public let scalar: Double
 
+  public init(edges: Variables.Indices, scalar: Double) {
+    self.edges = edges
+    self.scalar = scalar
+  }
+
+  @differentiable
   public func errorVector(at x: Variables) -> ErrorVector {
     return scalar * x.head
   }
@@ -35,10 +41,5 @@ public struct ScalarJacobianFactor<ErrorVector: EuclideanVectorN>: GaussianFacto
 
   public func errorVector_linearComponent_adjoint(_ y: ErrorVector) -> Variables {
     return Tuple1(scalar * y)
-  }
-
-  public typealias Linearization = Self
-  public func linearized(at x: Tuple1<ErrorVector>) -> ScalarJacobianFactor<ErrorVector> {
-    return self
   }
 }

--- a/Sources/SwiftFusionBenchmarks/Pose2SLAM.swift
+++ b/Sources/SwiftFusionBenchmarks/Pose2SLAM.swift
@@ -62,7 +62,7 @@ let pose2SLAM = BenchmarkSuite(name: "Pose2SLAM") { suite in
   ) {
     var x = intelDataset.initialGuess
     var graph = intelDataset.graph
-    graph.store(PriorFactor2(TypedID(0), Pose2(0, 0, 0)))
+    graph.store(PriorFactor(TypedID(0), Pose2(0, 0, 0)))
 
     for _ in 0..<10 {
       let linearized = graph.linearized(at: x)

--- a/Sources/SwiftFusionBenchmarks/Pose3SLAM.swift
+++ b/Sources/SwiftFusionBenchmarks/Pose3SLAM.swift
@@ -60,7 +60,7 @@ let pose3SLAM = BenchmarkSuite(name: "Pose3SLAM") { suite in
     var val = sphere2500Dataset.initialGuess
     var graph = sphere2500Dataset.graph
     
-    graph.store(PriorFactor3(TypedID(0), Pose3(Rot3.fromTangent(Vector3.zero), Vector3.zero)))
+    graph.store(PriorFactor(TypedID(0), Pose3(Rot3.fromTangent(Vector3.zero), Vector3.zero)))
     
     var optimizer = LM()
     optimizer.verbosity = .SUMMARY

--- a/Tests/SwiftFusionTests/Inference/ChordalInitializationTests.swift
+++ b/Tests/SwiftFusionTests/Inference/ChordalInitializationTests.swift
@@ -48,12 +48,12 @@ let pose3 = Pose3(R3,p3)
 /// simple test graph for the chordal initialization
 func graph1() -> FactorGraph {
   var g = FactorGraph()
-  g.store(BetweenFactor3(x0, x1, between(pose0, pose1)))
-  g.store(BetweenFactor3(x1, x2, between(pose1, pose2)))
-  g.store(BetweenFactor3(x2, x3, between(pose2, pose3)))
-  g.store(BetweenFactor3(x2, x0, between(pose2, pose0)))
-  g.store(BetweenFactor3(x0, x3, between(pose0, pose3)))
-  g.store(PriorFactor3(x0, pose0))
+  g.store(BetweenFactor(x0, x1, between(pose0, pose1)))
+  g.store(BetweenFactor(x1, x2, between(pose1, pose2)))
+  g.store(BetweenFactor(x2, x3, between(pose2, pose3)))
+  g.store(BetweenFactor(x2, x0, between(pose2, pose0)))
+  g.store(BetweenFactor(x0, x3, between(pose0, pose3)))
+  g.store(PriorFactor(x0, pose0))
   return g
 }
 
@@ -69,7 +69,7 @@ class ChordalInitializationTests: XCTestCase {
     
     let frf = RelaxedRotationFactorRot3(p0, p1, Matrix3(0.0,0.1,0.2,1.0,1.1,1.2,2.0,2.1,2.2))
     
-    let frf_j = frf.linearized(at: Tuple2(val[p0], val[p1]))
+    let frf_j = JacobianFactor9x3x3_2(linearizing: frf, at: Tuple2(val[p0], val[p1]))
     
     let Rij = Matrix3(0.0,0.1,0.2,1.0,1.1,1.2,2.0,2.1,2.2)
     let M9: Jacobian9x3x3_2 = Array9([
@@ -96,14 +96,14 @@ class ChordalInitializationTests: XCTestCase {
     )
     
     let frf_zero = RelaxedRotationFactorRot3(p0, p1, Matrix3.identity)
-    let frf_zero_j = frf_zero.linearized(at: Tuple2(val[p0], val[p1]))
+    let frf_zero_j = JacobianFactor9x3x3_2(linearizing: frf_zero, at: Tuple2(val[p0], val[p1]))
     
     // assert the zero error is correct
     assertAllKeyPathEqual(frf_zero_j.error, jf.error, accuracy: 1e-5)
     
     let fpf = RelaxedAnchorFactorRot3(p0, Matrix3.identity)
     
-    let fpf_j = fpf.linearized(at: Tuple1(Matrix3.zero))
+    let fpf_j = JacobianFactor9x3x3_1(linearizing: fpf, at: Tuple1(Matrix3.zero))
     
     let I_9x9: Jacobian9x3x3_1 = Array9([
       Tuple1(Matrix3(1,0,0,0,0,0,0,0,0)),

--- a/Tests/SwiftFusionTests/Inference/FactorGraphTests.swift
+++ b/Tests/SwiftFusionTests/Inference/FactorGraphTests.swift
@@ -26,29 +26,29 @@ class FactorGraphTests: XCTestCase {
     let pose2ID = TypedID<Pose2>(1)
 
     var graph = FactorGraph()
-    graph.store(PriorFactor2(pose1ID, Pose2(1, 2, 3)))
-    graph.store(PriorFactor2(pose2ID, Pose2(4, 5, 6)))
-    graph.store(BetweenFactor2(pose1ID, pose2ID, Pose2(7, 8, 9)))
+    graph.store(PriorFactor(pose1ID, Pose2(1, 2, 3)))
+    graph.store(PriorFactor(pose2ID, Pose2(4, 5, 6)))
+    graph.store(BetweenFactor(pose1ID, pose2ID, Pose2(7, 8, 9)))
 
     XCTAssertEqual(
-      graph.factors(type: PriorFactor2.self).map { $0.edges },
+      graph.factors(type: PriorFactor<Pose2>.self).map { $0.edges },
       [Tuple1(pose1ID), Tuple1(pose2ID)]
     )
     XCTAssertEqual(
-      graph.factors(type: PriorFactor2.self).map { $0.prior },
+      graph.factors(type: PriorFactor<Pose2>.self).map { $0.prior },
       [Pose2(1, 2, 3), Pose2(4, 5, 6)]
     )
 
     XCTAssertEqual(
-      graph.factors(type: BetweenFactor2.self).map { $0.edges },
+      graph.factors(type: BetweenFactor<Pose2>.self).map { $0.edges },
       [Tuple2(pose1ID, pose2ID)]
     )
     XCTAssertEqual(
-      graph.factors(type: BetweenFactor2.self).map { $0.difference },
+      graph.factors(type: BetweenFactor<Pose2>.self).map { $0.difference },
       [Pose2(7, 8, 9)]
     )
 
-    XCTAssertEqual(graph.factors(type: PriorFactor3.self).count, 0)
+    XCTAssertEqual(graph.factors(type: PriorFactor<Pose3>.self).count, 0)
   }
 
   func testSimplePose2SLAM() {
@@ -60,11 +60,11 @@ class FactorGraphTests: XCTestCase {
     let pose5ID = x.store(Pose2(Rot2(-.pi / 2), Vector2(2.1, 2.1)))
 
     var graph = FactorGraph()
-    graph.store(BetweenFactor2(pose2ID, pose1ID, Pose2(2.0, 0.0, .pi / 2)))
-    graph.store(BetweenFactor2(pose3ID, pose2ID, Pose2(2.0, 0.0, .pi / 2)))
-    graph.store(BetweenFactor2(pose4ID, pose3ID, Pose2(2.0, 0.0, .pi / 2)))
-    graph.store(BetweenFactor2(pose5ID, pose4ID, Pose2(2.0, 0.0, .pi / 2)))
-    graph.store(PriorFactor2(pose1ID, Pose2(0, 0, 0)))
+    graph.store(BetweenFactor(pose2ID, pose1ID, Pose2(2.0, 0.0, .pi / 2)))
+    graph.store(BetweenFactor(pose3ID, pose2ID, Pose2(2.0, 0.0, .pi / 2)))
+    graph.store(BetweenFactor(pose4ID, pose3ID, Pose2(2.0, 0.0, .pi / 2)))
+    graph.store(BetweenFactor(pose5ID, pose4ID, Pose2(2.0, 0.0, .pi / 2)))
+    graph.store(PriorFactor(pose1ID, Pose2(0, 0, 0)))
 
     for _ in 0..<3 {
       let linearized = graph.linearized(at: x)
@@ -123,15 +123,15 @@ class FactorGraphTests: XCTestCase {
     let id5 = x.store(hexagon[hexagonId[5]].retract(Vector6(s * Tensor<Double>(randomNormal: [6]))))
     
     var fg = FactorGraph()
-    fg.store(PriorFactor3(id0, p0))
+    fg.store(PriorFactor(id0, p0))
     let delta: Pose3 = between(p0, p1)
 
-    fg.store(BetweenFactor3(id0, id1, delta))
-    fg.store(BetweenFactor3(id1, id2, delta))
-    fg.store(BetweenFactor3(id2, id3, delta))
-    fg.store(BetweenFactor3(id3, id4, delta))
-    fg.store(BetweenFactor3(id4, id5, delta))
-    fg.store(BetweenFactor3(id5, id0, delta))
+    fg.store(BetweenFactor(id0, id1, delta))
+    fg.store(BetweenFactor(id1, id2, delta))
+    fg.store(BetweenFactor(id2, id3, delta))
+    fg.store(BetweenFactor(id3, id4, delta))
+    fg.store(BetweenFactor(id4, id5, delta))
+    fg.store(BetweenFactor(id5, id0, delta))
 
     // optimize
     for _ in 0..<16 {
@@ -168,15 +168,15 @@ class FactorGraphTests: XCTestCase {
       let id5 = x.store(hexagon[hexagonId[5]].retract(Vector6(s * Tensor(randomNormal: [6]))))
       
       var fg = FactorGraph()
-      fg.store(PriorFactor3(id0, p0))
+      fg.store(PriorFactor(id0, p0))
       let delta: Pose3 = between(p0, p1)
 
-      fg.store(BetweenFactorAlternative3(id0, id1, delta))
-      fg.store(BetweenFactorAlternative3(id1, id2, delta))
-      fg.store(BetweenFactorAlternative3(id2, id3, delta))
-      fg.store(BetweenFactorAlternative3(id3, id4, delta))
-      fg.store(BetweenFactorAlternative3(id4, id5, delta))
-      fg.store(BetweenFactorAlternative3(id5, id0, delta))
+      fg.store(BetweenFactorAlternative(id0, id1, delta))
+      fg.store(BetweenFactorAlternative(id1, id2, delta))
+      fg.store(BetweenFactorAlternative(id2, id3, delta))
+      fg.store(BetweenFactorAlternative(id3, id4, delta))
+      fg.store(BetweenFactorAlternative(id4, id5, delta))
+      fg.store(BetweenFactorAlternative(id5, id0, delta))
 
       // optimize
       for _ in 0..<16 {
@@ -220,15 +220,15 @@ class FactorGraphTests: XCTestCase {
       let id5 = x.store(hexagon[hexagonId[5]].retract(Vector6(s * Tensor(randomNormal: [6]))))
       
       var fg = FactorGraph()
-      fg.store(PriorFactor3(id0, p0))
+      fg.store(PriorFactor(id0, p0))
       let delta: Pose3 = between(p0, p1)
 
-      fg.store(BetweenFactor3(id0, id1, delta))
-      fg.store(BetweenFactor3(id1, id2, delta))
-      fg.store(BetweenFactor3(id2, id3, delta))
-      fg.store(BetweenFactor3(id3, id4, delta))
-      fg.store(BetweenFactor3(id4, id5, delta))
-      fg.store(BetweenFactor3(id5, id0, delta))
+      fg.store(BetweenFactor(id0, id1, delta))
+      fg.store(BetweenFactor(id1, id2, delta))
+      fg.store(BetweenFactor(id2, id3, delta))
+      fg.store(BetweenFactor(id3, id4, delta))
+      fg.store(BetweenFactor(id4, id5, delta))
+      fg.store(BetweenFactor(id5, id0, delta))
 
       let chordal_init = ChordalInitialization.GetInitializations(graph: fg, ids: [id0, id1, id2, id3, id4, id5])
       

--- a/Tests/SwiftFusionTests/Optimizers/LMTests.swift
+++ b/Tests/SwiftFusionTests/Optimizers/LMTests.swift
@@ -15,11 +15,11 @@ final class LMTests: XCTestCase {
     let pose5ID = x.store(Pose2(Rot2(-.pi / 2), Vector2(2.1, 2.1)))
 
     var graph = FactorGraph()
-    graph.store(BetweenFactor2(pose2ID, pose1ID, Pose2(2.0, 0.0, .pi / 2)))
-    graph.store(BetweenFactor2(pose3ID, pose2ID, Pose2(2.0, 0.0, .pi / 2)))
-    graph.store(BetweenFactor2(pose4ID, pose3ID, Pose2(2.0, 0.0, .pi / 2)))
-    graph.store(BetweenFactor2(pose5ID, pose4ID, Pose2(2.0, 0.0, .pi / 2)))
-    graph.store(PriorFactor2(pose1ID, Pose2(0, 0, 0)))
+    graph.store(BetweenFactor(pose2ID, pose1ID, Pose2(2.0, 0.0, .pi / 2)))
+    graph.store(BetweenFactor(pose3ID, pose2ID, Pose2(2.0, 0.0, .pi / 2)))
+    graph.store(BetweenFactor(pose4ID, pose3ID, Pose2(2.0, 0.0, .pi / 2)))
+    graph.store(BetweenFactor(pose5ID, pose4ID, Pose2(2.0, 0.0, .pi / 2)))
+    graph.store(PriorFactor(pose1ID, Pose2(0, 0, 0)))
 
     var optimizer = LM(precision: 1e-3, max_iteration: 10)
     optimizer.verbosity = .TRYLAMBDA

--- a/generate.sh
+++ b/generate.sh
@@ -25,6 +25,7 @@ GYB="$SWIFT_BASE"/utils/gyb
 
 GENERATED_FILES=(
   "Sources/SwiftFusion/Core/VectorN.swift"
+  "Sources/SwiftFusion/Inference/FactorBoilerplate.swift"
   "Tests/SwiftFusionTests/Core/VectorNTests.swift"
 )
 


### PR DESCRIPTION
See `BetweenFactor.swift` for an example of the reduced boilerplate.