### PR TITLE
use dynamically allocated array for big jacobians

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/saeta/penguin.git",
         "state": {
           "branch": "marcrasi-collection-protocols",
-          "revision": "e3a17b12fea35a5496c63a450f8397e3472b8f49",
+          "revision": "112ffef692811010aab04a6e1ae2fcd3b009f799",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
         "package": "Penguin",
         "repositoryURL": "https://github.com/saeta/penguin.git",
         "state": {
-          "branch": "master",
-          "revision": "81c7c9f",
+          "branch": "marcrasi-collection-protocols",
+          "revision": "e3a17b12fea35a5496c63a450f8397e3472b8f49",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     // Dependencies declare other packages that this package depends on.
     // .package(url: /* package url */, from: "1.0.0"),
     .package(url: "https://github.com/google/swift-benchmark.git", .branch("master")),
-    .package(url: "https://github.com/saeta/penguin.git", .branch("master")),
+    .package(url: "https://github.com/saeta/penguin.git", .branch("marcrasi-collection-protocols")),
     .package(url: "https://github.com/ProfFan/tensorboardx-s4tf.git", from: "0.1.3"),
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("swift-5.2-branch")),
     .package(url: "https://github.com/tensorflow/swift-models.git", .branch("master")),

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,12 @@ let package = Package(
     // Dependencies declare other packages that this package depends on.
     // .package(url: /* package url */, from: "1.0.0"),
     .package(url: "https://github.com/google/swift-benchmark.git", .branch("master")),
+
+    // There are some incompatible changes in penguin master but I need some new features so I have
+    // temporarily switched this to a branch with the features but not the incompatible changes.
+    // TODO(https://github.com/borglab/SwiftFusion/pull/154): Change back to `.branch("master")`.
     .package(url: "https://github.com/saeta/penguin.git", .branch("marcrasi-collection-protocols")),
+
     .package(url: "https://github.com/ProfFan/tensorboardx-s4tf.git", from: "0.1.3"),
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("swift-5.2-branch")),
     .package(url: "https://github.com/tensorflow/swift-models.git", .branch("master")),

--- a/Sources/SwiftFusion/Inference/BetweenFactorAlternative.swift
+++ b/Sources/SwiftFusion/Inference/BetweenFactorAlternative.swift
@@ -33,15 +33,3 @@ public struct BetweenFactorAlternative: LinearizableFactor2 {
     return Vector12(concatenating: R, t)
   }
 }
-
-public typealias Array8<T> = ArrayN<Array7<T>>
-public typealias Array9<T> = ArrayN<Array8<T>>
-public typealias Array10<T> = ArrayN<Array9<T>>
-public typealias Array11<T> = ArrayN<Array10<T>>
-public typealias Array12<T> = ArrayN<Array11<T>>
-
-/// A Jacobian factor with 1 6-dimensional input and a 12-dimensional error vector.
-public typealias JacobianFactor12x6_1 = JacobianFactor<Array12<Tuple1<Vector6>>, Vector12>
-
-/// A Jacobian factor with 2 6-dimensional inputs and a 12-dimensional error vector.
-public typealias JacobianFactor12x6_2 = JacobianFactor<Array12<Tuple2<Vector6, Vector6>>, Vector12>

--- a/Sources/SwiftFusion/Inference/ChordalInitialization.swift
+++ b/Sources/SwiftFusion/Inference/ChordalInitialization.swift
@@ -59,8 +59,8 @@ public struct RelaxedAnchorFactorRot3: LinearizableFactor1
 
 /// Type shorthands used in the relaxed pose graph
 /// NOTE: Specializations are added in `FactorsStorage.swift`
-public typealias Jacobian9x3x3_1 = Array9<Tuple1<Matrix3>>
-public typealias Jacobian9x3x3_2 = Array9<Tuple2<Matrix3, Matrix3>>
+public typealias Jacobian9x3x3_1 = Array<Tuple1<Matrix3>>
+public typealias Jacobian9x3x3_2 = Array<Tuple2<Matrix3, Matrix3>>
 public typealias JacobianFactor9x3x3_1 = JacobianFactor<Jacobian9x3x3_1, Vector9>
 public typealias JacobianFactor9x3x3_2 = JacobianFactor<Jacobian9x3x3_2, Vector9>
 

--- a/Sources/SwiftFusion/Inference/FactorsStorage.swift
+++ b/Sources/SwiftFusion/Inference/FactorsStorage.swift
@@ -200,9 +200,24 @@ extension AnyArrayBuffer where Dispatch == VectorFactorArrayDispatch {
     let dispatch: VectorFactorArrayDispatch
     let elementType = Type<Element>()
     typealias TangentVector = Element.LinearizableComponent.Variables.TangentVector
-    typealias Linearization<A: FixedSizeArray> = Type<JacobianFactor<A, Element.ErrorVector>>
-      where A.Element: Vector & DifferentiableVariableTuple
-    
+    typealias Linearization<A> = Type<JacobianFactor<A, Element.ErrorVector>>
+      where A: SourceInitializableCollection & UnsafeBufferAccessibleCollection,
+            A.Element: Vector & DifferentiableVariableTuple
+
+    // For small dimensions, we use a fixed size array in the linearization because the allocation
+    // and indirection overheads of a dynamically sized array are releatively big.
+    //
+    // For larger dimensions, dynamically sized array are more convenient (no need to define a
+    // new type and case for each size) and in some cases also happen to be faster than fixed size
+    // arrays.
+    //
+    // We chose 4 as the cutoff based on benchmark results:
+    // - "Pose2SLAM.FactorGraph", which heavily uses 3 dimensional error vectors, is ~30% faster
+    //   with a fixed size array than with a dynamically sized array.
+    // - "Pose3SLAM.FactorGraph", which heavily uses 6 dimensional error vectors, is ~3% faster
+    //   with a dynamically sized array than with a fixed size array.
+    // - "Pose3SLAM.sphere2500", which heavily uses 12 dimensional error vectors, has the same
+    //   performance with fixed size and dynamically sized arrays.
     switch Element.ErrorVector.dimension {
     case 1:
       dispatch = .init(elementType, linearization: Linearization<Array1<TangentVector>>())
@@ -212,24 +227,8 @@ extension AnyArrayBuffer where Dispatch == VectorFactorArrayDispatch {
       dispatch = .init(elementType, linearization: Linearization<Array3<TangentVector>>())
     case 4:
       dispatch = .init(elementType, linearization: Linearization<Array4<TangentVector>>())
-    case 5:
-      dispatch = .init(elementType, linearization: Linearization<Array5<TangentVector>>())
-    case 6:
-      dispatch = .init(elementType, linearization: Linearization<Array6<TangentVector>>())
-    case 7:
-      dispatch = .init(elementType, linearization: Linearization<Array7<TangentVector>>())
-    case 8:
-      dispatch = .init(elementType, linearization: Linearization<Array8<TangentVector>>())
-    case 9:
-      dispatch = .init(elementType, linearization: Linearization<Array9<TangentVector>>())
-    case 10:
-      dispatch = .init(elementType, linearization: Linearization<Array10<TangentVector>>())
-    case 11:
-      dispatch = .init(elementType, linearization: Linearization<Array11<TangentVector>>())
-    case 12:
-      dispatch = .init(elementType, linearization: Linearization<Array12<TangentVector>>())
     default:
-      fatalError("ErrorVector dimension \(Element.ErrorVector.dimension) not implemented")
+      dispatch = .init(elementType, linearization: Linearization<Array<TangentVector>>())
     }
 
     self.init(storage: src.storage, dispatch: dispatch)

--- a/Sources/SwiftFusion/Inference/FactorsStorage.swift
+++ b/Sources/SwiftFusion/Inference/FactorsStorage.swift
@@ -201,8 +201,7 @@ extension AnyArrayBuffer where Dispatch == VectorFactorArrayDispatch {
     let elementType = Type<Element>()
     typealias TangentVector = Element.LinearizableComponent.Variables.TangentVector
     typealias Linearization<A> = Type<JacobianFactor<A, Element.ErrorVector>>
-      where A: SourceInitializableCollection & UnsafeBufferAccessibleCollection,
-            A.Element: Vector & DifferentiableVariableTuple
+      where A: SourceInitializableCollection, A.Element: Vector & DifferentiableVariableTuple
 
     // For small dimensions, we use a fixed size array in the linearization because the allocation
     // and indirection overheads of a dynamically sized array are releatively big.

--- a/Sources/SwiftFusion/Inference/JacobianFactor.swift
+++ b/Sources/SwiftFusion/Inference/JacobianFactor.swift
@@ -16,10 +16,11 @@ import PenguinStructures
 
 /// A Gaussian distribution over the input, represented as a materialized Jacobian matrix and
 /// materialized error vector.
-public struct JacobianFactor<
-  Rows: SourceInitializableCollection & UnsafeBufferAccessibleCollection,
-  ErrorVector: Vector
->: LinearApproximationFactor where Rows.Element: Vector & DifferentiableVariableTuple {
+public struct JacobianFactor<Rows: SourceInitializableCollection, ErrorVector: Vector>:
+  LinearApproximationFactor
+where
+  Rows.Element: Vector & DifferentiableVariableTuple
+{
   public typealias Variables = Rows.Element
 
   /// The Jacobian matrix, as a fixed size array of rows.
@@ -71,15 +72,17 @@ public struct JacobianFactor<
   public func errorVector_linearComponent(_ x: Variables) -> ErrorVector {
     // The compiler isn't able to optimize the closure away if we map `jacobian`, but it is able
     // to optimize the closure away if we map `jacobian`'s `UnsafeBufferPointer`.
-    jacobian.withUnsafeBufferPointer { rows in
+    let r = jacobian.withContiguousStorageIfAvailable { rows in
       ErrorVector(rows.lazy.map { $0.dot(x) })
     }
+    assert(r != nil, "Rows must have contiguous storage")
+    return r.unsafelyUnwrapped
   }
 
   public func errorVector_linearComponent_adjoint(_ y: ErrorVector) -> Variables {
     // We use `UnsafeBufferPointer`s to avoid forming collections that can't be optimized away.
-    y.withUnsafeBufferPointer { scalars in
-      jacobian.withUnsafeBufferPointer { rows in
+    let r = y.withUnsafeBufferPointer { scalars in
+      jacobian.withContiguousStorageIfAvailable { rows in
         // We reduce the range `0..<ErrorVector.dimension` instead of `zip(scalars, rows)`, to
         // avoid forming collections that can't be optimized away.
         // TODO: This is not getting unrolled after `ErrorVector` is specialized. Convincing the
@@ -89,6 +92,8 @@ public struct JacobianFactor<
         }
       }
     }
+    assert(r != nil, "Rows must have contiguous storage")
+    return r.unsafelyUnwrapped
   }
 }
 

--- a/Sources/SwiftFusion/Inference/JacobianFactor.swift
+++ b/Sources/SwiftFusion/Inference/JacobianFactor.swift
@@ -17,7 +17,7 @@ import PenguinStructures
 /// A Gaussian distribution over the input, represented as a materialized Jacobian matrix and
 /// materialized error vector.
 public struct JacobianFactor<
-  Rows: FixedSizeArray,
+  Rows: SourceInitializableCollection & UnsafeBufferAccessibleCollection,
   ErrorVector: Vector
 >: LinearApproximationFactor where Rows.Element: Vector & DifferentiableVariableTuple {
   public typealias Variables = Rows.Element

--- a/Tests/SwiftFusionTests/Inference/ChordalInitializationTests.swift
+++ b/Tests/SwiftFusionTests/Inference/ChordalInitializationTests.swift
@@ -72,7 +72,7 @@ class ChordalInitializationTests: XCTestCase {
     let frf_j = JacobianFactor9x3x3_2(linearizing: frf, at: Tuple2(val[p0], val[p1]))
     
     let Rij = Matrix3(0.0,0.1,0.2,1.0,1.1,1.2,2.0,2.1,2.2)
-    let M9: Jacobian9x3x3_2 = Array9([
+    let M9: Jacobian9x3x3_2 = [
       Tuple2(Matrix3(-1,0,0,0,0,0,0,0,0), Matrix3(Rij[0, 0],Rij[0, 1],Rij[0, 2],0,0,0,0,0,0)),
       Tuple2(Matrix3(0,-1,0,0,0,0,0,0,0), Matrix3(Rij[1, 0],Rij[1, 1],Rij[1, 2],0,0,0,0,0,0)),
       Tuple2(Matrix3(0,0,-1,0,0,0,0,0,0), Matrix3(Rij[2, 0],Rij[2, 1],Rij[2, 2],0,0,0,0,0,0)),
@@ -82,7 +82,7 @@ class ChordalInitializationTests: XCTestCase {
       Tuple2(Matrix3(0,0,0,0,0,0,-1,0,0), Matrix3(0,0,0,0,0,0,Rij[0, 0],Rij[0, 1],Rij[0, 2])),
       Tuple2(Matrix3(0,0,0,0,0,0,0,-1,0), Matrix3(0,0,0,0,0,0,Rij[1, 0],Rij[1, 1],Rij[1, 2])),
       Tuple2(Matrix3(0,0,0,0,0,0,0,0,-1), Matrix3(0,0,0,0,0,0,Rij[2, 0],Rij[2, 1],Rij[2, 2]))
-    ])
+    ]
     
     let b = Vector9(0, 0, 0, 0, 0, 0, 0, 0, 0)
     
@@ -105,7 +105,7 @@ class ChordalInitializationTests: XCTestCase {
     
     let fpf_j = JacobianFactor9x3x3_1(linearizing: fpf, at: Tuple1(Matrix3.zero))
     
-    let I_9x9: Jacobian9x3x3_1 = Array9([
+    let I_9x9: Jacobian9x3x3_1 = [
       Tuple1(Matrix3(1,0,0,0,0,0,0,0,0)),
       Tuple1(Matrix3(0,1,0,0,0,0,0,0,0)),
       Tuple1(Matrix3(0,0,1,0,0,0,0,0,0)),
@@ -115,7 +115,7 @@ class ChordalInitializationTests: XCTestCase {
       Tuple1(Matrix3(0,0,0,0,0,0,1,0,0)),
       Tuple1(Matrix3(0,0,0,0,0,0,0,1,0)),
       Tuple1(Matrix3(0,0,0,0,0,0,0,0,1))
-    ])
+    ]
     
     // prior on the anchor orientation
     let jf_p = JacobianFactor9x3x3_1(jacobian: I_9x9,


### PR DESCRIPTION
My main motivation for this is so that we can have factors with big error vectors (on the order of 1,000 to 10,000 dimensions) without having to define fixed size arrays up to Array10000. We want to have error vectors with one element per pixel in an image.

Oddly, this also gave a 3% speedup in one of the benchmarks by changing the fixed size `Array6` to the dynamic `Array`. (See comment for details). Maybe it's avoiding some slow copies by passing around a pointer to the data.

This depends on a Penguin PR that I will create soon.