### PR TITLE
faster crop

### DIFF
--- a/Sources/SwiftFusion/Image/ArrayImage.swift
+++ b/Sources/SwiftFusion/Image/ArrayImage.swift
@@ -1,0 +1,103 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import TensorFlow
+
+/// Image stored as an `Array`.
+///
+/// Useful when doing lots of subscripting because `Array` subscripts are faster than `Tensor`
+/// subscripts.
+public struct ArrayImage: Differentiable {
+  var pixels: [Double]
+  @noDerivative let rows: Int
+  @noDerivative let cols: Int
+  @noDerivative let channels: Int
+
+  /// Creates a black instance.
+  public init(rows: Int, cols: Int, channels: Int) {
+    self.pixels = Array(repeating: 0, count: rows * cols * channels)
+    self.rows = rows
+    self.cols = cols
+    self.channels = channels
+  }
+
+  /// Creates an instance from the given image `tensor`.
+  @differentiable
+  public init(_ tensor: Tensor<Double>) {
+    precondition(
+      tensor.shape.count == 2 || tensor.shape.count == 3,
+      "image must have shape height x width x channelCount"
+    )
+
+    self.pixels = tensor.scalars
+    self.rows = tensor.shape[0]
+    self.cols = tensor.shape[1]
+    self.channels = tensor.shape.count == 2 ? 1 : tensor.shape[2]
+  }
+
+  /// Returns this image as an image `Tensor`.
+  @differentiable
+  public var tensor: Tensor<Double> {
+    Tensor(shape: [rows, cols, channels], scalars: pixels)
+  }
+
+  /// The index of a pixel in the `pixels` storage.
+  ///
+  /// Returns `nil` when the indices are out of bounds.
+  func index(_ i: Int, _ j: Int, _ channel: Int) -> Int? {
+    guard i >= 0, i < rows, j >= 0, j < cols, channel >= 0, channel < channels else {
+      return nil
+    }
+    return i * cols * channels + j * channels + channel
+  }
+
+  /// Accesses the pixel value at `(i, j, channel)`.
+  public subscript(_ i: Int, _ j: Int, _ channel: Int) -> Double {
+    get {
+      guard let idx = index(i, j, channel) else {
+        return 0
+      }
+      return pixels[idx]
+    }
+    _modify {
+      let idx = index(i, j, channel)
+      assert(idx != nil, "can only modify pixels that are in bounds")
+      yield &pixels[idx.unsafelyUnwrapped]
+    }
+  }
+
+  /// Updates the pixel value at `(i, j, channel)` to `value`.
+  ///
+  /// Use this instead of the subscript when you need to differentiably modify the image.
+  @differentiable
+  public mutating func update(_ i: Int, _ j: Int, _ channel: Int, to value: Double) {
+    self[i, j, channel] = value
+  }
+
+  @derivative(of: update)
+  @usableFromInline
+  mutating func vjpUpdate(_ i: Int, _ j: Int, _ channel: Int, to value: Double) -> (
+    value: (),
+    pullback: (inout TangentVector) -> Double
+  ) {
+    update(i, j, channel, to: value)
+    let idx = index(i, j, channel).unsafelyUnwrapped
+    func pullback(_ v: inout TangentVector) -> Double {
+      return v.pixels.base[idx]
+    }
+    return ((), pullback)
+  }
+}
+
+

--- a/Sources/SwiftFusion/Image/Patch.swift
+++ b/Sources/SwiftFusion/Image/Patch.swift
@@ -14,39 +14,78 @@
 
 import TensorFlow
 
-extension Tensor where Scalar == Double {
-  /// Returns the patch of `self` at `region`, sampling pixels using `resample`.
+extension ArrayImage {
+  /// Returns the patch of `self` at `region`.
   ///
   /// - Parameters:
-  ///   - self: a pixel tensor with shape `[height, width, channelCount]`. `height` and `width` are
-  ///     as defined in `docs/ImageOperations.md`.
   ///   - region: the center, orientation, and size of the patch to extract.
-  ///   - resample: Returns a sample of `image` at `point`.
-  ///     - image: a pixel tensor, with shape `[height, width, channelCount]`. `height` and
-  ///       `width` are as defined in `docs/ImageOperations.md`.
-  ///     - point: a point in `(u, v)` coordinates as defined in `docs/ImageOperations.md`.
-  @differentiable
-  public func patch(
-    at region: OrientedBoundingBox,
-    resample: @differentiable (_ image: Tensor<Scalar>, _ point: Vector2) -> Tensor<Scalar>
-      = bilinear
-  ) -> Tensor<Scalar> {
-    precondition(self.shape.count == 3, "image must have shape height x width x channelCount")
-    let patchShape: TensorShape = [region.rows, region.cols, self.shape[2]]
-    var patch = Tensor<Scalar>(zeros: patchShape)
+  @differentiable(wrt: region)
+  public func patch(at region: OrientedBoundingBox) -> Self {
+    var result = ArrayImage(rows: region.rows, cols: region.cols, channels: self.channels)
     for i in 0..<region.rows {
       for j in 0..<region.cols {
         // The position of the destination pixel in the destination image, in `(u, v)` coordinates.
         let uvDest = Vector2(Double(j) + 0.5, Double(i) + 0.5)
 
-        // The position of the destination pixel in the destination image, in coordinates where the
+        // The position of the destination pixel in the source image, in coordinates where the
         // center of the destination image is `(0, 0)`.
         let xyDest = uvDest - 0.5 * Vector2(Double(region.cols), Double(region.rows))
 
-        patch.differentiableUpdate(i, j, to: resample(self, region.center * xyDest))
+        for c in 0..<self.channels {
+          result.update(i, j, c, to: bilinear(self, region.center * xyDest, c))
+        }
       }
     }
-    return patch
+    return result
+  }
+
+  @derivative(of: patch, wrt: region)
+  @usableFromInline
+  func vjpPatch(at region: OrientedBoundingBox) -> (value: Self, pullback: (TangentVector) -> OrientedBoundingBox.TangentVector) {
+    let r = self.patch(at: region)
+    let channels = self.channels
+    func outerPb(_ dOut: TangentVector) -> OrientedBoundingBox.TangentVector {
+      var idx = 0
+      var dBox = OrientedBoundingBox.TangentVector.zero
+      for i in 0..<region.rows {
+        for j in 0..<region.cols {
+          // The position of the destination pixel in the destination image, in `(u, v)` coordinates.
+          let uvDest = Vector2(Double(j) + 0.5, Double(i) + 0.5)
+
+          // The position of the destination pixel in the source image, in coordinates where the
+          // center of the destination image is `(0, 0)`.
+          let xyDest = uvDest - 0.5 * Vector2(Double(region.cols), Double(region.rows))
+
+          for c in 0..<channels {
+            if dOut.pixels.base[idx] != 0 {
+              let pb = pullback(at: region) { bilinear(self, $0.center * xyDest, c) }
+              dBox += pb(dOut.pixels.base[idx])
+            }
+            idx += 1
+          }
+        }
+      }
+      return dBox
+    }
+    return (r, outerPb)
+  }
+}
+
+extension Tensor where Scalar == Double {
+  /// Returns the patch of `self` at `region`.
+  ///
+  /// - Parameters:
+  ///   - self: a pixel tensor with shape `[height, width]` or `[height, width, channelCount]`.
+  ///     `height` and `width` are as defined in `docs/ImageOperations.md`.
+  ///   - region: the center, orientation, and size of the patch to extract.
+  @differentiable(wrt: region)
+  public func patch(at region: OrientedBoundingBox) -> Tensor<Scalar> {
+    precondition(
+      self.shape.count == 2 || self.shape.count == 3,
+      "image must have shape [height, width] or [height, width, channelCount]"
+    )
+    let result = ArrayImage(self).patch(at: region).tensor
+    return self.shape.count == 2 ? result.reshaped(to: [region.rows, region.cols]) : result
   }
 }
 
@@ -57,63 +96,22 @@ extension Tensor where Scalar == Double {
 ///   - image: a pixel tensor, with shape `[height, width, channelCount]`. `height` and
 ///     `width` are as defined in `docs/ImageOperations.md`.
 ///   - point: a point in `(u, v)` coordinates as defined in `docs/ImageOperations.md`.
-@differentiable
-public func bilinear(_ image: Tensor<Double>, _ point: Vector2) -> Tensor<Double> {
-  precondition(image.shape.count == 3)
-
+///   - channel: The channel to return.
+@differentiable(wrt: point)
+public func bilinear(_ image: ArrayImage, _ point: Vector2, _ channel: Int) -> Double {
   // The `(i, j)` integer coordinates of the top left pixel to sample from.
-  let i = withoutDerivative(at: Int(floor(point.y - 0.5)))
-  let j = withoutDerivative(at: Int(floor(point.x - 0.5)))
+  let sourceI = withoutDerivative(at: Int(floor(point.y - 0.5)))
+  let sourceJ = withoutDerivative(at: Int(floor(point.x - 0.5)))
 
-  // Weight of the `(i, _)` pixels in the interpolation.
-  let weightI = Double(i) + 1.5 - point.y
+  // Weight of the `(sourceI, _)` pixels in the interpolation.
+  let weightI = Double(sourceI) + 1.5 - point.y
 
-  // Weight of the `(_, j)` pixels in the interpolation.
-  let weightJ = Double(j) + 1.5 - point.x
+  // Weight of the `(_, sourceJ)` pixels in the interpolation.
+  let weightJ = Double(sourceJ) + 1.5 - point.x
 
-  func pixelOrZero(_ t: Tensor<Double>, _ i: Int, _ j: Int) -> Tensor<Double> {
-    if i < 0 {
-      return Tensor(zeros: [t.shape[2]])
-    }
-    if j < 0 {
-      return Tensor(zeros: [t.shape[2]])
-    }
-    if i >= t.shape[0] {
-      return Tensor(zeros: [t.shape[2]])
-    }
-    if j >= t.shape[1] {
-      return Tensor(zeros: [t.shape[2]])
-    }
-    return t[i, j]
-  }
-
-  let s1 = pixelOrZero(image, i, j) * weightI * weightJ
-  let s2 = pixelOrZero(image, i + 1, j) * (1 - weightI) * weightJ
-  let s3 = pixelOrZero(image, i, j + 1) * weightI * (1 - weightJ)
-  let s4 = pixelOrZero(image, i + 1, j + 1) * (1 - weightI) * (1 - weightJ)
+  let s1 = image[sourceI, sourceJ, channel] * weightI * weightJ
+  let s2 = image[sourceI + 1, sourceJ, channel] * (1 - weightI) * weightJ
+  let s3 = image[sourceI, sourceJ + 1, channel] * weightI * (1 - weightJ)
+  let s4 = image[sourceI + 1, sourceJ + 1, channel] * (1 - weightI) * (1 - weightJ)
   return s1 + s2 + s3 + s4
-}
-
-/// Implements a differentiable update method because the normal subscript setter does not have a
-/// derivative.
-fileprivate extension Tensor where Scalar: TensorFlowFloatingPoint {
-  @differentiable
-  mutating func differentiableUpdate(_ i: Int, _ j: Int, to value: Self) {
-    precondition(self.shape.count == 3)
-    self[i, j] = value
-  }
-
-  @derivative(of: differentiableUpdate)
-  mutating func vjpDifferentiableUpdate(_ i: Int, _ j: Int, to value: Self)
-    -> (value: (), pullback: (inout Self) -> Self)
-  {
-    self.differentiableUpdate(i, j, to: value)
-    let valueShape = value.shape
-    func pullback(_ t: inout Self) -> Self {
-      let tValue = t[i, j]
-      t[i, j] = Tensor(zeros: valueShape)
-      return tValue
-    }
-    return ((), pullback)
-  }
 }

--- a/Sources/SwiftFusionBenchmarks/Patch.swift
+++ b/Sources/SwiftFusionBenchmarks/Patch.swift
@@ -13,9 +13,18 @@
 // limitations under the License.
 
 import Benchmark
+import SwiftFusion
+import TensorFlow
 
-Benchmark.main([
-  patchBenchmark,
-  pose2SLAM,
-  pose3SLAM
-])
+let patchBenchmark = BenchmarkSuite(name: "Patch") { suite in
+  /// Measures speed of taking a 100x100x1 patch from a 500x500x1 image.
+  suite.benchmark(
+    "100x100x1 patch from 500x500x1 image",
+    settings: Iterations(1), TimeUnit(.ms)
+  ) {
+    let rows = 100
+    let cols = 100
+    let image = Tensor<Double>(randomNormal: [500, 500, 1])
+    _ = image.patch(at: OrientedBoundingBox(center: Pose2(100, 100, 0.5), rows: rows, cols: cols))
+  }
+}

--- a/Tests/SwiftFusionTests/Image/ArrayImageTests.swift
+++ b/Tests/SwiftFusionTests/Image/ArrayImageTests.swift
@@ -12,10 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Benchmark
+import ModelSupport
+import SwiftFusion
+import TensorFlow
+import XCTest
 
-Benchmark.main([
-  patchBenchmark,
-  pose2SLAM,
-  pose3SLAM
-])
+final class ArrayImageTests: XCTestCase {
+  func testCreateBlank() {
+    let rows = 10
+    let cols = 10
+    let channels = 3
+    let image = ArrayImage(rows: rows, cols: cols, channels: channels)
+    for i in 0..<rows {
+      for j in 0..<cols {
+        for k in 0..<channels {
+          XCTAssertEqual(image[i, j, k], 0)
+        }
+      }
+    }
+  }
+}

--- a/Tests/SwiftFusionTests/Image/PatchTests.swift
+++ b/Tests/SwiftFusionTests/Image/PatchTests.swift
@@ -27,20 +27,6 @@ final class PatchTests: XCTestCase {
     XCTAssertEqual(patch, expectedPatch)
   }
 
-  /// The derivative of a patch with respect to the input image is the identity restricted to the
-  /// patch region.
-  func testSliceDerivativeWithRespectToImage() {
-    let image = Tensor<Double>(randomUniform: [100, 100, 3])
-    let grad = gradient(at: image) { image in
-      image.patch(
-        at: OrientedBoundingBox(center: Pose2(Rot2(0), Vector2(60, 30)), rows: 10, cols: 20)
-      ).sum()
-    }
-    var expectedGrad = Tensor<Double>(zeros: [100, 100, 3])
-    expectedGrad[25..<35, 50..<70] = Tensor(ones: [10, 20, 3])
-    XCTAssertEqual(grad, expectedGrad)
-  }
-
   /// Test cropping an example image.
   func testExampleImage() {
     let dataDir = URL.sourceFileDirectory().appendingPathComponent("data")


### PR DESCRIPTION
This makes the crop faster in a few ways:
* Do the crop on an `Array`, which has faster indexing than a `Tensor`.
* Do the derivative only with respect to the bounding box position, so that we don't spend time calculating the derivative with respect to the input image.
* Do the pullback with a custom vjp that is more efficient than the synthesized vjp.

@ProfFan this is just the speedups that I have already shown you. I have some additional speedups that I'll put in a separate PR soon. 