### PR TITLE
identity linearization factor

### DIFF
--- a/Sources/SwiftFusion/Inference/IdentityLinearizationFactor.swift
+++ b/Sources/SwiftFusion/Inference/IdentityLinearizationFactor.swift
@@ -1,0 +1,65 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import PenguinStructures
+
+/// A linear approximation of a `GaussianFactor`.
+///
+/// Since `GaussianFactor`s are linear, they are their own linear approximations.
+public struct IdentityLinearizationFactor<Base: GaussianFactor>: LinearApproximationFactor {
+  /// The appoximated factor.
+  let base: Base
+
+  /// A tuple of the variable types of variables adjacent to this factor.
+  public typealias Variables = Base.Variables
+
+  /// The type of the error vector.
+  public typealias ErrorVector = Base.ErrorVector
+
+  /// The IDs of the variables adjacent to this factor.
+  public var edges: Variables.Indices {
+    base.edges
+  }
+
+  /// Creates a factor that linearly approximates `f` at `x`.
+  ///
+  /// - Requires: `F == Base`.
+  public init<F: LinearizableFactor>(linearizing f: F, at x: F.Variables)
+  where F.Variables.TangentVector == Variables, F.ErrorVector == ErrorVector {
+    self.base = f as! Base
+  }
+
+  /// Returns the error at `x`.
+  ///
+  /// This is typically interpreted as negative log-likelihood.
+  public func error(at x: Variables) -> Double {
+    base.error(at: x)
+  }
+
+  /// Returns the error vector given the values of the adjacent variables.
+  @differentiable
+  public func errorVector(at x: Variables) -> ErrorVector {
+    base.errorVector(at: x)
+  }
+
+  /// The linear component of `errorVector`.
+  public func errorVector_linearComponent(_ x: Variables) -> ErrorVector {
+    base.errorVector_linearComponent(x)
+  }
+
+  /// The adjoint (aka "transpose" or "dual") of the linear component of `errorVector`.
+  public func errorVector_linearComponent_adjoint(_ y: ErrorVector) -> Variables {
+    base.errorVector_linearComponent_adjoint(y)
+  }
+}

--- a/Tests/SwiftFusionTests/Inference/IdentityLinearizationFactorTests.swift
+++ b/Tests/SwiftFusionTests/Inference/IdentityLinearizationFactorTests.swift
@@ -1,0 +1,43 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import TensorFlow
+import XCTest
+
+import PenguinStructures
+import SwiftFusion
+
+fileprivate typealias TestGaussianFactor = JacobianFactor<Array3<Tuple1<Vector3>>, Vector3>
+
+class IdentityLinearizationFactorTests: XCTestCase {
+  /// Test that `IdentityLinearizationFactor` forwards to the underlying factor's methods.
+  func testForwardsMethods() {
+    let base = TestGaussianFactor(
+      jacobian: FixedSizeMatrix3([1, 2, 3, 4, 5, 6, 7, 8, 9]),
+      error: Vector3(10, 20, 30),
+      edges: Tuple1(TypedID(0)))
+    let f = IdentityLinearizationFactor<TestGaussianFactor>(
+      linearizing: base, at: Tuple1(Vector3(0, 0, 0)))
+    XCTAssertEqual(f.edges, base.edges)
+    let x = Tuple1(Vector3(100, 200, 300))
+    let y = Vector3(100, 200, 300)
+    XCTAssertEqual(f.error(at: x), base.error(at: x))
+    XCTAssertEqual(f.errorVector(at: x), base.errorVector(at: x))
+    XCTAssertEqual(f.errorVector_linearComponent(x), base.errorVector_linearComponent(x))
+    XCTAssertEqual(
+      f.errorVector_linearComponent_adjoint(y),
+      base.errorVector_linearComponent_adjoint(y))
+  }
+}


### PR DESCRIPTION
A factor that makes it possible to linearize any `GaussianFactor` without doing any real work.

Requested by @dabrahams for a thing he is working on.