### PR TITLE
make it possible to use `Tensor` in factor graphs

### DIFF
--- a/Sources/SwiftFusion/Core/EuclideanVector.swift
+++ b/Sources/SwiftFusion/Core/EuclideanVector.swift
@@ -68,12 +68,6 @@ extension EuclideanVector {
   public init(_ vector: Vector) {
     self.init(vector.scalars)
   }
-
-  /// Creates a vector with the same elements as `tensor`.
-  public init(_ tensor: Tensor<Double>) {
-    let vector = Vector(tensor.scalars)
-    self.init(vector)
-  }
 }
 
 /// Default implementations of some `EuclideanVector` requirements.

--- a/Sources/SwiftFusion/Core/EuclideanVectorN.swift
+++ b/Sources/SwiftFusion/Core/EuclideanVectorN.swift
@@ -156,12 +156,27 @@ extension EuclideanVectorN {
     }
   }
 
-  /// Returns this vector as a `Tensor<Double>`.
-  ///
-  /// Note: This is for backwards compatibility with existing code.
-  public var tensor: Tensor<Double> {
+  @differentiable
+  public init(flatTensor: Tensor<Double>) {
+    self.init(flatTensor.scalars)
+  }
+
+  @derivative(of: init(flatTensor:))
+  @usableFromInline
+  static func vjpInit(flatTensor: Tensor<Double>) -> (value: Self, pullback: (Self) -> Tensor<Double>) {
+    return (Self(flatTensor: flatTensor), { $0.flatTensor })
+  }
+
+  @differentiable
+  public var flatTensor: Tensor<Double> {
     withUnsafeBufferPointer { b in
       return Tensor<Double>(shape: [b.count], scalars: b)
     }
+  }
+
+  @derivative(of: flatTensor)
+  @usableFromInline
+  func vjpFlatTensor() -> (value: Tensor<Double>, pullback: (Tensor<Double>) -> Self) {
+    return (self.flatTensor, { Self(flatTensor: $0) })
   }
 }

--- a/Sources/SwiftFusion/Core/EuclideanVectorN.swift
+++ b/Sources/SwiftFusion/Core/EuclideanVectorN.swift
@@ -7,11 +7,25 @@ public protocol EuclideanVectorN: EuclideanVector {
 
   /// A standard basis of vectors.
   static var standardBasis: [Self] { get }
+
+  /// Returns the result of calling `body` on the scalars of `self`.
+  ///
+  /// A default is provided that returns a pointer to `self`.
+  func withUnsafeBufferPointer<R>(
+    _ body: (UnsafeBufferPointer<Double>) throws -> R
+  ) rethrows -> R
+
+  /// Returns the result of calling `body` on the scalars of `self`.
+  ///
+  /// A default is provided that returns a pointer to `self`.
+  mutating func withUnsafeMutableBufferPointer<R>(
+    _ body: (UnsafeMutableBufferPointer<Double>) throws -> R
+  ) rethrows -> R
 }
 
 extension EuclideanVectorN {
   /// Returns the result of calling `body` on the scalars of `self`.
-  func withUnsafeBufferPointer<R>(
+  public func withUnsafeBufferPointer<R>(
     _ body: (UnsafeBufferPointer<Double>) throws -> R
   ) rethrows -> R {
     return try withUnsafePointer(to: self) { p in
@@ -24,7 +38,7 @@ extension EuclideanVectorN {
   }
 
   /// Returns the result of calling `body` on the scalars of `self`.
-  mutating func withUnsafeMutableBufferPointer<R>(
+  public mutating func withUnsafeMutableBufferPointer<R>(
     _ body: (UnsafeMutableBufferPointer<Double>) throws -> R
   ) rethrows -> R {
     return try withUnsafeMutablePointer(to: &self) { p in

--- a/Sources/SwiftFusion/Core/FixedShapeTensor.swift
+++ b/Sources/SwiftFusion/Core/FixedShapeTensor.swift
@@ -1,0 +1,77 @@
+import TensorFlow
+
+public protocol FixedShapeTensor: EuclideanVectorN {
+  static var shape: TensorShape { get }
+  @differentiable init(_ tensor: Tensor<Double>)
+  @differentiable var tensor: Tensor<Double> { get set }
+}
+
+/// Default implementations of `EuclideanVectorN` requirements.
+extension FixedShapeTensor {
+  @differentiable
+  public static func += (_ lhs: inout Self, _ rhs: Self) {
+    lhs = Self(lhs.tensor + rhs.tensor)
+  }
+
+  @differentiable
+  public static func -= (_ lhs: inout Self, _ rhs: Self) {
+    lhs = Self(lhs.tensor - rhs.tensor)
+  }
+
+  @differentiable
+  public static func *= (_ lhs: inout Self, _ rhs: Double) {
+    lhs = Self(lhs.tensor * rhs)
+  }
+
+  @differentiable
+  public func dot(_ other: Self) -> Double {
+    (self.tensor * other.tensor).sum().scalarized()
+  }
+
+  public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
+    self.init(Tensor(shape: Self.shape, scalars: Array(scalars)))
+  }
+
+  public static var dimension: Int {
+    shape.reduce(1, *)
+  }
+
+  public static var standardBasis: [Self] {
+    (0..<dimension).map { i in
+      var b = Array(repeating: Double(0), count: dimension)
+      b[i] = 1
+      return Self(Tensor(shape: shape, scalars: b))
+    }
+  }
+
+  /// Returns the result of calling `body` on the scalars of `self`.
+  public func withUnsafeBufferPointer<R>(
+    _ body: (UnsafeBufferPointer<Double>) throws -> R
+  ) rethrows -> R {
+    try self.tensor.scalars.withUnsafeBufferPointer(body)
+  }
+
+  /// Returns the result of calling `body` on the scalars of `self`.
+  public mutating func withUnsafeMutableBufferPointer<R>(
+    _ body: (UnsafeMutableBufferPointer<Double>) throws -> R
+  ) rethrows -> R {
+    var scalars = self.tensor.scalars
+    let r = try scalars.withUnsafeMutableBufferPointer { b in
+      try body(b)
+    }
+    self.tensor = Tensor(shape: Self.shape, scalars: scalars)
+    return r
+  }
+}
+
+public struct Tensor10_10: AdditiveArithmetic, FixedShapeTensor {
+  public typealias TangentVector = Tensor10_10
+  public static var shape: TensorShape { [10, 10] }
+  @differentiable public var tensor: Tensor<Double>
+
+  @differentiable
+  public init(_ tensor: Tensor<Double>) {
+    precondition(tensor.shape == Self.shape)
+    self.tensor = tensor
+  }
+}

--- a/Sources/SwiftFusion/Geometry/Pose2.swift
+++ b/Sources/SwiftFusion/Geometry/Pose2.swift
@@ -189,7 +189,7 @@ extension Pose2Coordinate {
 extension Pose2 {
   /// The Adjoint group action of `self` on the tangent space, as a matrix.
   public var AdjointMatrix: Tensor<Double> {
-    Tensor(stacking: Pose2.TangentVector.standardBasis.map { Adjoint($0).tensor }).transposed()
+    Tensor(stacking: Pose2.TangentVector.standardBasis.map { Adjoint($0).flatTensor }).transposed()
   }
 }
 

--- a/Tests/SwiftFusionTests/Core/AnyDifferentiableTests.swift
+++ b/Tests/SwiftFusionTests/Core/AnyDifferentiableTests.swift
@@ -29,7 +29,7 @@ class AnyDifferentiableTests: XCTestCase {
     }
 
     let initialPoses = (0..<3).map { _ in Pose2(randomWithCovariance: eye(rowCount: 3)) }
-    let initialVectors = (0..<3).map { _ in Vector2(Tensor(randomNormal: [2])) }
+    let initialVectors = (0..<3).map { _ in Vector2(flatTensor: Tensor(randomNormal: [2])) }
     let elementsErased =
       initialPoses.map { AnyDifferentiable($0) } + initialVectors.map { AnyDifferentiable($0) }
 

--- a/Tests/SwiftFusionTests/Core/EuclideanVectorTests.swift
+++ b/Tests/SwiftFusionTests/Core/EuclideanVectorTests.swift
@@ -229,6 +229,8 @@ extension EuclideanVectorTests where Testee: EuclideanVectorN {
     runAllEuclideanVectorTests()
     testDimension()
     testStandardBasis()
+    testWithUnsafeBufferPointer()
+    testWithUnsafeMutableBufferPointer()
   }
 
   /// Tests that the dimension is correct.
@@ -240,6 +242,24 @@ extension EuclideanVectorTests where Testee: EuclideanVectorN {
   func testStandardBasis() {
     let actualStandardBasis = Array(Testee.standardBasis)
     XCTAssertEqual(actualStandardBasis, self.basisVectors)
+  }
+
+  func testWithUnsafeBufferPointer() {
+    let v = makeVector(from: 1, stride: 1)
+    v.withUnsafeBufferPointer { b in
+      XCTAssertEqual(Array(b), Array(1..<(Self.dimension+1)).map { Double($0) })
+    }
+  }
+
+  func testWithUnsafeMutableBufferPointer() {
+    var v = makeVector(from: 1, stride: 1)
+    v.withUnsafeMutableBufferPointer { b in
+      XCTAssertEqual(Array(b), Array(1..<(Self.dimension+1)).map { Double($0) })
+      for i in 0..<b.count {
+        b[i] = -Double(i)
+      }
+    }
+    XCTAssertEqual(v, makeVector(from: 0, stride: -1))
   }
 }
 

--- a/Tests/SwiftFusionTests/Core/FixedShapeTensorTests.swift
+++ b/Tests/SwiftFusionTests/Core/FixedShapeTensorTests.swift
@@ -1,0 +1,58 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+import PenguinStructures
+import SwiftFusion
+import TensorFlow
+
+class FixedShapeTensorTests: XCTestCase {
+  /// Test that we can differentiably convert a `Tensor` to a `FixedShapeTensor`.
+  func testInitFromTensor() {
+    let t = Tensor<Double>(ones: [10, 10])
+    let (value, pb) = valueWithPullback(at: t) { Tensor10_10($0) }
+    XCTAssertEqual(value, Tensor10_10(t))
+    for i in 0..<10 {
+      for j in 0..<10 {
+        var basisVector = Tensor<Double>(zeros: [10, 10])
+        basisVector[i, j] = Tensor(1)
+        XCTAssertEqual(pb(Tensor10_10(basisVector)), basisVector)
+      }
+    }
+  }
+
+  /// Test that we can differentiably convert a `FixedShapeTensor` to a `Tensor`.
+  func testToTensor() {
+    let t = Tensor<Double>(ones: [10, 10])
+    let fst = Tensor10_10(t)
+    let (value, pb) = valueWithPullback(at: fst) { $0.tensor }
+    XCTAssertEqual(value, t)
+    for i in 0..<10 {
+      for j in 0..<10 {
+        var basisVector = Tensor<Double>(zeros: [10, 10])
+        basisVector[i, j] = Tensor(1)
+        XCTAssertEqual(pb(basisVector), Tensor10_10(basisVector))
+      }
+    }
+  }
+}
+
+class FixedShapeTensorEuclideanVectorTests: XCTestCase, EuclideanVectorTests {
+  typealias Testee = Tensor10_10
+  static var dimension: Int { 100 }
+  func testAll() {
+    runAllEuclideanVectorNTests()
+  }
+}

--- a/Tests/SwiftFusionTests/Geometry/Pose2Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Pose2Tests.swift
@@ -240,7 +240,7 @@ final class Pose2Tests: XCTestCase {
       assertEqual(
         Tensor<Double>(stacking: jacobian(
           of: identity,
-          at: Pose2(randomWithCovariance: eye(rowCount: 3))).map { $0.tensor }),
+          at: Pose2(randomWithCovariance: eye(rowCount: 3))).map { $0.flatTensor }),
         expected,
         accuracy: 1e-10
       )
@@ -253,7 +253,7 @@ final class Pose2Tests: XCTestCase {
       let pose = Pose2(randomWithCovariance: eye(rowCount: 3))
       let expected = -pose.AdjointMatrix
       assertEqual(
-        Tensor<Double>(stacking: jacobian(of: { $0.inverse() }, at: pose).map { $0.tensor }),
+        Tensor<Double>(stacking: jacobian(of: { $0.inverse() }, at: pose).map { $0.flatTensor }),
         expected,
         accuracy: 1e-10
       )
@@ -268,12 +268,12 @@ final class Pose2Tests: XCTestCase {
       let expectedWrtLhs = rhs.inverse().AdjointMatrix
       let expectedWrtRhs: Tensor<Double> = eye(rowCount: 3)
       assertEqual(
-        Tensor<Double>(stacking: jacobian(of: { $0 * rhs }, at: lhs).map { $0.tensor }),
+        Tensor<Double>(stacking: jacobian(of: { $0 * rhs }, at: lhs).map { $0.flatTensor }),
         expectedWrtLhs,
         accuracy: 1e-10
       )
       assertEqual(
-        Tensor<Double>(stacking: jacobian(of: { lhs * $0 }, at: rhs).map { $0.tensor }),
+        Tensor<Double>(stacking: jacobian(of: { lhs * $0 }, at: rhs).map { $0.flatTensor }),
         expectedWrtRhs,
         accuracy: 1e-10
       )
@@ -318,12 +318,12 @@ final class Pose2Tests: XCTestCase {
     ])
 
     assertEqual(
-      Tensor<Double>(stacking: jacobian(of: { between($0, wT2) }, at: wT1).map { $0.tensor }),
+      Tensor<Double>(stacking: jacobian(of: { between($0, wT2) }, at: wT1).map { $0.flatTensor }),
       expectedWrtLhs,
       accuracy: 1e-10
     )
     assertEqual(
-      Tensor<Double>(stacking: jacobian(of: { between(wT1, $0) }, at: wT2).map { $0.tensor }),
+      Tensor<Double>(stacking: jacobian(of: { between(wT1, $0) }, at: wT2).map { $0.flatTensor }),
       expectedWrtRhs,
       accuracy: 1e-10
     )
@@ -335,13 +335,13 @@ final class Pose2Tests: XCTestCase {
       let pose = Pose2(randomWithCovariance: eye(rowCount: 3))
       for v in Pose2.TangentVector.standardBasis {
         assertEqual(
-          pose.Adjoint(v).tensor,
-          pose.coordinate.defaultAdjoint(v).tensor,
+          pose.Adjoint(v).flatTensor,
+          pose.coordinate.defaultAdjoint(v).flatTensor,
           accuracy: 1e-10
         )
         assertEqual(
-          pose.AdjointTranspose(v).tensor,
-          pose.coordinate.defaultAdjointTranspose(v).tensor,
+          pose.AdjointTranspose(v).flatTensor,
+          pose.coordinate.defaultAdjointTranspose(v).flatTensor,
           accuracy: 1e-10
         )
       }

--- a/Tests/SwiftFusionTests/Geometry/Pose3Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Pose3Tests.swift
@@ -7,15 +7,15 @@ final class Pose3Tests: XCTestCase {
   /// Tests that the manifold invariant holds for Pose2
   func testManifoldIdentity() {
     for _ in 0..<10 {
-      let p = Pose3.fromTangent(Vector6(Tensor<Double>(randomNormal: [6])))
-      let q = Pose3.fromTangent(Vector6(Tensor<Double>(randomNormal: [6])))
+      let p = Pose3.fromTangent(Vector6(flatTensor: Tensor<Double>(randomNormal: [6])))
+      let q = Pose3.fromTangent(Vector6(flatTensor: Tensor<Double>(randomNormal: [6])))
       let actual: Pose3 = Pose3(coordinate: p.coordinate.retract(p.coordinate.localCoordinate(q.coordinate)))
       assertAllKeyPathEqual(actual, q, accuracy: 1e-10)
     }
   }
   
   func testTrivialRotation() {
-    let p = Pose3.fromTangent(Vector6(Tensor<Double>([0.3, 0, 0, 0, 0, 0])))
+    let p = Pose3.fromTangent(Vector6(flatTensor: Tensor<Double>([0.3, 0, 0, 0, 0, 0])))
     let R = Rot3.fromTangent(Vector3(0.3, 0, 0))
     
     assertAllKeyPathEqual(p.rot, R, accuracy: 1e-10)
@@ -24,7 +24,7 @@ final class Pose3Tests: XCTestCase {
   func testTrivialFull1() {
     let P = Vector3(0.2,0.7,-2)
     let R = Rot3.fromTangent(Vector3(0.3, 0, 0))
-    let p = Pose3.fromTangent(Vector6(Tensor<Double>([0.3, 0, 0, 0.2, 0.394742, -2.08998])))
+    let p = Pose3.fromTangent(Vector6(flatTensor: Tensor<Double>([0.3, 0, 0, 0.2, 0.394742, -2.08998])))
     assertAllKeyPathEqual(p.rot, R, accuracy: 1e-10)
     assertAllKeyPathEqual(p.t, P, accuracy: 1e-5)
   }
@@ -32,7 +32,7 @@ final class Pose3Tests: XCTestCase {
   func testTrivialFull2() {
     let P = Vector3(3.5,-8.2,4.2)
     let R = Rot3.fromTangent(Vector3(0.3, 0, 0))
-    let t12 = Vector6(Tensor<Double>(repeating: 0.1, shape: [6]))
+    let t12 = Vector6(flatTensor: Tensor<Double>(repeating: 0.1, shape: [6]))
     let t1 = Pose3(R, P)
     let t2 = Pose3(coordinate: t1.coordinate.retract(t12))
     assertAllKeyPathEqual(t1.coordinate.localCoordinate(t2.coordinate), t12, accuracy: 1e-5)
@@ -106,11 +106,11 @@ final class Pose3Tests: XCTestCase {
     var val = VariableAssignments()
     let s: Double = 0.10
     let _ = val.store(p0)
-    let _ = val.store(hexagon_val[hexagon_id[1]].retract(Vector6(s * Tensor<Double>(randomNormal: [6]))))
-    let _ = val.store(hexagon_val[hexagon_id[2]].retract(Vector6(s * Tensor<Double>(randomNormal: [6]))))
-    let _ = val.store(hexagon_val[hexagon_id[3]].retract(Vector6(s * Tensor<Double>(randomNormal: [6]))))
-    let _ = val.store(hexagon_val[hexagon_id[4]].retract(Vector6(s * Tensor<Double>(randomNormal: [6]))))
-    let _ = val.store(hexagon_val[hexagon_id[5]].retract(Vector6(s * Tensor<Double>(randomNormal: [6]))))
+    let _ = val.store(hexagon_val[hexagon_id[1]].retract(Vector6(flatTensor: s * Tensor<Double>(randomNormal: [6]))))
+    let _ = val.store(hexagon_val[hexagon_id[2]].retract(Vector6(flatTensor: s * Tensor<Double>(randomNormal: [6]))))
+    let _ = val.store(hexagon_val[hexagon_id[3]].retract(Vector6(flatTensor: s * Tensor<Double>(randomNormal: [6]))))
+    let _ = val.store(hexagon_val[hexagon_id[4]].retract(Vector6(flatTensor: s * Tensor<Double>(randomNormal: [6]))))
+    let _ = val.store(hexagon_val[hexagon_id[5]].retract(Vector6(flatTensor: s * Tensor<Double>(randomNormal: [6]))))
 
     // optimize
     for _ in 0..<16 {
@@ -132,11 +132,11 @@ final class Pose3Tests: XCTestCase {
   /// Tests that the custom implementation of `Adjoint` is correct.
   func testAdjoint() {
     for _ in 0..<10 {
-      let pose = Pose3.fromTangent(Vector6(Tensor<Double>(randomNormal: [6])))
+      let pose = Pose3.fromTangent(Vector6(flatTensor: Tensor<Double>(randomNormal: [6])))
       for v in Pose3.TangentVector.standardBasis {
         assertEqual(
-          pose.Adjoint(v).tensor,
-          pose.coordinate.defaultAdjoint(v).tensor,
+          pose.Adjoint(v).flatTensor,
+          pose.coordinate.defaultAdjoint(v).flatTensor,
           accuracy: 1e-10
         )
       }
@@ -146,11 +146,11 @@ final class Pose3Tests: XCTestCase {
   /// Tests that the custom implementation of `AdjointTranspose` is correct.
   func testAdjointTranspose() {
     for _ in 0..<10 {
-      let pose = Pose3.fromTangent(Vector6(Tensor<Double>(randomNormal: [6])))
+      let pose = Pose3.fromTangent(Vector6(flatTensor: Tensor<Double>(randomNormal: [6])))
       for v in Pose3.TangentVector.standardBasis {
         assertEqual(
-          pose.AdjointTranspose(v).tensor,
-          pose.coordinate.defaultAdjointTranspose(v).tensor,
+          pose.AdjointTranspose(v).flatTensor,
+          pose.coordinate.defaultAdjointTranspose(v).flatTensor,
           accuracy: 1e-10
         )
       }

--- a/Tests/SwiftFusionTests/Geometry/Rot3Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Rot3Tests.swift
@@ -42,8 +42,8 @@ final class Rot3Tests: XCTestCase {
   /// Tests that the manifold invariant holds for Rot3
   func testManifoldIdentity() {
     for _ in 0..<30 {
-      let p = Rot3.fromTangent(Vector3(Tensor<Double>(randomNormal: [3])))
-      let q = Rot3.fromTangent(Vector3(Tensor<Double>(randomNormal: [3])))
+      let p = Rot3.fromTangent(Vector3(flatTensor: Tensor<Double>(randomNormal: [3])))
+      let q = Rot3.fromTangent(Vector3(flatTensor: Tensor<Double>(randomNormal: [3])))
       let actual: Rot3 = Rot3(coordinate: p.coordinate.retract(p.coordinate.localCoordinate(q.coordinate)))
       assertAllKeyPathEqual(actual, q, accuracy: 1e-6)
     }
@@ -54,14 +54,14 @@ final class Rot3Tests: XCTestCase {
   func testManifoldIdentitySpecial1() {
     for i in -5..<5 {
       let p = Rot3.fromTangent(Vector3(Double(2*i - 1) * .pi, 0, 0))
-      let q = Rot3.fromTangent(Vector3(Tensor<Double>(randomNormal: [3])))
+      let q = Rot3.fromTangent(Vector3(flatTensor: Tensor<Double>(randomNormal: [3])))
       let actual: Rot3 = Rot3(coordinate: p.coordinate.retract(p.coordinate.localCoordinate(q.coordinate)))
       assertAllKeyPathEqual(actual, q, accuracy: 1e-6)
     }
     
     for i in -5..<5 {
       let p = Rot3.fromTangent(Vector3(0, 0, Double(2*i - 1) * .pi))
-      let q = Rot3.fromTangent(Vector3(Tensor<Double>(randomNormal: [3])))
+      let q = Rot3.fromTangent(Vector3(flatTensor: Tensor<Double>(randomNormal: [3])))
       let actual: Rot3 = Rot3(coordinate: p.coordinate.retract(p.coordinate.localCoordinate(q.coordinate)))
       assertAllKeyPathEqual(actual, q, accuracy: 1e-6)
     }
@@ -70,8 +70,8 @@ final class Rot3Tests: XCTestCase {
   /// Tests that the manifold invariant holds for Rot3
   func testManifoldIdentitySpecial2() {
     for _ in 0..<10 {
-      let p = Rot3.fromTangent(Vector3(1e-10 * Tensor<Double>(randomNormal: [3])))
-      let q = Rot3.fromTangent(Vector3(Tensor<Double>(randomNormal: [3])))
+      let p = Rot3.fromTangent(Vector3(flatTensor: 1e-10 * Tensor<Double>(randomNormal: [3])))
+      let q = Rot3.fromTangent(Vector3(flatTensor: Tensor<Double>(randomNormal: [3])))
       let actual: Rot3 = Rot3(coordinate: p.coordinate.retract(p.coordinate.localCoordinate(q.coordinate)))
       assertAllKeyPathEqual(actual, q, accuracy: 1e-6)
     }
@@ -136,16 +136,16 @@ final class Rot3Tests: XCTestCase {
   /// Tests that the custom implementations of `Adjoint` and `AdjointTranspose` are correct.
   func testAdjoint() {
     for _ in 0..<10 {
-      let rot = Rot3.fromTangent(Vector3(Tensor<Double>(randomNormal: [3])))
+      let rot = Rot3.fromTangent(Vector3(flatTensor: Tensor<Double>(randomNormal: [3])))
       for v in Pose2.TangentVector.standardBasis {
         assertEqual(
-          rot.Adjoint(v).tensor,
-          rot.coordinate.defaultAdjoint(v).tensor,
+          rot.Adjoint(v).flatTensor,
+          rot.coordinate.defaultAdjoint(v).flatTensor,
           accuracy: 1e-10
         )
         assertEqual(
-          rot.AdjointTranspose(v).tensor,
-          rot.coordinate.defaultAdjointTranspose(v).tensor,
+          rot.AdjointTranspose(v).flatTensor,
+          rot.coordinate.defaultAdjointTranspose(v).flatTensor,
           accuracy: 1e-10
         )
       }

--- a/Tests/SwiftFusionTests/Inference/ChordalInitializationTests.swift
+++ b/Tests/SwiftFusionTests/Inference/ChordalInitializationTests.swift
@@ -90,8 +90,8 @@ class ChordalInitializationTests: XCTestCase {
     
     // assert the jacobian is correct
     assertEqual(
-      Tensor<Double>(stacking: frf_j.jacobian.map { $0.tensor }),
-      Tensor<Double>(stacking: jf.jacobian.map { $0.tensor })
+      Tensor<Double>(stacking: frf_j.jacobian.map { $0.flatTensor }),
+      Tensor<Double>(stacking: jf.jacobian.map { $0.flatTensor })
       , accuracy: 1e-4
     )
     
@@ -124,8 +124,8 @@ class ChordalInitializationTests: XCTestCase {
     
     // assert the Jacobian is correct
     assertEqual(
-      Tensor<Double>(stacking: fpf_j.jacobian.map { $0.tensor }),
-      Tensor<Double>(stacking: jf_p.jacobian.map { $0.tensor })
+      Tensor<Double>(stacking: fpf_j.jacobian.map { $0.flatTensor }),
+      Tensor<Double>(stacking: jf_p.jacobian.map { $0.flatTensor })
       , accuracy: 1e-4
     )
     

--- a/Tests/SwiftFusionTests/Inference/FactorGraphTests.swift
+++ b/Tests/SwiftFusionTests/Inference/FactorGraphTests.swift
@@ -116,11 +116,11 @@ class FactorGraphTests: XCTestCase {
     
     let s: Double = 0.10
     let id0 = x.store(p0)
-    let id1 = x.store(hexagon[hexagonId[1]].retract(Vector6(s * Tensor<Double>(randomNormal: [6]))))
-    let id2 = x.store(hexagon[hexagonId[2]].retract(Vector6(s * Tensor<Double>(randomNormal: [6]))))
-    let id3 = x.store(hexagon[hexagonId[3]].retract(Vector6(s * Tensor<Double>(randomNormal: [6]))))
-    let id4 = x.store(hexagon[hexagonId[4]].retract(Vector6(s * Tensor<Double>(randomNormal: [6]))))
-    let id5 = x.store(hexagon[hexagonId[5]].retract(Vector6(s * Tensor<Double>(randomNormal: [6]))))
+    let id1 = x.store(hexagon[hexagonId[1]].retract(Vector6(flatTensor: s * Tensor<Double>(randomNormal: [6]))))
+    let id2 = x.store(hexagon[hexagonId[2]].retract(Vector6(flatTensor: s * Tensor<Double>(randomNormal: [6]))))
+    let id3 = x.store(hexagon[hexagonId[3]].retract(Vector6(flatTensor: s * Tensor<Double>(randomNormal: [6]))))
+    let id4 = x.store(hexagon[hexagonId[4]].retract(Vector6(flatTensor: s * Tensor<Double>(randomNormal: [6]))))
+    let id5 = x.store(hexagon[hexagonId[5]].retract(Vector6(flatTensor: s * Tensor<Double>(randomNormal: [6]))))
     
     var fg = FactorGraph()
     fg.store(PriorFactor(id0, p0))
@@ -161,11 +161,11 @@ class FactorGraphTests: XCTestCase {
       
       let s: Double = 0.9
       let id0 = x.store(p0)
-      let id1 = x.store(hexagon[hexagonId[1]].retract(Vector6(s * Tensor(randomNormal: [6]))))
-      let id2 = x.store(hexagon[hexagonId[2]].retract(Vector6(s * Tensor(randomNormal: [6]))))
-      let id3 = x.store(hexagon[hexagonId[3]].retract(Vector6(s * Tensor(randomNormal: [6]))))
-      let id4 = x.store(hexagon[hexagonId[4]].retract(Vector6(s * Tensor(randomNormal: [6]))))
-      let id5 = x.store(hexagon[hexagonId[5]].retract(Vector6(s * Tensor(randomNormal: [6]))))
+      let id1 = x.store(hexagon[hexagonId[1]].retract(Vector6(flatTensor: s * Tensor(randomNormal: [6]))))
+      let id2 = x.store(hexagon[hexagonId[2]].retract(Vector6(flatTensor: s * Tensor(randomNormal: [6]))))
+      let id3 = x.store(hexagon[hexagonId[3]].retract(Vector6(flatTensor: s * Tensor(randomNormal: [6]))))
+      let id4 = x.store(hexagon[hexagonId[4]].retract(Vector6(flatTensor: s * Tensor(randomNormal: [6]))))
+      let id5 = x.store(hexagon[hexagonId[5]].retract(Vector6(flatTensor: s * Tensor(randomNormal: [6]))))
       
       var fg = FactorGraph()
       fg.store(PriorFactor(id0, p0))
@@ -213,11 +213,11 @@ class FactorGraphTests: XCTestCase {
       
       let s = 0.9
       let id0 = x.store(p0)
-      let id1 = x.store(hexagon[hexagonId[1]].retract(Vector6(s * Tensor(randomNormal: [6]))))
-      let id2 = x.store(hexagon[hexagonId[2]].retract(Vector6(s * Tensor(randomNormal: [6]))))
-      let id3 = x.store(hexagon[hexagonId[3]].retract(Vector6(s * Tensor(randomNormal: [6]))))
-      let id4 = x.store(hexagon[hexagonId[4]].retract(Vector6(s * Tensor(randomNormal: [6]))))
-      let id5 = x.store(hexagon[hexagonId[5]].retract(Vector6(s * Tensor(randomNormal: [6]))))
+      let id1 = x.store(hexagon[hexagonId[1]].retract(Vector6(flatTensor: s * Tensor(randomNormal: [6]))))
+      let id2 = x.store(hexagon[hexagonId[2]].retract(Vector6(flatTensor: s * Tensor(randomNormal: [6]))))
+      let id3 = x.store(hexagon[hexagonId[3]].retract(Vector6(flatTensor: s * Tensor(randomNormal: [6]))))
+      let id4 = x.store(hexagon[hexagonId[4]].retract(Vector6(flatTensor: s * Tensor(randomNormal: [6]))))
+      let id5 = x.store(hexagon[hexagonId[5]].retract(Vector6(flatTensor: s * Tensor(randomNormal: [6]))))
       
       var fg = FactorGraph()
       fg.store(PriorFactor(id0, p0))

--- a/Tests/SwiftFusionTests/Optimizers/CGLSTests.swift
+++ b/Tests/SwiftFusionTests/Optimizers/CGLSTests.swift
@@ -17,7 +17,7 @@ final class CGLSTests: XCTestCase {
     let expected = SimpleGaussianFactorGraph.correctDelta()
     
     for k in [SimpleGaussianFactorGraph.x1ID, SimpleGaussianFactorGraph.x2ID] {
-      assertEqual(x[k].tensor, expected[k].tensor, accuracy: 1e-6)
+      assertEqual(x[k].flatTensor, expected[k].flatTensor, accuracy: 1e-6)
     }
   }
 }


### PR DESCRIPTION
* Adds differentiable `init(flatTensor:)` and `.flatTensor` for converting fixed size vectors from/to `Tensor`, so that we can "escape" to `TensorFlow`-land in calculations that need `TensorFlow` functions.
* Adds `FixedShapeTensor` so that we can use `Tensor`s as variables and error vectors in factor graphs.