### PR TITLE
remove `ScalarsInitializableVector`

### DIFF
--- a/Sources/SwiftFusion/Core/FixedShapeTensor.swift
+++ b/Sources/SwiftFusion/Core/FixedShapeTensor.swift
@@ -38,10 +38,6 @@ extension FixedShapeTensor {
     (self.tensor * other.tensor).sum().scalarized()
   }
 
-  public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
-    self.init(Tensor(shape: Self.shape, scalars: Array(scalars)))
-  }
-
   public var dimension: Int {
     Self.dimension
   }
@@ -49,6 +45,8 @@ extension FixedShapeTensor {
   public static var dimension: Int {
     shape.reduce(1, *)
   }
+
+  public static var zero: Self { Self(Tensor(zeros: shape)) }
 
   public var standardBasis: [Self] {
     (0..<dimension).map { i in

--- a/Sources/SwiftFusion/Core/Tuple+Vector.swift
+++ b/Sources/SwiftFusion/Core/Tuple+Vector.swift
@@ -111,12 +111,8 @@ extension Empty: FixedSizeVector {
   }
 }
 
-extension Tuple: FixedSizeVector, ScalarsInitializableVector
+extension Tuple: FixedSizeVector
   where Head: FixedSizeVector, Tail: FixedSizeVector
 {
   public static var dimension: Int { Head.dimension + Tail.dimension }
-  public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
-    let i = scalars.index(scalars.startIndex, offsetBy: Head.dimension)
-    self.init(head: .init(scalars[..<i]), tail: .init(scalars[i...]))
-  }
 }

--- a/Sources/SwiftFusion/Core/VectorN.swift
+++ b/Sources/SwiftFusion/Core/VectorN.swift
@@ -81,6 +81,38 @@ extension Vector1: FixedSizeVector {
 
 extension Vector1: ElementaryFunctions {}
 
+/// Converstion to/from `Tensor`.
+extension Vector1 {
+  /// Returns a `Tensor` with shape `[Self.dimension]` with the same scalars as `self`.
+  public var tensor: Tensor<Double> {
+    withUnsafeBufferPointer { b in
+      return Tensor<Double>(shape: [b.count], scalars: b)
+    }
+  }
+
+  @derivative(of: tensor)
+  @usableFromInline
+  func vjpFlatTensor() -> (value: Tensor<Double>, pullback: (Tensor<Double>) -> Self)
+  {
+    return (self.tensor, { Self(tensor: $0) })
+  }
+
+  /// Creates an instance with the same scalars as `tensor`.
+  @differentiable
+  public init(tensor: Tensor<Double>) {
+    self.init(tensor.scalars)
+  }
+
+  @derivative(of: init(tensor:))
+  @usableFromInline
+  static func vjpInit(tensor: Tensor<Double>) -> (
+    value: Self,
+    pullback: (Self) -> Tensor<Double>
+  ) {
+    return (Self(tensor: tensor), { $0.tensor })
+  }
+}
+
 // ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^2, with Euclidean inner product.
@@ -174,6 +206,38 @@ extension Vector2: FixedSizeVector {
 }
 
 extension Vector2: ElementaryFunctions {}
+
+/// Converstion to/from `Tensor`.
+extension Vector2 {
+  /// Returns a `Tensor` with shape `[Self.dimension]` with the same scalars as `self`.
+  public var tensor: Tensor<Double> {
+    withUnsafeBufferPointer { b in
+      return Tensor<Double>(shape: [b.count], scalars: b)
+    }
+  }
+
+  @derivative(of: tensor)
+  @usableFromInline
+  func vjpFlatTensor() -> (value: Tensor<Double>, pullback: (Tensor<Double>) -> Self)
+  {
+    return (self.tensor, { Self(tensor: $0) })
+  }
+
+  /// Creates an instance with the same scalars as `tensor`.
+  @differentiable
+  public init(tensor: Tensor<Double>) {
+    self.init(tensor.scalars)
+  }
+
+  @derivative(of: init(tensor:))
+  @usableFromInline
+  static func vjpInit(tensor: Tensor<Double>) -> (
+    value: Self,
+    pullback: (Self) -> Tensor<Double>
+  ) {
+    return (Self(tensor: tensor), { $0.tensor })
+  }
+}
 
 // ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
@@ -285,6 +349,38 @@ extension Vector3: FixedSizeVector {
 }
 
 extension Vector3: ElementaryFunctions {}
+
+/// Converstion to/from `Tensor`.
+extension Vector3 {
+  /// Returns a `Tensor` with shape `[Self.dimension]` with the same scalars as `self`.
+  public var tensor: Tensor<Double> {
+    withUnsafeBufferPointer { b in
+      return Tensor<Double>(shape: [b.count], scalars: b)
+    }
+  }
+
+  @derivative(of: tensor)
+  @usableFromInline
+  func vjpFlatTensor() -> (value: Tensor<Double>, pullback: (Tensor<Double>) -> Self)
+  {
+    return (self.tensor, { Self(tensor: $0) })
+  }
+
+  /// Creates an instance with the same scalars as `tensor`.
+  @differentiable
+  public init(tensor: Tensor<Double>) {
+    self.init(tensor.scalars)
+  }
+
+  @derivative(of: init(tensor:))
+  @usableFromInline
+  static func vjpInit(tensor: Tensor<Double>) -> (
+    value: Self,
+    pullback: (Self) -> Tensor<Double>
+  ) {
+    return (Self(tensor: tensor), { $0.tensor })
+  }
+}
 
 // ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
@@ -413,6 +509,38 @@ extension Vector4: FixedSizeVector {
 }
 
 extension Vector4: ElementaryFunctions {}
+
+/// Converstion to/from `Tensor`.
+extension Vector4 {
+  /// Returns a `Tensor` with shape `[Self.dimension]` with the same scalars as `self`.
+  public var tensor: Tensor<Double> {
+    withUnsafeBufferPointer { b in
+      return Tensor<Double>(shape: [b.count], scalars: b)
+    }
+  }
+
+  @derivative(of: tensor)
+  @usableFromInline
+  func vjpFlatTensor() -> (value: Tensor<Double>, pullback: (Tensor<Double>) -> Self)
+  {
+    return (self.tensor, { Self(tensor: $0) })
+  }
+
+  /// Creates an instance with the same scalars as `tensor`.
+  @differentiable
+  public init(tensor: Tensor<Double>) {
+    self.init(tensor.scalars)
+  }
+
+  @derivative(of: init(tensor:))
+  @usableFromInline
+  static func vjpInit(tensor: Tensor<Double>) -> (
+    value: Self,
+    pullback: (Self) -> Tensor<Double>
+  ) {
+    return (Self(tensor: tensor), { $0.tensor })
+  }
+}
 
 // ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
@@ -558,6 +686,38 @@ extension Vector5: FixedSizeVector {
 }
 
 extension Vector5: ElementaryFunctions {}
+
+/// Converstion to/from `Tensor`.
+extension Vector5 {
+  /// Returns a `Tensor` with shape `[Self.dimension]` with the same scalars as `self`.
+  public var tensor: Tensor<Double> {
+    withUnsafeBufferPointer { b in
+      return Tensor<Double>(shape: [b.count], scalars: b)
+    }
+  }
+
+  @derivative(of: tensor)
+  @usableFromInline
+  func vjpFlatTensor() -> (value: Tensor<Double>, pullback: (Tensor<Double>) -> Self)
+  {
+    return (self.tensor, { Self(tensor: $0) })
+  }
+
+  /// Creates an instance with the same scalars as `tensor`.
+  @differentiable
+  public init(tensor: Tensor<Double>) {
+    self.init(tensor.scalars)
+  }
+
+  @derivative(of: init(tensor:))
+  @usableFromInline
+  static func vjpInit(tensor: Tensor<Double>) -> (
+    value: Self,
+    pullback: (Self) -> Tensor<Double>
+  ) {
+    return (Self(tensor: tensor), { $0.tensor })
+  }
+}
 
 // ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
@@ -720,6 +880,38 @@ extension Vector6: FixedSizeVector {
 }
 
 extension Vector6: ElementaryFunctions {}
+
+/// Converstion to/from `Tensor`.
+extension Vector6 {
+  /// Returns a `Tensor` with shape `[Self.dimension]` with the same scalars as `self`.
+  public var tensor: Tensor<Double> {
+    withUnsafeBufferPointer { b in
+      return Tensor<Double>(shape: [b.count], scalars: b)
+    }
+  }
+
+  @derivative(of: tensor)
+  @usableFromInline
+  func vjpFlatTensor() -> (value: Tensor<Double>, pullback: (Tensor<Double>) -> Self)
+  {
+    return (self.tensor, { Self(tensor: $0) })
+  }
+
+  /// Creates an instance with the same scalars as `tensor`.
+  @differentiable
+  public init(tensor: Tensor<Double>) {
+    self.init(tensor.scalars)
+  }
+
+  @derivative(of: init(tensor:))
+  @usableFromInline
+  static func vjpInit(tensor: Tensor<Double>) -> (
+    value: Self,
+    pullback: (Self) -> Tensor<Double>
+  ) {
+    return (Self(tensor: tensor), { $0.tensor })
+  }
+}
 
 // ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
@@ -899,6 +1091,38 @@ extension Vector7: FixedSizeVector {
 }
 
 extension Vector7: ElementaryFunctions {}
+
+/// Converstion to/from `Tensor`.
+extension Vector7 {
+  /// Returns a `Tensor` with shape `[Self.dimension]` with the same scalars as `self`.
+  public var tensor: Tensor<Double> {
+    withUnsafeBufferPointer { b in
+      return Tensor<Double>(shape: [b.count], scalars: b)
+    }
+  }
+
+  @derivative(of: tensor)
+  @usableFromInline
+  func vjpFlatTensor() -> (value: Tensor<Double>, pullback: (Tensor<Double>) -> Self)
+  {
+    return (self.tensor, { Self(tensor: $0) })
+  }
+
+  /// Creates an instance with the same scalars as `tensor`.
+  @differentiable
+  public init(tensor: Tensor<Double>) {
+    self.init(tensor.scalars)
+  }
+
+  @derivative(of: init(tensor:))
+  @usableFromInline
+  static func vjpInit(tensor: Tensor<Double>) -> (
+    value: Self,
+    pullback: (Self) -> Tensor<Double>
+  ) {
+    return (Self(tensor: tensor), { $0.tensor })
+  }
+}
 
 // ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
@@ -1095,6 +1319,38 @@ extension Vector8: FixedSizeVector {
 }
 
 extension Vector8: ElementaryFunctions {}
+
+/// Converstion to/from `Tensor`.
+extension Vector8 {
+  /// Returns a `Tensor` with shape `[Self.dimension]` with the same scalars as `self`.
+  public var tensor: Tensor<Double> {
+    withUnsafeBufferPointer { b in
+      return Tensor<Double>(shape: [b.count], scalars: b)
+    }
+  }
+
+  @derivative(of: tensor)
+  @usableFromInline
+  func vjpFlatTensor() -> (value: Tensor<Double>, pullback: (Tensor<Double>) -> Self)
+  {
+    return (self.tensor, { Self(tensor: $0) })
+  }
+
+  /// Creates an instance with the same scalars as `tensor`.
+  @differentiable
+  public init(tensor: Tensor<Double>) {
+    self.init(tensor.scalars)
+  }
+
+  @derivative(of: init(tensor:))
+  @usableFromInline
+  static func vjpInit(tensor: Tensor<Double>) -> (
+    value: Self,
+    pullback: (Self) -> Tensor<Double>
+  ) {
+    return (Self(tensor: tensor), { $0.tensor })
+  }
+}
 
 // ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
@@ -1308,6 +1564,38 @@ extension Vector9: FixedSizeVector {
 }
 
 extension Vector9: ElementaryFunctions {}
+
+/// Converstion to/from `Tensor`.
+extension Vector9 {
+  /// Returns a `Tensor` with shape `[Self.dimension]` with the same scalars as `self`.
+  public var tensor: Tensor<Double> {
+    withUnsafeBufferPointer { b in
+      return Tensor<Double>(shape: [b.count], scalars: b)
+    }
+  }
+
+  @derivative(of: tensor)
+  @usableFromInline
+  func vjpFlatTensor() -> (value: Tensor<Double>, pullback: (Tensor<Double>) -> Self)
+  {
+    return (self.tensor, { Self(tensor: $0) })
+  }
+
+  /// Creates an instance with the same scalars as `tensor`.
+  @differentiable
+  public init(tensor: Tensor<Double>) {
+    self.init(tensor.scalars)
+  }
+
+  @derivative(of: init(tensor:))
+  @usableFromInline
+  static func vjpInit(tensor: Tensor<Double>) -> (
+    value: Self,
+    pullback: (Self) -> Tensor<Double>
+  ) {
+    return (Self(tensor: tensor), { $0.tensor })
+  }
+}
 
 // ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
@@ -1538,6 +1826,38 @@ extension Vector10: FixedSizeVector {
 }
 
 extension Vector10: ElementaryFunctions {}
+
+/// Converstion to/from `Tensor`.
+extension Vector10 {
+  /// Returns a `Tensor` with shape `[Self.dimension]` with the same scalars as `self`.
+  public var tensor: Tensor<Double> {
+    withUnsafeBufferPointer { b in
+      return Tensor<Double>(shape: [b.count], scalars: b)
+    }
+  }
+
+  @derivative(of: tensor)
+  @usableFromInline
+  func vjpFlatTensor() -> (value: Tensor<Double>, pullback: (Tensor<Double>) -> Self)
+  {
+    return (self.tensor, { Self(tensor: $0) })
+  }
+
+  /// Creates an instance with the same scalars as `tensor`.
+  @differentiable
+  public init(tensor: Tensor<Double>) {
+    self.init(tensor.scalars)
+  }
+
+  @derivative(of: init(tensor:))
+  @usableFromInline
+  static func vjpInit(tensor: Tensor<Double>) -> (
+    value: Self,
+    pullback: (Self) -> Tensor<Double>
+  ) {
+    return (Self(tensor: tensor), { $0.tensor })
+  }
+}
 
 // ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
@@ -1785,6 +2105,38 @@ extension Vector11: FixedSizeVector {
 }
 
 extension Vector11: ElementaryFunctions {}
+
+/// Converstion to/from `Tensor`.
+extension Vector11 {
+  /// Returns a `Tensor` with shape `[Self.dimension]` with the same scalars as `self`.
+  public var tensor: Tensor<Double> {
+    withUnsafeBufferPointer { b in
+      return Tensor<Double>(shape: [b.count], scalars: b)
+    }
+  }
+
+  @derivative(of: tensor)
+  @usableFromInline
+  func vjpFlatTensor() -> (value: Tensor<Double>, pullback: (Tensor<Double>) -> Self)
+  {
+    return (self.tensor, { Self(tensor: $0) })
+  }
+
+  /// Creates an instance with the same scalars as `tensor`.
+  @differentiable
+  public init(tensor: Tensor<Double>) {
+    self.init(tensor.scalars)
+  }
+
+  @derivative(of: init(tensor:))
+  @usableFromInline
+  static func vjpInit(tensor: Tensor<Double>) -> (
+    value: Self,
+    pullback: (Self) -> Tensor<Double>
+  ) {
+    return (Self(tensor: tensor), { $0.tensor })
+  }
+}
 
 // ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
@@ -2049,4 +2401,36 @@ extension Vector12: FixedSizeVector {
 }
 
 extension Vector12: ElementaryFunctions {}
+
+/// Converstion to/from `Tensor`.
+extension Vector12 {
+  /// Returns a `Tensor` with shape `[Self.dimension]` with the same scalars as `self`.
+  public var tensor: Tensor<Double> {
+    withUnsafeBufferPointer { b in
+      return Tensor<Double>(shape: [b.count], scalars: b)
+    }
+  }
+
+  @derivative(of: tensor)
+  @usableFromInline
+  func vjpFlatTensor() -> (value: Tensor<Double>, pullback: (Tensor<Double>) -> Self)
+  {
+    return (self.tensor, { Self(tensor: $0) })
+  }
+
+  /// Creates an instance with the same scalars as `tensor`.
+  @differentiable
+  public init(tensor: Tensor<Double>) {
+    self.init(tensor.scalars)
+  }
+
+  @derivative(of: init(tensor:))
+  @usableFromInline
+  static func vjpInit(tensor: Tensor<Double>) -> (
+    value: Self,
+    pullback: (Self) -> Tensor<Double>
+  ) {
+    return (Self(tensor: tensor), { $0.tensor })
+  }
+}
 

--- a/Sources/SwiftFusion/Core/VectorN.swift.gyb
+++ b/Sources/SwiftFusion/Core/VectorN.swift.gyb
@@ -83,4 +83,36 @@ extension Vector${dim}: FixedSizeVector {
 
 extension Vector${dim}: ElementaryFunctions {}
 
+/// Converstion to/from `Tensor`.
+extension Vector${dim} {
+  /// Returns a `Tensor` with shape `[Self.dimension]` with the same scalars as `self`.
+  public var tensor: Tensor<Double> {
+    withUnsafeBufferPointer { b in
+      return Tensor<Double>(shape: [b.count], scalars: b)
+    }
+  }
+
+  @derivative(of: tensor)
+  @usableFromInline
+  func vjpFlatTensor() -> (value: Tensor<Double>, pullback: (Tensor<Double>) -> Self)
+  {
+    return (self.tensor, { Self(tensor: $0) })
+  }
+
+  /// Creates an instance with the same scalars as `tensor`.
+  @differentiable
+  public init(tensor: Tensor<Double>) {
+    self.init(tensor.scalars)
+  }
+
+  @derivative(of: init(tensor:))
+  @usableFromInline
+  static func vjpInit(tensor: Tensor<Double>) -> (
+    value: Self,
+    pullback: (Self) -> Tensor<Double>
+  ) {
+    return (Self(tensor: tensor), { $0.tensor })
+  }
+}
+
 % end

--- a/Sources/SwiftFusion/Geometry/Pose2.swift
+++ b/Sources/SwiftFusion/Geometry/Pose2.swift
@@ -206,7 +206,7 @@ extension Pose2 {
   /// The Adjoint group action of `self` on the tangent space, as a matrix.
   public var AdjointMatrix: Tensor<Double> {
     Tensor(
-      stacking: Pose2.TangentVector.standardBasis.map { Adjoint($0).flatTensor }).transposed()
+      stacking: Pose2.TangentVector.standardBasis.map { Adjoint($0).tensor }).transposed()
   }
 }
 

--- a/Sources/SwiftFusion/Geometry/Rot3.swift
+++ b/Sources/SwiftFusion/Geometry/Rot3.swift
@@ -95,8 +95,9 @@ public extension Rot3 {
     let S = Tensor<Double>(shape: [3], scalars: [1, 1, det]).diagonal()
     
     let R = matmul(V!, matmul(S, U!.transposed()))
-    
-    let M_r = Matrix3(R.scalars)
+   
+    let scalars = R.scalars
+    let M_r = Matrix3(rows: Vector3(scalars[0..<3]), Vector3(scalars[3..<6]), Vector3(scalars[6..<9]))
     
     return Rot3(coordinate: Matrix3Coordinate(M_r))
   }
@@ -210,11 +211,10 @@ extension Matrix3Coordinate: ManifoldCoordinate {
 
   @differentiable(wrt: global)
   public func localCoordinate(_ global: Matrix3Coordinate) -> Vector3 {
-    let relative = self.inverse() * global
-    let R = Vector9(relative.R)
-    let (R11, R12, R13) = (R.s0, R.s1, R.s2)
-    let (R21, R22, R23) = (R.s3, R.s4, R.s5)
-    let (R31, R32, R33) = (R.s6, R.s7, R.s8)
+    let R = (self.inverse() * global).R
+    let (R11, R12, R13) = (R[0, 0], R[0, 1], R[0, 2])
+    let (R21, R22, R23) = (R[1, 0], R[1, 1], R[1, 2])
+    let (R31, R32, R33) = (R[2, 0], R[2, 1], R[2, 2])
 
     let tr = R11 + R22 + R33
 

--- a/Sources/SwiftFusion/Inference/BetweenFactorAlternative.swift
+++ b/Sources/SwiftFusion/Inference/BetweenFactorAlternative.swift
@@ -29,7 +29,25 @@ public struct BetweenFactorAlternative: LinearizableFactor2 {
     let actualMotion = between(start, end)
     let R = actualMotion.coordinate.rot.coordinate.R + (-1) * difference.rot.coordinate.R
     let t = actualMotion.t - difference.t
-    
+
     return Vector12(concatenating: R, t)
+  }
+}
+
+fileprivate extension Vector12 {
+  @differentiable
+  init(concatenating m: Matrix3, _ v: Vector3) {
+    self.s0 = m[0, 0]
+    self.s1 = m[0, 1]
+    self.s2 = m[0, 2]
+    self.s3 = m[1, 0]
+    self.s4 = m[1, 1]
+    self.s5 = m[1, 2]
+    self.s6 = m[2, 0]
+    self.s7 = m[2, 1]
+    self.s8 = m[2, 2]
+    self.s9 = v.x
+    self.s10 = v.y
+    self.s11 = v.z
   }
 }

--- a/Sources/SwiftFusion/Inference/ChordalInitialization.swift
+++ b/Sources/SwiftFusion/Inference/ChordalInitialization.swift
@@ -57,6 +57,20 @@ public struct RelaxedAnchorFactorRot3: LinearizableFactor1
   }
 }
 
+fileprivate extension Vector9 {
+  init(_ m: Matrix3) {
+    self.s0 = m[0, 0]
+    self.s1 = m[0, 1]
+    self.s2 = m[0, 2]
+    self.s3 = m[1, 0]
+    self.s4 = m[1, 1]
+    self.s5 = m[1, 2]
+    self.s6 = m[2, 0]
+    self.s7 = m[2, 1]
+    self.s8 = m[2, 2]
+  }
+}
+
 /// Type shorthands used in the relaxed pose graph
 /// NOTE: Specializations are added in `FactorsStorage.swift`
 public typealias Jacobian9x3x3_1 = Array<Tuple1<Matrix3>>

--- a/Tests/SwiftFusionTests/Core/AnyDifferentiableTests.swift
+++ b/Tests/SwiftFusionTests/Core/AnyDifferentiableTests.swift
@@ -29,7 +29,7 @@ class AnyDifferentiableTests: XCTestCase {
     }
 
     let initialPoses = (0..<3).map { _ in Pose2(randomWithCovariance: eye(rowCount: 3)) }
-    let initialVectors = (0..<3).map { _ in Vector2(flatTensor: Tensor(randomNormal: [2])) }
+    let initialVectors = (0..<3).map { _ in Vector2(tensor: Tensor(randomNormal: [2])) }
     let elementsErased =
       initialPoses.map { AnyDifferentiable($0) } + initialVectors.map { AnyDifferentiable($0) }
 

--- a/Tests/SwiftFusionTests/Core/FixedSizeMatrixTests.swift
+++ b/Tests/SwiftFusionTests/Core/FixedSizeMatrixTests.swift
@@ -325,3 +325,15 @@ class FixedSizeMatrixTests: XCTestCase {
     )
   }
 }
+
+fileprivate extension FixedSizeMatrix where Rows.Element == Vector2 {
+  /// Creates a matrix with `elements`, in row-major order.
+  ///
+  /// Requires: `elements.count == Self.shape[0] * Self.shape[1]`.
+  init<C: Collection>(_ elements: C) where C.Element == Double {
+    precondition(elements.count == Self.shape[0] * Self.shape[1])
+    self.init(rows: Rows((0..<Rows.count).lazy.map { i in
+      Rows.Element(elements.dropFirst(i * Self.shape[1]))
+    }))
+  }
+}

--- a/Tests/SwiftFusionTests/Geometry/Pose2Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Pose2Tests.swift
@@ -248,7 +248,7 @@ final class Pose2Tests: XCTestCase {
       assertEqual(
         Tensor<Double>(stacking: jacobian(
           of: identity,
-          at: Pose2(randomWithCovariance: eye(rowCount: 3))).map { $0.flatTensor }),
+          at: Pose2(randomWithCovariance: eye(rowCount: 3))).map { $0.tensor }),
         expected,
         accuracy: 1e-10
       )
@@ -261,7 +261,7 @@ final class Pose2Tests: XCTestCase {
       let pose = Pose2(randomWithCovariance: eye(rowCount: 3))
       let expected = -pose.AdjointMatrix
       assertEqual(
-        Tensor<Double>(stacking: jacobian(of: { $0.inverse() }, at: pose).map { $0.flatTensor }),
+        Tensor<Double>(stacking: jacobian(of: { $0.inverse() }, at: pose).map { $0.tensor }),
         expected,
         accuracy: 1e-10
       )
@@ -276,12 +276,12 @@ final class Pose2Tests: XCTestCase {
       let expectedWrtLhs = rhs.inverse().AdjointMatrix
       let expectedWrtRhs: Tensor<Double> = eye(rowCount: 3)
       assertEqual(
-        Tensor<Double>(stacking: jacobian(of: { $0 * rhs }, at: lhs).map { $0.flatTensor }),
+        Tensor<Double>(stacking: jacobian(of: { $0 * rhs }, at: lhs).map { $0.tensor }),
         expectedWrtLhs,
         accuracy: 1e-10
       )
       assertEqual(
-        Tensor<Double>(stacking: jacobian(of: { lhs * $0 }, at: rhs).map { $0.flatTensor }),
+        Tensor<Double>(stacking: jacobian(of: { lhs * $0 }, at: rhs).map { $0.tensor }),
         expectedWrtRhs,
         accuracy: 1e-10
       )
@@ -327,12 +327,12 @@ final class Pose2Tests: XCTestCase {
     ])
 
     assertEqual(
-      Tensor<Double>(stacking: jacobian(of: { between($0, wT2) }, at: wT1).map { $0.flatTensor }),
+      Tensor<Double>(stacking: jacobian(of: { between($0, wT2) }, at: wT1).map { $0.tensor }),
       expectedWrtLhs,
       accuracy: 1e-10
     )
     assertEqual(
-      Tensor<Double>(stacking: jacobian(of: { between(wT1, $0) }, at: wT2).map { $0.flatTensor }),
+      Tensor<Double>(stacking: jacobian(of: { between(wT1, $0) }, at: wT2).map { $0.tensor }),
       expectedWrtRhs,
       accuracy: 1e-10
     )
@@ -344,13 +344,13 @@ final class Pose2Tests: XCTestCase {
       let pose = Pose2(randomWithCovariance: eye(rowCount: 3))
       for v in Pose2.TangentVector.standardBasis {
         assertEqual(
-          pose.Adjoint(v).flatTensor,
-          pose.coordinate.defaultAdjoint(v).flatTensor,
+          pose.Adjoint(v).tensor,
+          pose.coordinate.defaultAdjoint(v).tensor,
           accuracy: 1e-10
         )
         assertEqual(
-          pose.AdjointTranspose(v).flatTensor,
-          pose.coordinate.defaultAdjointTranspose(v).flatTensor,
+          pose.AdjointTranspose(v).tensor,
+          pose.coordinate.defaultAdjointTranspose(v).tensor,
           accuracy: 1e-10
         )
       }

--- a/Tests/SwiftFusionTests/Geometry/Pose3Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Pose3Tests.swift
@@ -7,15 +7,15 @@ final class Pose3Tests: XCTestCase {
   /// Tests that the manifold invariant holds for Pose2
   func testManifoldIdentity() {
     for _ in 0..<10 {
-      let p = Pose3.fromTangent(Vector6(flatTensor: Tensor<Double>(randomNormal: [6])))
-      let q = Pose3.fromTangent(Vector6(flatTensor: Tensor<Double>(randomNormal: [6])))
+      let p = Pose3.fromTangent(Vector6(tensor: Tensor<Double>(randomNormal: [6])))
+      let q = Pose3.fromTangent(Vector6(tensor: Tensor<Double>(randomNormal: [6])))
       let actual: Pose3 = Pose3(coordinate: p.coordinate.retract(p.coordinate.localCoordinate(q.coordinate)))
       assertAllKeyPathEqual(actual, q, accuracy: 1e-10)
     }
   }
   
   func testTrivialRotation() {
-    let p = Pose3.fromTangent(Vector6(flatTensor: Tensor<Double>([0.3, 0, 0, 0, 0, 0])))
+    let p = Pose3.fromTangent(Vector6(tensor: Tensor<Double>([0.3, 0, 0, 0, 0, 0])))
     let R = Rot3.fromTangent(Vector3(0.3, 0, 0))
     
     assertAllKeyPathEqual(p.rot, R, accuracy: 1e-10)
@@ -24,7 +24,7 @@ final class Pose3Tests: XCTestCase {
   func testTrivialFull1() {
     let P = Vector3(0.2,0.7,-2)
     let R = Rot3.fromTangent(Vector3(0.3, 0, 0))
-    let p = Pose3.fromTangent(Vector6(flatTensor: Tensor<Double>([0.3, 0, 0, 0.2, 0.394742, -2.08998])))
+    let p = Pose3.fromTangent(Vector6(tensor: Tensor<Double>([0.3, 0, 0, 0.2, 0.394742, -2.08998])))
     assertAllKeyPathEqual(p.rot, R, accuracy: 1e-10)
     assertAllKeyPathEqual(p.t, P, accuracy: 1e-5)
   }
@@ -32,7 +32,7 @@ final class Pose3Tests: XCTestCase {
   func testTrivialFull2() {
     let P = Vector3(3.5,-8.2,4.2)
     let R = Rot3.fromTangent(Vector3(0.3, 0, 0))
-    let t12 = Vector6(flatTensor: Tensor<Double>(repeating: 0.1, shape: [6]))
+    let t12 = Vector6(tensor: Tensor<Double>(repeating: 0.1, shape: [6]))
     let t1 = Pose3(R, P)
     let t2 = Pose3(coordinate: t1.coordinate.retract(t12))
     assertAllKeyPathEqual(t1.coordinate.localCoordinate(t2.coordinate), t12, accuracy: 1e-5)
@@ -106,11 +106,11 @@ final class Pose3Tests: XCTestCase {
     var val = VariableAssignments()
     let s: Double = 0.10
     let _ = val.store(p0)
-    let _ = val.store(hexagon_val[hexagon_id[1]].retract(Vector6(flatTensor: s * Tensor<Double>(randomNormal: [6]))))
-    let _ = val.store(hexagon_val[hexagon_id[2]].retract(Vector6(flatTensor: s * Tensor<Double>(randomNormal: [6]))))
-    let _ = val.store(hexagon_val[hexagon_id[3]].retract(Vector6(flatTensor: s * Tensor<Double>(randomNormal: [6]))))
-    let _ = val.store(hexagon_val[hexagon_id[4]].retract(Vector6(flatTensor: s * Tensor<Double>(randomNormal: [6]))))
-    let _ = val.store(hexagon_val[hexagon_id[5]].retract(Vector6(flatTensor: s * Tensor<Double>(randomNormal: [6]))))
+    let _ = val.store(hexagon_val[hexagon_id[1]].retract(Vector6(tensor: s * Tensor<Double>(randomNormal: [6]))))
+    let _ = val.store(hexagon_val[hexagon_id[2]].retract(Vector6(tensor: s * Tensor<Double>(randomNormal: [6]))))
+    let _ = val.store(hexagon_val[hexagon_id[3]].retract(Vector6(tensor: s * Tensor<Double>(randomNormal: [6]))))
+    let _ = val.store(hexagon_val[hexagon_id[4]].retract(Vector6(tensor: s * Tensor<Double>(randomNormal: [6]))))
+    let _ = val.store(hexagon_val[hexagon_id[5]].retract(Vector6(tensor: s * Tensor<Double>(randomNormal: [6]))))
 
     // optimize
     for _ in 0..<16 {
@@ -132,11 +132,11 @@ final class Pose3Tests: XCTestCase {
   /// Tests that the custom implementation of `Adjoint` is correct.
   func testAdjoint() {
     for _ in 0..<10 {
-      let pose = Pose3.fromTangent(Vector6(flatTensor: Tensor<Double>(randomNormal: [6])))
+      let pose = Pose3.fromTangent(Vector6(tensor: Tensor<Double>(randomNormal: [6])))
       for v in Pose3.TangentVector.standardBasis {
         assertEqual(
-          pose.Adjoint(v).flatTensor,
-          pose.coordinate.defaultAdjoint(v).flatTensor,
+          pose.Adjoint(v).tensor,
+          pose.coordinate.defaultAdjoint(v).tensor,
           accuracy: 1e-10
         )
       }
@@ -146,11 +146,11 @@ final class Pose3Tests: XCTestCase {
   /// Tests that the custom implementation of `AdjointTranspose` is correct.
   func testAdjointTranspose() {
     for _ in 0..<10 {
-      let pose = Pose3.fromTangent(Vector6(flatTensor: Tensor<Double>(randomNormal: [6])))
+      let pose = Pose3.fromTangent(Vector6(tensor: Tensor<Double>(randomNormal: [6])))
       for v in Pose3.TangentVector.standardBasis {
         assertEqual(
-          pose.AdjointTranspose(v).flatTensor,
-          pose.coordinate.defaultAdjointTranspose(v).flatTensor,
+          pose.AdjointTranspose(v).tensor,
+          pose.coordinate.defaultAdjointTranspose(v).tensor,
           accuracy: 1e-10
         )
       }

--- a/Tests/SwiftFusionTests/Geometry/Rot3Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Rot3Tests.swift
@@ -42,8 +42,8 @@ final class Rot3Tests: XCTestCase {
   /// Tests that the manifold invariant holds for Rot3
   func testManifoldIdentity() {
     for _ in 0..<30 {
-      let p = Rot3.fromTangent(Vector3(flatTensor: Tensor<Double>(randomNormal: [3])))
-      let q = Rot3.fromTangent(Vector3(flatTensor: Tensor<Double>(randomNormal: [3])))
+      let p = Rot3.fromTangent(Vector3(tensor: Tensor<Double>(randomNormal: [3])))
+      let q = Rot3.fromTangent(Vector3(tensor: Tensor<Double>(randomNormal: [3])))
       let actual: Rot3 = Rot3(coordinate: p.coordinate.retract(p.coordinate.localCoordinate(q.coordinate)))
       assertAllKeyPathEqual(actual, q, accuracy: 1e-6)
     }
@@ -54,14 +54,14 @@ final class Rot3Tests: XCTestCase {
   func testManifoldIdentitySpecial1() {
     for i in -5..<5 {
       let p = Rot3.fromTangent(Vector3(Double(2*i - 1) * .pi, 0, 0))
-      let q = Rot3.fromTangent(Vector3(flatTensor: Tensor<Double>(randomNormal: [3])))
+      let q = Rot3.fromTangent(Vector3(tensor: Tensor<Double>(randomNormal: [3])))
       let actual: Rot3 = Rot3(coordinate: p.coordinate.retract(p.coordinate.localCoordinate(q.coordinate)))
       assertAllKeyPathEqual(actual, q, accuracy: 1e-6)
     }
     
     for i in -5..<5 {
       let p = Rot3.fromTangent(Vector3(0, 0, Double(2*i - 1) * .pi))
-      let q = Rot3.fromTangent(Vector3(flatTensor: Tensor<Double>(randomNormal: [3])))
+      let q = Rot3.fromTangent(Vector3(tensor: Tensor<Double>(randomNormal: [3])))
       let actual: Rot3 = Rot3(coordinate: p.coordinate.retract(p.coordinate.localCoordinate(q.coordinate)))
       assertAllKeyPathEqual(actual, q, accuracy: 1e-6)
     }
@@ -70,8 +70,8 @@ final class Rot3Tests: XCTestCase {
   /// Tests that the manifold invariant holds for Rot3
   func testManifoldIdentitySpecial2() {
     for _ in 0..<10 {
-      let p = Rot3.fromTangent(Vector3(flatTensor: 1e-10 * Tensor<Double>(randomNormal: [3])))
-      let q = Rot3.fromTangent(Vector3(flatTensor: Tensor<Double>(randomNormal: [3])))
+      let p = Rot3.fromTangent(Vector3(tensor: 1e-10 * Tensor<Double>(randomNormal: [3])))
+      let q = Rot3.fromTangent(Vector3(tensor: Tensor<Double>(randomNormal: [3])))
       let actual: Rot3 = Rot3(coordinate: p.coordinate.retract(p.coordinate.localCoordinate(q.coordinate)))
       assertAllKeyPathEqual(actual, q, accuracy: 1e-6)
     }
@@ -136,16 +136,16 @@ final class Rot3Tests: XCTestCase {
   /// Tests that the custom implementations of `Adjoint` and `AdjointTranspose` are correct.
   func testAdjoint() {
     for _ in 0..<10 {
-      let rot = Rot3.fromTangent(Vector3(flatTensor: Tensor<Double>(randomNormal: [3])))
+      let rot = Rot3.fromTangent(Vector3(tensor: Tensor<Double>(randomNormal: [3])))
       for v in Pose2.TangentVector.standardBasis {
         assertEqual(
-          rot.Adjoint(v).flatTensor,
-          rot.coordinate.defaultAdjoint(v).flatTensor,
+          rot.Adjoint(v).tensor,
+          rot.coordinate.defaultAdjoint(v).tensor,
           accuracy: 1e-10
         )
         assertEqual(
-          rot.AdjointTranspose(v).flatTensor,
-          rot.coordinate.defaultAdjointTranspose(v).flatTensor,
+          rot.AdjointTranspose(v).tensor,
+          rot.coordinate.defaultAdjointTranspose(v).tensor,
           accuracy: 1e-10
         )
       }

--- a/Tests/SwiftFusionTests/Inference/ChordalInitializationTests.swift
+++ b/Tests/SwiftFusionTests/Inference/ChordalInitializationTests.swift
@@ -90,8 +90,8 @@ class ChordalInitializationTests: XCTestCase {
     
     // assert the jacobian is correct
     assertEqual(
-      Tensor<Double>(stacking: frf_j.jacobian.map { $0.flatTensor }),
-      Tensor<Double>(stacking: jf.jacobian.map { $0.flatTensor })
+      Tensor<Double>(stacking: frf_j.jacobian.flatMap { [$0.head.tensor, $0.tail.head.tensor] }),
+      Tensor<Double>(stacking: jf.jacobian.flatMap { [$0.head.tensor, $0.tail.head.tensor] })
       , accuracy: 1e-4
     )
     
@@ -124,8 +124,8 @@ class ChordalInitializationTests: XCTestCase {
     
     // assert the Jacobian is correct
     assertEqual(
-      Tensor<Double>(stacking: fpf_j.jacobian.map { $0.flatTensor }),
-      Tensor<Double>(stacking: jf_p.jacobian.map { $0.flatTensor })
+      Tensor<Double>(stacking: frf_j.jacobian.flatMap { [$0.head.tensor, $0.tail.head.tensor] }),
+      Tensor<Double>(stacking: jf.jacobian.flatMap { [$0.head.tensor, $0.tail.head.tensor] })
       , accuracy: 1e-4
     )
     

--- a/Tests/SwiftFusionTests/Inference/FactorGraphTests.swift
+++ b/Tests/SwiftFusionTests/Inference/FactorGraphTests.swift
@@ -116,11 +116,11 @@ class FactorGraphTests: XCTestCase {
     
     let s: Double = 0.10
     let id0 = x.store(p0)
-    let id1 = x.store(hexagon[hexagonId[1]].retract(Vector6(flatTensor: s * Tensor<Double>(randomNormal: [6]))))
-    let id2 = x.store(hexagon[hexagonId[2]].retract(Vector6(flatTensor: s * Tensor<Double>(randomNormal: [6]))))
-    let id3 = x.store(hexagon[hexagonId[3]].retract(Vector6(flatTensor: s * Tensor<Double>(randomNormal: [6]))))
-    let id4 = x.store(hexagon[hexagonId[4]].retract(Vector6(flatTensor: s * Tensor<Double>(randomNormal: [6]))))
-    let id5 = x.store(hexagon[hexagonId[5]].retract(Vector6(flatTensor: s * Tensor<Double>(randomNormal: [6]))))
+    let id1 = x.store(hexagon[hexagonId[1]].retract(Vector6(tensor: s * Tensor<Double>(randomNormal: [6]))))
+    let id2 = x.store(hexagon[hexagonId[2]].retract(Vector6(tensor: s * Tensor<Double>(randomNormal: [6]))))
+    let id3 = x.store(hexagon[hexagonId[3]].retract(Vector6(tensor: s * Tensor<Double>(randomNormal: [6]))))
+    let id4 = x.store(hexagon[hexagonId[4]].retract(Vector6(tensor: s * Tensor<Double>(randomNormal: [6]))))
+    let id5 = x.store(hexagon[hexagonId[5]].retract(Vector6(tensor: s * Tensor<Double>(randomNormal: [6]))))
     
     var fg = FactorGraph()
     fg.store(PriorFactor(id0, p0))
@@ -161,11 +161,11 @@ class FactorGraphTests: XCTestCase {
       
       let s: Double = 0.9
       let id0 = x.store(p0)
-      let id1 = x.store(hexagon[hexagonId[1]].retract(Vector6(flatTensor: s * Tensor(randomNormal: [6]))))
-      let id2 = x.store(hexagon[hexagonId[2]].retract(Vector6(flatTensor: s * Tensor(randomNormal: [6]))))
-      let id3 = x.store(hexagon[hexagonId[3]].retract(Vector6(flatTensor: s * Tensor(randomNormal: [6]))))
-      let id4 = x.store(hexagon[hexagonId[4]].retract(Vector6(flatTensor: s * Tensor(randomNormal: [6]))))
-      let id5 = x.store(hexagon[hexagonId[5]].retract(Vector6(flatTensor: s * Tensor(randomNormal: [6]))))
+      let id1 = x.store(hexagon[hexagonId[1]].retract(Vector6(tensor: s * Tensor(randomNormal: [6]))))
+      let id2 = x.store(hexagon[hexagonId[2]].retract(Vector6(tensor: s * Tensor(randomNormal: [6]))))
+      let id3 = x.store(hexagon[hexagonId[3]].retract(Vector6(tensor: s * Tensor(randomNormal: [6]))))
+      let id4 = x.store(hexagon[hexagonId[4]].retract(Vector6(tensor: s * Tensor(randomNormal: [6]))))
+      let id5 = x.store(hexagon[hexagonId[5]].retract(Vector6(tensor: s * Tensor(randomNormal: [6]))))
       
       var fg = FactorGraph()
       fg.store(PriorFactor(id0, p0))
@@ -213,11 +213,11 @@ class FactorGraphTests: XCTestCase {
       
       let s = 0.9
       let id0 = x.store(p0)
-      let id1 = x.store(hexagon[hexagonId[1]].retract(Vector6(flatTensor: s * Tensor(randomNormal: [6]))))
-      let id2 = x.store(hexagon[hexagonId[2]].retract(Vector6(flatTensor: s * Tensor(randomNormal: [6]))))
-      let id3 = x.store(hexagon[hexagonId[3]].retract(Vector6(flatTensor: s * Tensor(randomNormal: [6]))))
-      let id4 = x.store(hexagon[hexagonId[4]].retract(Vector6(flatTensor: s * Tensor(randomNormal: [6]))))
-      let id5 = x.store(hexagon[hexagonId[5]].retract(Vector6(flatTensor: s * Tensor(randomNormal: [6]))))
+      let id1 = x.store(hexagon[hexagonId[1]].retract(Vector6(tensor: s * Tensor(randomNormal: [6]))))
+      let id2 = x.store(hexagon[hexagonId[2]].retract(Vector6(tensor: s * Tensor(randomNormal: [6]))))
+      let id3 = x.store(hexagon[hexagonId[3]].retract(Vector6(tensor: s * Tensor(randomNormal: [6]))))
+      let id4 = x.store(hexagon[hexagonId[4]].retract(Vector6(tensor: s * Tensor(randomNormal: [6]))))
+      let id5 = x.store(hexagon[hexagonId[5]].retract(Vector6(tensor: s * Tensor(randomNormal: [6]))))
       
       var fg = FactorGraph()
       fg.store(PriorFactor(id0, p0))

--- a/Tests/SwiftFusionTests/Inference/IdentityLinearizationFactorTests.swift
+++ b/Tests/SwiftFusionTests/Inference/IdentityLinearizationFactorTests.swift
@@ -25,7 +25,7 @@ class IdentityLinearizationFactorTests: XCTestCase {
   /// Test that `IdentityLinearizationFactor` forwards to the underlying factor's methods.
   func testForwardsMethods() {
     let base = TestGaussianFactor(
-      jacobian: Matrix3([1, 2, 3, 4, 5, 6, 7, 8, 9]),
+      jacobian: Matrix3.identity,
       error: Vector3(10, 20, 30),
       edges: Tuple1(TypedID(0)))
     let f = IdentityLinearizationFactor<TestGaussianFactor>(

--- a/Tests/SwiftFusionTests/Optimizers/CGLSTests.swift
+++ b/Tests/SwiftFusionTests/Optimizers/CGLSTests.swift
@@ -17,7 +17,7 @@ final class CGLSTests: XCTestCase {
     let expected = SimpleGaussianFactorGraph.correctDelta()
     
     for k in [SimpleGaussianFactorGraph.x1ID, SimpleGaussianFactorGraph.x2ID] {
-      assertEqual(x[k].flatTensor, expected[k].flatTensor, accuracy: 1e-6)
+      assertEqual(x[k].tensor, expected[k].tensor, accuracy: 1e-6)
     }
   }
 }


### PR DESCRIPTION
Most uses of `ScalarsInitializableVector` only happen on concrete types, so we can move that functionality to concrete types.

One use in `JacobianFactor.swift` is truly generic but we can implement that by mutating the `zero` vector instead (like we did with standard basis).