### PR TITLE
Add Vector.scalars

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/saeta/penguin.git",
         "state": {
           "branch": "master",
-          "revision": "34449dabad0b86654f9914768fc0d062b652dcf4",
+          "revision": "d30c8ad1cf6bc775160803cea5f0fbe6e747376f",
           "version": null
         }
       },

--- a/Sources/SwiftFusion/Core/FixedShapeTensor.swift
+++ b/Sources/SwiftFusion/Core/FixedShapeTensor.swift
@@ -83,11 +83,31 @@ extension FixedShapeTensor {
 public struct Tensor10x10: AdditiveArithmetic, FixedShapeTensor {
   public typealias TangentVector = Tensor10x10
   public static var shape: TensorShape { [10, 10] }
-  @differentiable public var tensor: Tensor<Double>
+  
+  @differentiable public var tensor: Tensor<Double> {
+    get { scalars.storage }
+    set { scalars.storage = newValue }
+  }
+
+  public struct Scalars
+    : RandomAccessCollection, MutableCollection, Differentiable, AdditiveArithmetic
+  {
+    fileprivate var storage: Tensor<Double>
+    
+    public var startIndex: Int { 0 }
+    public var endIndex: Int { 100 }
+    
+    public subscript(i: Int) -> Double {
+      get { storage[i / 10, i % 10].scalarized() }
+      set { storage[i / 10, i % 10] = Tensor(newValue) }
+    }
+  }
+  
+  @differentiable public var scalars: Scalars
 
   @differentiable
   public init(_ tensor: Tensor<Double>) {
     precondition(tensor.shape == Self.shape)
-    self.tensor = tensor
+    self.scalars = Scalars(storage: tensor)
   }
 }

--- a/Sources/SwiftFusion/Core/FixedSizeMatrix.swift
+++ b/Sources/SwiftFusion/Core/FixedSizeMatrix.swift
@@ -118,6 +118,7 @@ extension FixedSizeMatrix: Differentiable {
 
 extension FixedSizeMatrix: FixedSizeVector {
   public struct Scalars: RandomAccessCollection, MutableCollection {
+    public typealias Indices = Range<Int>
     fileprivate var base: FixedSizeMatrix
     public var startIndex: Int { 0 }
     public var endIndex: Int { base.withUnsafeBufferPointer { $0.count } }

--- a/Sources/SwiftFusion/Core/FixedSizeMatrix.swift
+++ b/Sources/SwiftFusion/Core/FixedSizeMatrix.swift
@@ -117,6 +117,27 @@ extension FixedSizeMatrix: Differentiable {
 }
 
 extension FixedSizeMatrix: FixedSizeVector {
+  public struct Scalars: RandomAccessCollection, MutableCollection {
+    fileprivate var base: FixedSizeMatrix
+    public var startIndex: Int { 0 }
+    public var endIndex: Int { base.withUnsafeBufferPointer { $0.count } }
+    public subscript(i: Int) -> Double {
+      get {
+        precondition(i >= 0 && i < endIndex)
+        return base.withUnsafeBufferPointer { $0[i] }
+      }
+      set {
+        precondition(i >= 0 && i < endIndex)
+        base[i] = newValue
+      }
+    }
+  }
+  
+  public var scalars: Scalars {
+    get { Scalars(base: self) }
+    set { self = newValue.base }
+  }
+  
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
     lhs.withUnsafeMutableBufferPointer { bLhs in

--- a/Sources/SwiftFusion/Core/Tuple+Vector.swift
+++ b/Sources/SwiftFusion/Core/Tuple+Vector.swift
@@ -60,6 +60,8 @@ where Head: Differentiable, Tail: Differentiable, Tail.TangentVector: TupleProto
 }
 
 extension Empty: Vector {
+  public typealias Scalars = Array0<Double>
+  public var scalars: Scalars { get { .init() } set {  } }
   public var dimension: Int { return 0 }
 
   @differentiable
@@ -77,6 +79,14 @@ extension Empty: Vector {
 
 extension Tuple: Vector
 where Head: Vector, Tail: Vector {
+  public var scalars: Concatenation<Head.Scalars, Tail.Scalars> {
+    get { head.scalars.concatenated(to: tail.scalars) }
+    set {
+      head.scalars = newValue.first
+      tail.scalars = newValue.second
+    }
+  }
+  
   public var dimension: Int { return head.dimension + tail.dimension }
 
   @differentiable

--- a/Sources/SwiftFusion/Core/Vector.swift
+++ b/Sources/SwiftFusion/Core/Vector.swift
@@ -8,6 +8,10 @@ import TensorFlow
 // have Euclidean structure and standard basis, so we'll reserve the short name `Vector` for
 // such vectors and use a longer name like `GeneralizedVector` for the generalized vector spaces.
 public protocol Vector: Differentiable where Self.TangentVector == Self {
+  associatedtype Scalars: MutableCollection where Scalars.Element == Double
+
+  var scalars: Scalars { get set }
+  
   /// The number of components of this vector.
   var dimension: Int { get }
 
@@ -41,31 +45,6 @@ public protocol Vector: Differentiable where Self.TangentVector == Self {
   /// generalized vector.
   @differentiable
   func dot(_ other: Self) -> Double
-
-  // MARK: - Methods for accessing the standard basis and for manipulating the coordinates under
-  // the standard basis.
-
-  /// Returns the result of calling `body` on the scalars of `self`.
-  ///
-  /// Note: Depends on a determined standard basis, and therefore would not be available on a
-  /// generalized vector.
-  ///
-  /// A default is provided that is correct for types that are represented as contiguous scalars
-  /// in memory.
-  func withUnsafeBufferPointer<R>(
-    _ body: (UnsafeBufferPointer<Double>) throws -> R
-  ) rethrows -> R
-
-  /// Returns the result of calling `body` on the scalars of `self`.
-  ///
-  /// Note: Depends on a determined standard basis, and therefore would not be available on a
-  /// generalized vector.
-  ///
-  /// A default is provided that is correct for types that are represented as contiguous scalars
-  /// in memory.
-  mutating func withUnsafeMutableBufferPointer<R>(
-    _ body: (UnsafeMutableBufferPointer<Double>) throws -> R
-  ) rethrows -> R
 }
 
 /// A `Vector` whose instances can be initialized for a collection of scalars.

--- a/Sources/SwiftFusion/Core/Vector.swift
+++ b/Sources/SwiftFusion/Core/Vector.swift
@@ -45,6 +45,18 @@ public protocol Vector: Differentiable where Self.TangentVector == Self {
   /// generalized vector.
   @differentiable
   func dot(_ other: Self) -> Double
+
+  // DWA TODO: Remove these requirements!
+  
+  /// Returns the result of calling `body` on the scalars of `self`.
+  func withUnsafeBufferPointer<R>(
+    _ body: (UnsafeBufferPointer<Double>) throws -> R
+  ) rethrows -> R
+
+  /// Returns the result of calling `body` on the scalars of `self`.
+  mutating func withUnsafeMutableBufferPointer<R>(
+    _ body: (UnsafeMutableBufferPointer<Double>) throws -> R
+  ) rethrows -> R
 }
 
 /// A `Vector` whose instances can be initialized for a collection of scalars.

--- a/Sources/SwiftFusion/Core/VectorN.swift
+++ b/Sources/SwiftFusion/Core/VectorN.swift
@@ -1,22 +1,19 @@
-// WARNING: This is a generated file. Do not edit it. Instead, edit the corresponding ".gyb" file.
-// See "generate.sh" in the root of this repository for instructions how to regenerate files.
-
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 1)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 1)
 import TensorFlow
 
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^1, with Euclidean inner product.
 public struct Vector1: KeyPathIterable {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var x: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
 
   @differentiable
   public init(_ x: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.x = x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
   }
 }
 
@@ -24,31 +21,31 @@ public struct Vector1: KeyPathIterable {
 extension Vector1: AdditiveArithmetic, Vector {
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.x += rhs.x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
   }
 
   @differentiable
   public static func -= (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.x -= rhs.x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
   }
 
   @differentiable
   public static func *= (_ lhs: inout Self, _ rhs: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.x *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
   }
 
   @differentiable
   public func dot(_ other: Self) -> Double {
     var result = Double(0)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.x * other.x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
     return result
   }
 
@@ -56,22 +53,41 @@ extension Vector1: AdditiveArithmetic, Vector {
 
   public static var standardBasis: [Self] {
     var result = Array(repeating: Self.zero, count: 1)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[0].x = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
     return result
   }
 
   public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
     var index = scalars.startIndex
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.x = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
   }
 
-  public var scalars: [Double] {
-    return [x]
+  public struct Scalars: RandomAccessCollection, MutableCollection {
+    internal var base: Vector1
+    public var startIndex: Int { 0 }
+    public var endIndex: Int { base.dimension }
+    public subscript(i: Int) -> Double {
+      get {
+        precondition(i >= 0 && i < endIndex)
+        return withUnsafePointer(to: self) { $0[i] }
+      }
+      _modify {
+        precondition(i >= 0 && i < endIndex)
+        p = withUnsafeMutablePointer(to: &self) { $0 }
+        yield &p[i]
+        _fixLifetime(self)
+      }
+    }
+  }
+  
+  public var scalars: Scalars {
+    get { .init(base: self) }
+    set { self = newValue.base  }
   }
 }
 
@@ -81,23 +97,23 @@ extension Vector1: FixedSizeVector {
 
 extension Vector1: ElementaryFunctions {}
 
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^2, with Euclidean inner product.
 public struct Vector2: KeyPathIterable {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var x: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var y: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
 
   @differentiable
   public init(_ x: Double, _ y: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.x = x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.y = y
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
   }
 }
 
@@ -105,39 +121,39 @@ public struct Vector2: KeyPathIterable {
 extension Vector2: AdditiveArithmetic, Vector {
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.x += rhs.x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.y += rhs.y
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
   }
 
   @differentiable
   public static func -= (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.x -= rhs.x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.y -= rhs.y
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
   }
 
   @differentiable
   public static func *= (_ lhs: inout Self, _ rhs: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.x *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.y *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
   }
 
   @differentiable
   public func dot(_ other: Self) -> Double {
     var result = Double(0)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.x * other.x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.y * other.y
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
     return result
   }
 
@@ -145,27 +161,46 @@ extension Vector2: AdditiveArithmetic, Vector {
 
   public static var standardBasis: [Self] {
     var result = Array(repeating: Self.zero, count: 2)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[0].x = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[1].y = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
     return result
   }
 
   public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
     var index = scalars.startIndex
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.x = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.y = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
   }
 
-  public var scalars: [Double] {
-    return [x, y]
+  public struct Scalars: RandomAccessCollection, MutableCollection {
+    internal var base: Vector2
+    public var startIndex: Int { 0 }
+    public var endIndex: Int { base.dimension }
+    public subscript(i: Int) -> Double {
+      get {
+        precondition(i >= 0 && i < endIndex)
+        return withUnsafePointer(to: self) { $0[i] }
+      }
+      _modify {
+        precondition(i >= 0 && i < endIndex)
+        p = withUnsafeMutablePointer(to: &self) { $0 }
+        yield &p[i]
+        _fixLifetime(self)
+      }
+    }
+  }
+  
+  public var scalars: Scalars {
+    get { .init(base: self) }
+    set { self = newValue.base  }
   }
 }
 
@@ -175,27 +210,27 @@ extension Vector2: FixedSizeVector {
 
 extension Vector2: ElementaryFunctions {}
 
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^3, with Euclidean inner product.
 public struct Vector3: KeyPathIterable {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var x: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var y: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var z: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
 
   @differentiable
   public init(_ x: Double, _ y: Double, _ z: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.x = x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.y = y
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.z = z
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
   }
 }
 
@@ -203,47 +238,47 @@ public struct Vector3: KeyPathIterable {
 extension Vector3: AdditiveArithmetic, Vector {
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.x += rhs.x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.y += rhs.y
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.z += rhs.z
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
   }
 
   @differentiable
   public static func -= (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.x -= rhs.x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.y -= rhs.y
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.z -= rhs.z
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
   }
 
   @differentiable
   public static func *= (_ lhs: inout Self, _ rhs: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.x *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.y *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.z *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
   }
 
   @differentiable
   public func dot(_ other: Self) -> Double {
     var result = Double(0)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.x * other.x
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.y * other.y
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.z * other.z
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
     return result
   }
 
@@ -251,32 +286,51 @@ extension Vector3: AdditiveArithmetic, Vector {
 
   public static var standardBasis: [Self] {
     var result = Array(repeating: Self.zero, count: 3)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[0].x = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[1].y = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[2].z = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
     return result
   }
 
   public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
     var index = scalars.startIndex
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.x = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.y = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.z = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
   }
 
-  public var scalars: [Double] {
-    return [x, y, z]
+  public struct Scalars: RandomAccessCollection, MutableCollection {
+    internal var base: Vector3
+    public var startIndex: Int { 0 }
+    public var endIndex: Int { base.dimension }
+    public subscript(i: Int) -> Double {
+      get {
+        precondition(i >= 0 && i < endIndex)
+        return withUnsafePointer(to: self) { $0[i] }
+      }
+      _modify {
+        precondition(i >= 0 && i < endIndex)
+        p = withUnsafeMutablePointer(to: &self) { $0 }
+        yield &p[i]
+        _fixLifetime(self)
+      }
+    }
+  }
+  
+  public var scalars: Scalars {
+    get { .init(base: self) }
+    set { self = newValue.base  }
   }
 }
 
@@ -286,31 +340,31 @@ extension Vector3: FixedSizeVector {
 
 extension Vector3: ElementaryFunctions {}
 
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^4, with Euclidean inner product.
 public struct Vector4: KeyPathIterable {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s0: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s1: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s2: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s3: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
 
   @differentiable
   public init(_ s0: Double, _ s1: Double, _ s2: Double, _ s3: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s0 = s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s1 = s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s2 = s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s3 = s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
   }
 }
 
@@ -318,55 +372,55 @@ public struct Vector4: KeyPathIterable {
 extension Vector4: AdditiveArithmetic, Vector {
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s0 += rhs.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s1 += rhs.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s2 += rhs.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s3 += rhs.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
   }
 
   @differentiable
   public static func -= (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s0 -= rhs.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s1 -= rhs.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s2 -= rhs.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s3 -= rhs.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
   }
 
   @differentiable
   public static func *= (_ lhs: inout Self, _ rhs: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s0 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s1 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s2 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s3 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
   }
 
   @differentiable
   public func dot(_ other: Self) -> Double {
     var result = Double(0)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s0 * other.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s1 * other.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s2 * other.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s3 * other.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
     return result
   }
 
@@ -374,37 +428,56 @@ extension Vector4: AdditiveArithmetic, Vector {
 
   public static var standardBasis: [Self] {
     var result = Array(repeating: Self.zero, count: 4)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[0].s0 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[1].s1 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[2].s2 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[3].s3 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
     return result
   }
 
   public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
     var index = scalars.startIndex
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s0 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s1 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s2 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s3 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
   }
 
-  public var scalars: [Double] {
-    return [s0, s1, s2, s3]
+  public struct Scalars: RandomAccessCollection, MutableCollection {
+    internal var base: Vector4
+    public var startIndex: Int { 0 }
+    public var endIndex: Int { base.dimension }
+    public subscript(i: Int) -> Double {
+      get {
+        precondition(i >= 0 && i < endIndex)
+        return withUnsafePointer(to: self) { $0[i] }
+      }
+      _modify {
+        precondition(i >= 0 && i < endIndex)
+        p = withUnsafeMutablePointer(to: &self) { $0 }
+        yield &p[i]
+        _fixLifetime(self)
+      }
+    }
+  }
+  
+  public var scalars: Scalars {
+    get { .init(base: self) }
+    set { self = newValue.base  }
   }
 }
 
@@ -414,35 +487,35 @@ extension Vector4: FixedSizeVector {
 
 extension Vector4: ElementaryFunctions {}
 
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^5, with Euclidean inner product.
 public struct Vector5: KeyPathIterable {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s0: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s1: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s2: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s3: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s4: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
 
   @differentiable
   public init(_ s0: Double, _ s1: Double, _ s2: Double, _ s3: Double, _ s4: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s0 = s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s1 = s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s2 = s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s3 = s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s4 = s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
   }
 }
 
@@ -450,63 +523,63 @@ public struct Vector5: KeyPathIterable {
 extension Vector5: AdditiveArithmetic, Vector {
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s0 += rhs.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s1 += rhs.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s2 += rhs.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s3 += rhs.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s4 += rhs.s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
   }
 
   @differentiable
   public static func -= (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s0 -= rhs.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s1 -= rhs.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s2 -= rhs.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s3 -= rhs.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s4 -= rhs.s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
   }
 
   @differentiable
   public static func *= (_ lhs: inout Self, _ rhs: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s0 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s1 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s2 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s3 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s4 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
   }
 
   @differentiable
   public func dot(_ other: Self) -> Double {
     var result = Double(0)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s0 * other.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s1 * other.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s2 * other.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s3 * other.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s4 * other.s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
     return result
   }
 
@@ -514,42 +587,61 @@ extension Vector5: AdditiveArithmetic, Vector {
 
   public static var standardBasis: [Self] {
     var result = Array(repeating: Self.zero, count: 5)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[0].s0 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[1].s1 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[2].s2 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[3].s3 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[4].s4 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
     return result
   }
 
   public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
     var index = scalars.startIndex
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s0 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s1 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s2 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s3 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s4 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
   }
 
-  public var scalars: [Double] {
-    return [s0, s1, s2, s3, s4]
+  public struct Scalars: RandomAccessCollection, MutableCollection {
+    internal var base: Vector5
+    public var startIndex: Int { 0 }
+    public var endIndex: Int { base.dimension }
+    public subscript(i: Int) -> Double {
+      get {
+        precondition(i >= 0 && i < endIndex)
+        return withUnsafePointer(to: self) { $0[i] }
+      }
+      _modify {
+        precondition(i >= 0 && i < endIndex)
+        p = withUnsafeMutablePointer(to: &self) { $0 }
+        yield &p[i]
+        _fixLifetime(self)
+      }
+    }
+  }
+  
+  public var scalars: Scalars {
+    get { .init(base: self) }
+    set { self = newValue.base  }
   }
 }
 
@@ -559,39 +651,39 @@ extension Vector5: FixedSizeVector {
 
 extension Vector5: ElementaryFunctions {}
 
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^6, with Euclidean inner product.
 public struct Vector6: KeyPathIterable {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s0: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s1: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s2: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s3: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s4: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s5: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
 
   @differentiable
   public init(_ s0: Double, _ s1: Double, _ s2: Double, _ s3: Double, _ s4: Double, _ s5: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s0 = s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s1 = s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s2 = s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s3 = s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s4 = s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s5 = s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
   }
 }
 
@@ -599,71 +691,71 @@ public struct Vector6: KeyPathIterable {
 extension Vector6: AdditiveArithmetic, Vector {
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s0 += rhs.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s1 += rhs.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s2 += rhs.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s3 += rhs.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s4 += rhs.s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s5 += rhs.s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
   }
 
   @differentiable
   public static func -= (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s0 -= rhs.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s1 -= rhs.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s2 -= rhs.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s3 -= rhs.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s4 -= rhs.s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s5 -= rhs.s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
   }
 
   @differentiable
   public static func *= (_ lhs: inout Self, _ rhs: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s0 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s1 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s2 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s3 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s4 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s5 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
   }
 
   @differentiable
   public func dot(_ other: Self) -> Double {
     var result = Double(0)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s0 * other.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s1 * other.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s2 * other.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s3 * other.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s4 * other.s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s5 * other.s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
     return result
   }
 
@@ -671,47 +763,66 @@ extension Vector6: AdditiveArithmetic, Vector {
 
   public static var standardBasis: [Self] {
     var result = Array(repeating: Self.zero, count: 6)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[0].s0 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[1].s1 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[2].s2 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[3].s3 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[4].s4 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[5].s5 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
     return result
   }
 
   public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
     var index = scalars.startIndex
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s0 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s1 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s2 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s3 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s4 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s5 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
   }
 
-  public var scalars: [Double] {
-    return [s0, s1, s2, s3, s4, s5]
+  public struct Scalars: RandomAccessCollection, MutableCollection {
+    internal var base: Vector6
+    public var startIndex: Int { 0 }
+    public var endIndex: Int { base.dimension }
+    public subscript(i: Int) -> Double {
+      get {
+        precondition(i >= 0 && i < endIndex)
+        return withUnsafePointer(to: self) { $0[i] }
+      }
+      _modify {
+        precondition(i >= 0 && i < endIndex)
+        p = withUnsafeMutablePointer(to: &self) { $0 }
+        yield &p[i]
+        _fixLifetime(self)
+      }
+    }
+  }
+  
+  public var scalars: Scalars {
+    get { .init(base: self) }
+    set { self = newValue.base  }
   }
 }
 
@@ -721,43 +832,43 @@ extension Vector6: FixedSizeVector {
 
 extension Vector6: ElementaryFunctions {}
 
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^7, with Euclidean inner product.
 public struct Vector7: KeyPathIterable {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s0: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s1: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s2: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s3: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s4: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s5: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s6: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
 
   @differentiable
   public init(_ s0: Double, _ s1: Double, _ s2: Double, _ s3: Double, _ s4: Double, _ s5: Double, _ s6: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s0 = s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s1 = s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s2 = s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s3 = s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s4 = s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s5 = s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s6 = s6
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
   }
 }
 
@@ -765,79 +876,79 @@ public struct Vector7: KeyPathIterable {
 extension Vector7: AdditiveArithmetic, Vector {
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s0 += rhs.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s1 += rhs.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s2 += rhs.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s3 += rhs.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s4 += rhs.s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s5 += rhs.s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s6 += rhs.s6
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
   }
 
   @differentiable
   public static func -= (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s0 -= rhs.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s1 -= rhs.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s2 -= rhs.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s3 -= rhs.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s4 -= rhs.s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s5 -= rhs.s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s6 -= rhs.s6
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
   }
 
   @differentiable
   public static func *= (_ lhs: inout Self, _ rhs: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s0 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s1 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s2 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s3 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s4 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s5 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s6 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
   }
 
   @differentiable
   public func dot(_ other: Self) -> Double {
     var result = Double(0)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s0 * other.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s1 * other.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s2 * other.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s3 * other.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s4 * other.s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s5 * other.s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s6 * other.s6
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
     return result
   }
 
@@ -845,52 +956,71 @@ extension Vector7: AdditiveArithmetic, Vector {
 
   public static var standardBasis: [Self] {
     var result = Array(repeating: Self.zero, count: 7)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[0].s0 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[1].s1 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[2].s2 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[3].s3 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[4].s4 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[5].s5 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[6].s6 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
     return result
   }
 
   public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
     var index = scalars.startIndex
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s0 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s1 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s2 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s3 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s4 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s5 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s6 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
   }
 
-  public var scalars: [Double] {
-    return [s0, s1, s2, s3, s4, s5, s6]
+  public struct Scalars: RandomAccessCollection, MutableCollection {
+    internal var base: Vector7
+    public var startIndex: Int { 0 }
+    public var endIndex: Int { base.dimension }
+    public subscript(i: Int) -> Double {
+      get {
+        precondition(i >= 0 && i < endIndex)
+        return withUnsafePointer(to: self) { $0[i] }
+      }
+      _modify {
+        precondition(i >= 0 && i < endIndex)
+        p = withUnsafeMutablePointer(to: &self) { $0 }
+        yield &p[i]
+        _fixLifetime(self)
+      }
+    }
+  }
+  
+  public var scalars: Scalars {
+    get { .init(base: self) }
+    set { self = newValue.base  }
   }
 }
 
@@ -900,47 +1030,47 @@ extension Vector7: FixedSizeVector {
 
 extension Vector7: ElementaryFunctions {}
 
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^8, with Euclidean inner product.
 public struct Vector8: KeyPathIterable {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s0: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s1: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s2: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s3: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s4: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s5: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s6: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s7: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
 
   @differentiable
   public init(_ s0: Double, _ s1: Double, _ s2: Double, _ s3: Double, _ s4: Double, _ s5: Double, _ s6: Double, _ s7: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s0 = s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s1 = s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s2 = s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s3 = s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s4 = s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s5 = s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s6 = s6
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s7 = s7
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
   }
 }
 
@@ -948,87 +1078,87 @@ public struct Vector8: KeyPathIterable {
 extension Vector8: AdditiveArithmetic, Vector {
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s0 += rhs.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s1 += rhs.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s2 += rhs.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s3 += rhs.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s4 += rhs.s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s5 += rhs.s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s6 += rhs.s6
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s7 += rhs.s7
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
   }
 
   @differentiable
   public static func -= (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s0 -= rhs.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s1 -= rhs.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s2 -= rhs.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s3 -= rhs.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s4 -= rhs.s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s5 -= rhs.s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s6 -= rhs.s6
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s7 -= rhs.s7
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
   }
 
   @differentiable
   public static func *= (_ lhs: inout Self, _ rhs: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s0 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s1 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s2 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s3 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s4 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s5 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s6 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s7 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
   }
 
   @differentiable
   public func dot(_ other: Self) -> Double {
     var result = Double(0)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s0 * other.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s1 * other.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s2 * other.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s3 * other.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s4 * other.s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s5 * other.s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s6 * other.s6
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s7 * other.s7
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
     return result
   }
 
@@ -1036,57 +1166,76 @@ extension Vector8: AdditiveArithmetic, Vector {
 
   public static var standardBasis: [Self] {
     var result = Array(repeating: Self.zero, count: 8)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[0].s0 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[1].s1 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[2].s2 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[3].s3 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[4].s4 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[5].s5 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[6].s6 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[7].s7 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
     return result
   }
 
   public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
     var index = scalars.startIndex
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s0 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s1 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s2 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s3 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s4 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s5 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s6 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s7 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
   }
 
-  public var scalars: [Double] {
-    return [s0, s1, s2, s3, s4, s5, s6, s7]
+  public struct Scalars: RandomAccessCollection, MutableCollection {
+    internal var base: Vector8
+    public var startIndex: Int { 0 }
+    public var endIndex: Int { base.dimension }
+    public subscript(i: Int) -> Double {
+      get {
+        precondition(i >= 0 && i < endIndex)
+        return withUnsafePointer(to: self) { $0[i] }
+      }
+      _modify {
+        precondition(i >= 0 && i < endIndex)
+        p = withUnsafeMutablePointer(to: &self) { $0 }
+        yield &p[i]
+        _fixLifetime(self)
+      }
+    }
+  }
+  
+  public var scalars: Scalars {
+    get { .init(base: self) }
+    set { self = newValue.base  }
   }
 }
 
@@ -1096,51 +1245,51 @@ extension Vector8: FixedSizeVector {
 
 extension Vector8: ElementaryFunctions {}
 
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^9, with Euclidean inner product.
 public struct Vector9: KeyPathIterable {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s0: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s1: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s2: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s3: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s4: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s5: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s6: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s7: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s8: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
 
   @differentiable
   public init(_ s0: Double, _ s1: Double, _ s2: Double, _ s3: Double, _ s4: Double, _ s5: Double, _ s6: Double, _ s7: Double, _ s8: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s0 = s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s1 = s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s2 = s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s3 = s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s4 = s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s5 = s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s6 = s6
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s7 = s7
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s8 = s8
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
   }
 }
 
@@ -1148,95 +1297,95 @@ public struct Vector9: KeyPathIterable {
 extension Vector9: AdditiveArithmetic, Vector {
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s0 += rhs.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s1 += rhs.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s2 += rhs.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s3 += rhs.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s4 += rhs.s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s5 += rhs.s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s6 += rhs.s6
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s7 += rhs.s7
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s8 += rhs.s8
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
   }
 
   @differentiable
   public static func -= (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s0 -= rhs.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s1 -= rhs.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s2 -= rhs.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s3 -= rhs.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s4 -= rhs.s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s5 -= rhs.s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s6 -= rhs.s6
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s7 -= rhs.s7
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s8 -= rhs.s8
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
   }
 
   @differentiable
   public static func *= (_ lhs: inout Self, _ rhs: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s0 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s1 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s2 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s3 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s4 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s5 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s6 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s7 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s8 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
   }
 
   @differentiable
   public func dot(_ other: Self) -> Double {
     var result = Double(0)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s0 * other.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s1 * other.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s2 * other.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s3 * other.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s4 * other.s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s5 * other.s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s6 * other.s6
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s7 * other.s7
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s8 * other.s8
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
     return result
   }
 
@@ -1244,62 +1393,81 @@ extension Vector9: AdditiveArithmetic, Vector {
 
   public static var standardBasis: [Self] {
     var result = Array(repeating: Self.zero, count: 9)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[0].s0 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[1].s1 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[2].s2 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[3].s3 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[4].s4 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[5].s5 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[6].s6 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[7].s7 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[8].s8 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
     return result
   }
 
   public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
     var index = scalars.startIndex
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s0 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s1 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s2 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s3 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s4 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s5 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s6 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s7 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s8 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
   }
 
-  public var scalars: [Double] {
-    return [s0, s1, s2, s3, s4, s5, s6, s7, s8]
+  public struct Scalars: RandomAccessCollection, MutableCollection {
+    internal var base: Vector9
+    public var startIndex: Int { 0 }
+    public var endIndex: Int { base.dimension }
+    public subscript(i: Int) -> Double {
+      get {
+        precondition(i >= 0 && i < endIndex)
+        return withUnsafePointer(to: self) { $0[i] }
+      }
+      _modify {
+        precondition(i >= 0 && i < endIndex)
+        p = withUnsafeMutablePointer(to: &self) { $0 }
+        yield &p[i]
+        _fixLifetime(self)
+      }
+    }
+  }
+  
+  public var scalars: Scalars {
+    get { .init(base: self) }
+    set { self = newValue.base  }
   }
 }
 
@@ -1309,55 +1477,55 @@ extension Vector9: FixedSizeVector {
 
 extension Vector9: ElementaryFunctions {}
 
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^10, with Euclidean inner product.
 public struct Vector10: KeyPathIterable {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s0: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s1: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s2: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s3: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s4: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s5: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s6: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s7: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s8: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s9: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
 
   @differentiable
   public init(_ s0: Double, _ s1: Double, _ s2: Double, _ s3: Double, _ s4: Double, _ s5: Double, _ s6: Double, _ s7: Double, _ s8: Double, _ s9: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s0 = s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s1 = s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s2 = s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s3 = s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s4 = s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s5 = s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s6 = s6
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s7 = s7
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s8 = s8
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s9 = s9
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
   }
 }
 
@@ -1365,103 +1533,103 @@ public struct Vector10: KeyPathIterable {
 extension Vector10: AdditiveArithmetic, Vector {
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s0 += rhs.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s1 += rhs.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s2 += rhs.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s3 += rhs.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s4 += rhs.s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s5 += rhs.s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s6 += rhs.s6
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s7 += rhs.s7
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s8 += rhs.s8
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s9 += rhs.s9
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
   }
 
   @differentiable
   public static func -= (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s0 -= rhs.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s1 -= rhs.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s2 -= rhs.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s3 -= rhs.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s4 -= rhs.s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s5 -= rhs.s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s6 -= rhs.s6
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s7 -= rhs.s7
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s8 -= rhs.s8
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s9 -= rhs.s9
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
   }
 
   @differentiable
   public static func *= (_ lhs: inout Self, _ rhs: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s0 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s1 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s2 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s3 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s4 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s5 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s6 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s7 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s8 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s9 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
   }
 
   @differentiable
   public func dot(_ other: Self) -> Double {
     var result = Double(0)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s0 * other.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s1 * other.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s2 * other.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s3 * other.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s4 * other.s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s5 * other.s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s6 * other.s6
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s7 * other.s7
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s8 * other.s8
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s9 * other.s9
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
     return result
   }
 
@@ -1469,67 +1637,86 @@ extension Vector10: AdditiveArithmetic, Vector {
 
   public static var standardBasis: [Self] {
     var result = Array(repeating: Self.zero, count: 10)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[0].s0 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[1].s1 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[2].s2 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[3].s3 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[4].s4 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[5].s5 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[6].s6 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[7].s7 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[8].s8 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[9].s9 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
     return result
   }
 
   public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
     var index = scalars.startIndex
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s0 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s1 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s2 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s3 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s4 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s5 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s6 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s7 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s8 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s9 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
   }
 
-  public var scalars: [Double] {
-    return [s0, s1, s2, s3, s4, s5, s6, s7, s8, s9]
+  public struct Scalars: RandomAccessCollection, MutableCollection {
+    internal var base: Vector10
+    public var startIndex: Int { 0 }
+    public var endIndex: Int { base.dimension }
+    public subscript(i: Int) -> Double {
+      get {
+        precondition(i >= 0 && i < endIndex)
+        return withUnsafePointer(to: self) { $0[i] }
+      }
+      _modify {
+        precondition(i >= 0 && i < endIndex)
+        p = withUnsafeMutablePointer(to: &self) { $0 }
+        yield &p[i]
+        _fixLifetime(self)
+      }
+    }
+  }
+  
+  public var scalars: Scalars {
+    get { .init(base: self) }
+    set { self = newValue.base  }
   }
 }
 
@@ -1539,59 +1726,59 @@ extension Vector10: FixedSizeVector {
 
 extension Vector10: ElementaryFunctions {}
 
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^11, with Euclidean inner product.
 public struct Vector11: KeyPathIterable {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s0: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s1: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s2: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s3: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s4: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s5: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s6: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s7: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s8: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s9: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s10: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
 
   @differentiable
   public init(_ s0: Double, _ s1: Double, _ s2: Double, _ s3: Double, _ s4: Double, _ s5: Double, _ s6: Double, _ s7: Double, _ s8: Double, _ s9: Double, _ s10: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s0 = s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s1 = s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s2 = s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s3 = s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s4 = s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s5 = s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s6 = s6
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s7 = s7
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s8 = s8
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s9 = s9
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s10 = s10
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
   }
 }
 
@@ -1599,111 +1786,111 @@ public struct Vector11: KeyPathIterable {
 extension Vector11: AdditiveArithmetic, Vector {
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s0 += rhs.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s1 += rhs.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s2 += rhs.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s3 += rhs.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s4 += rhs.s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s5 += rhs.s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s6 += rhs.s6
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s7 += rhs.s7
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s8 += rhs.s8
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s9 += rhs.s9
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s10 += rhs.s10
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
   }
 
   @differentiable
   public static func -= (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s0 -= rhs.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s1 -= rhs.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s2 -= rhs.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s3 -= rhs.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s4 -= rhs.s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s5 -= rhs.s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s6 -= rhs.s6
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s7 -= rhs.s7
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s8 -= rhs.s8
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s9 -= rhs.s9
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s10 -= rhs.s10
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
   }
 
   @differentiable
   public static func *= (_ lhs: inout Self, _ rhs: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s0 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s1 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s2 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s3 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s4 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s5 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s6 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s7 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s8 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s9 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s10 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
   }
 
   @differentiable
   public func dot(_ other: Self) -> Double {
     var result = Double(0)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s0 * other.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s1 * other.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s2 * other.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s3 * other.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s4 * other.s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s5 * other.s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s6 * other.s6
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s7 * other.s7
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s8 * other.s8
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s9 * other.s9
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s10 * other.s10
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
     return result
   }
 
@@ -1711,72 +1898,91 @@ extension Vector11: AdditiveArithmetic, Vector {
 
   public static var standardBasis: [Self] {
     var result = Array(repeating: Self.zero, count: 11)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[0].s0 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[1].s1 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[2].s2 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[3].s3 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[4].s4 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[5].s5 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[6].s6 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[7].s7 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[8].s8 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[9].s9 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[10].s10 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
     return result
   }
 
   public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
     var index = scalars.startIndex
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s0 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s1 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s2 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s3 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s4 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s5 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s6 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s7 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s8 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s9 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s10 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
   }
 
-  public var scalars: [Double] {
-    return [s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10]
+  public struct Scalars: RandomAccessCollection, MutableCollection {
+    internal var base: Vector11
+    public var startIndex: Int { 0 }
+    public var endIndex: Int { base.dimension }
+    public subscript(i: Int) -> Double {
+      get {
+        precondition(i >= 0 && i < endIndex)
+        return withUnsafePointer(to: self) { $0[i] }
+      }
+      _modify {
+        precondition(i >= 0 && i < endIndex)
+        p = withUnsafeMutablePointer(to: &self) { $0 }
+        yield &p[i]
+        _fixLifetime(self)
+      }
+    }
+  }
+  
+  public var scalars: Scalars {
+    get { .init(base: self) }
+    set { self = newValue.base  }
   }
 }
 
@@ -1786,63 +1992,63 @@ extension Vector11: FixedSizeVector {
 
 extension Vector11: ElementaryFunctions {}
 
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^12, with Euclidean inner product.
 public struct Vector12: KeyPathIterable {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s0: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s1: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s2: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s3: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s4: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s5: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s6: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s7: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s8: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s9: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s10: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s11: Double
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
 
   @differentiable
   public init(_ s0: Double, _ s1: Double, _ s2: Double, _ s3: Double, _ s4: Double, _ s5: Double, _ s6: Double, _ s7: Double, _ s8: Double, _ s9: Double, _ s10: Double, _ s11: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s0 = s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s1 = s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s2 = s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s3 = s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s4 = s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s5 = s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s6 = s6
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s7 = s7
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s8 = s8
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s9 = s9
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s10 = s10
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s11 = s11
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
   }
 }
 
@@ -1850,119 +2056,119 @@ public struct Vector12: KeyPathIterable {
 extension Vector12: AdditiveArithmetic, Vector {
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s0 += rhs.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s1 += rhs.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s2 += rhs.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s3 += rhs.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s4 += rhs.s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s5 += rhs.s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s6 += rhs.s6
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s7 += rhs.s7
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s8 += rhs.s8
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s9 += rhs.s9
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s10 += rhs.s10
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s11 += rhs.s11
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
   }
 
   @differentiable
   public static func -= (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s0 -= rhs.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s1 -= rhs.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s2 -= rhs.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s3 -= rhs.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s4 -= rhs.s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s5 -= rhs.s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s6 -= rhs.s6
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s7 -= rhs.s7
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s8 -= rhs.s8
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s9 -= rhs.s9
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s10 -= rhs.s10
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s11 -= rhs.s11
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
   }
 
   @differentiable
   public static func *= (_ lhs: inout Self, _ rhs: Double) {
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s0 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s1 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s2 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s3 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s4 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s5 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s6 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s7 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s8 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s9 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s10 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s11 *= rhs
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
   }
 
   @differentiable
   public func dot(_ other: Self) -> Double {
     var result = Double(0)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s0 * other.s0
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s1 * other.s1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s2 * other.s2
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s3 * other.s3
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s4 * other.s4
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s5 * other.s5
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s6 * other.s6
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s7 * other.s7
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s8 * other.s8
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s9 * other.s9
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s10 * other.s10
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s11 * other.s11
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
     return result
   }
 
@@ -1970,77 +2176,96 @@ extension Vector12: AdditiveArithmetic, Vector {
 
   public static var standardBasis: [Self] {
     var result = Array(repeating: Self.zero, count: 12)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[0].s0 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[1].s1 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[2].s2 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[3].s3 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[4].s4 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[5].s5 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[6].s6 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[7].s7 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[8].s8 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[9].s9 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[10].s10 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[11].s11 = 1
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
     return result
   }
 
   public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
     var index = scalars.startIndex
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s0 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s1 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s2 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s3 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s4 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s5 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s6 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s7 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s8 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s9 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s10 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s11 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
+// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
   }
 
-  public var scalars: [Double] {
-    return [s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11]
+  public struct Scalars: RandomAccessCollection, MutableCollection {
+    internal var base: Vector12
+    public var startIndex: Int { 0 }
+    public var endIndex: Int { base.dimension }
+    public subscript(i: Int) -> Double {
+      get {
+        precondition(i >= 0 && i < endIndex)
+        return withUnsafePointer(to: self) { $0[i] }
+      }
+      _modify {
+        precondition(i >= 0 && i < endIndex)
+        p = withUnsafeMutablePointer(to: &self) { $0 }
+        yield &p[i]
+        _fixLifetime(self)
+      }
+    }
+  }
+  
+  public var scalars: Scalars {
+    get { .init(base: self) }
+    set { self = newValue.base  }
   }
 }
 

--- a/Sources/SwiftFusion/Core/VectorN.swift
+++ b/Sources/SwiftFusion/Core/VectorN.swift
@@ -1,19 +1,13 @@
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 1)
 import TensorFlow
 
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^1, with Euclidean inner product.
 public struct Vector1: KeyPathIterable {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var x: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
 
   @differentiable
   public init(_ x: Double) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.x = x
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
   }
 }
 
@@ -21,31 +15,23 @@ public struct Vector1: KeyPathIterable {
 extension Vector1: AdditiveArithmetic, Vector {
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.x += rhs.x
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
   }
 
   @differentiable
   public static func -= (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.x -= rhs.x
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
   }
 
   @differentiable
   public static func *= (_ lhs: inout Self, _ rhs: Double) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.x *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
   }
 
   @differentiable
   public func dot(_ other: Self) -> Double {
     var result = Double(0)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.x * other.x
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
     return result
   }
 
@@ -53,33 +39,33 @@ extension Vector1: AdditiveArithmetic, Vector {
 
   public static var standardBasis: [Self] {
     var result = Array(repeating: Self.zero, count: 1)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[0].x = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
     return result
   }
 
   public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
     var index = scalars.startIndex
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.x = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
   }
 
   public struct Scalars: RandomAccessCollection, MutableCollection {
+    public typealias Indices = Range<Int>
     internal var base: Vector1
     public var startIndex: Int { 0 }
     public var endIndex: Int { base.dimension }
     public subscript(i: Int) -> Double {
       get {
         precondition(i >= 0 && i < endIndex)
-        return withUnsafePointer(to: self) { $0[i] }
+        return withUnsafePointer(to: self) {
+          UnsafeRawPointer($0).assumingMemoryBound(to: Double.self)[i]
+        }
       }
       _modify {
         precondition(i >= 0 && i < endIndex)
-        p = withUnsafeMutablePointer(to: &self) { $0 }
-        yield &p[i]
+        let p = withUnsafeMutablePointer(to: &self) { $0 }
+        let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        yield &q[i]
         _fixLifetime(self)
       }
     }
@@ -97,23 +83,16 @@ extension Vector1: FixedSizeVector {
 
 extension Vector1: ElementaryFunctions {}
 
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^2, with Euclidean inner product.
 public struct Vector2: KeyPathIterable {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var x: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var y: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
 
   @differentiable
   public init(_ x: Double, _ y: Double) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.x = x
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.y = y
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
   }
 }
 
@@ -121,39 +100,27 @@ public struct Vector2: KeyPathIterable {
 extension Vector2: AdditiveArithmetic, Vector {
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.x += rhs.x
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.y += rhs.y
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
   }
 
   @differentiable
   public static func -= (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.x -= rhs.x
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.y -= rhs.y
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
   }
 
   @differentiable
   public static func *= (_ lhs: inout Self, _ rhs: Double) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.x *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.y *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
   }
 
   @differentiable
   public func dot(_ other: Self) -> Double {
     var result = Double(0)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.x * other.x
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.y * other.y
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
     return result
   }
 
@@ -161,38 +128,36 @@ extension Vector2: AdditiveArithmetic, Vector {
 
   public static var standardBasis: [Self] {
     var result = Array(repeating: Self.zero, count: 2)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[0].x = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[1].y = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
     return result
   }
 
   public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
     var index = scalars.startIndex
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.x = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.y = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
   }
 
   public struct Scalars: RandomAccessCollection, MutableCollection {
+    public typealias Indices = Range<Int>
     internal var base: Vector2
     public var startIndex: Int { 0 }
     public var endIndex: Int { base.dimension }
     public subscript(i: Int) -> Double {
       get {
         precondition(i >= 0 && i < endIndex)
-        return withUnsafePointer(to: self) { $0[i] }
+        return withUnsafePointer(to: self) {
+          UnsafeRawPointer($0).assumingMemoryBound(to: Double.self)[i]
+        }
       }
       _modify {
         precondition(i >= 0 && i < endIndex)
-        p = withUnsafeMutablePointer(to: &self) { $0 }
-        yield &p[i]
+        let p = withUnsafeMutablePointer(to: &self) { $0 }
+        let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        yield &q[i]
         _fixLifetime(self)
       }
     }
@@ -210,27 +175,18 @@ extension Vector2: FixedSizeVector {
 
 extension Vector2: ElementaryFunctions {}
 
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^3, with Euclidean inner product.
 public struct Vector3: KeyPathIterable {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var x: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var y: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var z: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
 
   @differentiable
   public init(_ x: Double, _ y: Double, _ z: Double) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.x = x
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.y = y
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.z = z
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
   }
 }
 
@@ -238,47 +194,31 @@ public struct Vector3: KeyPathIterable {
 extension Vector3: AdditiveArithmetic, Vector {
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.x += rhs.x
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.y += rhs.y
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.z += rhs.z
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
   }
 
   @differentiable
   public static func -= (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.x -= rhs.x
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.y -= rhs.y
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.z -= rhs.z
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
   }
 
   @differentiable
   public static func *= (_ lhs: inout Self, _ rhs: Double) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.x *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.y *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.z *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
   }
 
   @differentiable
   public func dot(_ other: Self) -> Double {
     var result = Double(0)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.x * other.x
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.y * other.y
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.z * other.z
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
     return result
   }
 
@@ -286,43 +226,39 @@ extension Vector3: AdditiveArithmetic, Vector {
 
   public static var standardBasis: [Self] {
     var result = Array(repeating: Self.zero, count: 3)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[0].x = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[1].y = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[2].z = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
     return result
   }
 
   public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
     var index = scalars.startIndex
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.x = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.y = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.z = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
   }
 
   public struct Scalars: RandomAccessCollection, MutableCollection {
+    public typealias Indices = Range<Int>
     internal var base: Vector3
     public var startIndex: Int { 0 }
     public var endIndex: Int { base.dimension }
     public subscript(i: Int) -> Double {
       get {
         precondition(i >= 0 && i < endIndex)
-        return withUnsafePointer(to: self) { $0[i] }
+        return withUnsafePointer(to: self) {
+          UnsafeRawPointer($0).assumingMemoryBound(to: Double.self)[i]
+        }
       }
       _modify {
         precondition(i >= 0 && i < endIndex)
-        p = withUnsafeMutablePointer(to: &self) { $0 }
-        yield &p[i]
+        let p = withUnsafeMutablePointer(to: &self) { $0 }
+        let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        yield &q[i]
         _fixLifetime(self)
       }
     }
@@ -340,31 +276,20 @@ extension Vector3: FixedSizeVector {
 
 extension Vector3: ElementaryFunctions {}
 
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^4, with Euclidean inner product.
 public struct Vector4: KeyPathIterable {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s0: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s1: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s2: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s3: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
 
   @differentiable
   public init(_ s0: Double, _ s1: Double, _ s2: Double, _ s3: Double) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s0 = s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s1 = s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s2 = s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s3 = s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
   }
 }
 
@@ -372,55 +297,35 @@ public struct Vector4: KeyPathIterable {
 extension Vector4: AdditiveArithmetic, Vector {
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s0 += rhs.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s1 += rhs.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s2 += rhs.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s3 += rhs.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
   }
 
   @differentiable
   public static func -= (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s0 -= rhs.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s1 -= rhs.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s2 -= rhs.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s3 -= rhs.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
   }
 
   @differentiable
   public static func *= (_ lhs: inout Self, _ rhs: Double) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s0 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s1 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s2 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s3 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
   }
 
   @differentiable
   public func dot(_ other: Self) -> Double {
     var result = Double(0)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s0 * other.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s1 * other.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s2 * other.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s3 * other.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
     return result
   }
 
@@ -428,48 +333,42 @@ extension Vector4: AdditiveArithmetic, Vector {
 
   public static var standardBasis: [Self] {
     var result = Array(repeating: Self.zero, count: 4)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[0].s0 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[1].s1 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[2].s2 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[3].s3 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
     return result
   }
 
   public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
     var index = scalars.startIndex
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s0 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s1 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s2 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s3 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
   }
 
   public struct Scalars: RandomAccessCollection, MutableCollection {
+    public typealias Indices = Range<Int>
     internal var base: Vector4
     public var startIndex: Int { 0 }
     public var endIndex: Int { base.dimension }
     public subscript(i: Int) -> Double {
       get {
         precondition(i >= 0 && i < endIndex)
-        return withUnsafePointer(to: self) { $0[i] }
+        return withUnsafePointer(to: self) {
+          UnsafeRawPointer($0).assumingMemoryBound(to: Double.self)[i]
+        }
       }
       _modify {
         precondition(i >= 0 && i < endIndex)
-        p = withUnsafeMutablePointer(to: &self) { $0 }
-        yield &p[i]
+        let p = withUnsafeMutablePointer(to: &self) { $0 }
+        let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        yield &q[i]
         _fixLifetime(self)
       }
     }
@@ -487,35 +386,22 @@ extension Vector4: FixedSizeVector {
 
 extension Vector4: ElementaryFunctions {}
 
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^5, with Euclidean inner product.
 public struct Vector5: KeyPathIterable {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s0: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s1: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s2: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s3: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s4: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
 
   @differentiable
   public init(_ s0: Double, _ s1: Double, _ s2: Double, _ s3: Double, _ s4: Double) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s0 = s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s1 = s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s2 = s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s3 = s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s4 = s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
   }
 }
 
@@ -523,63 +409,39 @@ public struct Vector5: KeyPathIterable {
 extension Vector5: AdditiveArithmetic, Vector {
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s0 += rhs.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s1 += rhs.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s2 += rhs.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s3 += rhs.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s4 += rhs.s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
   }
 
   @differentiable
   public static func -= (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s0 -= rhs.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s1 -= rhs.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s2 -= rhs.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s3 -= rhs.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s4 -= rhs.s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
   }
 
   @differentiable
   public static func *= (_ lhs: inout Self, _ rhs: Double) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s0 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s1 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s2 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s3 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s4 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
   }
 
   @differentiable
   public func dot(_ other: Self) -> Double {
     var result = Double(0)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s0 * other.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s1 * other.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s2 * other.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s3 * other.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s4 * other.s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
     return result
   }
 
@@ -587,53 +449,45 @@ extension Vector5: AdditiveArithmetic, Vector {
 
   public static var standardBasis: [Self] {
     var result = Array(repeating: Self.zero, count: 5)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[0].s0 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[1].s1 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[2].s2 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[3].s3 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[4].s4 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
     return result
   }
 
   public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
     var index = scalars.startIndex
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s0 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s1 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s2 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s3 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s4 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
   }
 
   public struct Scalars: RandomAccessCollection, MutableCollection {
+    public typealias Indices = Range<Int>
     internal var base: Vector5
     public var startIndex: Int { 0 }
     public var endIndex: Int { base.dimension }
     public subscript(i: Int) -> Double {
       get {
         precondition(i >= 0 && i < endIndex)
-        return withUnsafePointer(to: self) { $0[i] }
+        return withUnsafePointer(to: self) {
+          UnsafeRawPointer($0).assumingMemoryBound(to: Double.self)[i]
+        }
       }
       _modify {
         precondition(i >= 0 && i < endIndex)
-        p = withUnsafeMutablePointer(to: &self) { $0 }
-        yield &p[i]
+        let p = withUnsafeMutablePointer(to: &self) { $0 }
+        let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        yield &q[i]
         _fixLifetime(self)
       }
     }
@@ -651,39 +505,24 @@ extension Vector5: FixedSizeVector {
 
 extension Vector5: ElementaryFunctions {}
 
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^6, with Euclidean inner product.
 public struct Vector6: KeyPathIterable {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s0: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s1: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s2: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s3: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s4: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s5: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
 
   @differentiable
   public init(_ s0: Double, _ s1: Double, _ s2: Double, _ s3: Double, _ s4: Double, _ s5: Double) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s0 = s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s1 = s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s2 = s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s3 = s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s4 = s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s5 = s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
   }
 }
 
@@ -691,71 +530,43 @@ public struct Vector6: KeyPathIterable {
 extension Vector6: AdditiveArithmetic, Vector {
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s0 += rhs.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s1 += rhs.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s2 += rhs.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s3 += rhs.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s4 += rhs.s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s5 += rhs.s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
   }
 
   @differentiable
   public static func -= (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s0 -= rhs.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s1 -= rhs.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s2 -= rhs.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s3 -= rhs.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s4 -= rhs.s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s5 -= rhs.s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
   }
 
   @differentiable
   public static func *= (_ lhs: inout Self, _ rhs: Double) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s0 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s1 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s2 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s3 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s4 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s5 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
   }
 
   @differentiable
   public func dot(_ other: Self) -> Double {
     var result = Double(0)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s0 * other.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s1 * other.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s2 * other.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s3 * other.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s4 * other.s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s5 * other.s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
     return result
   }
 
@@ -763,58 +574,48 @@ extension Vector6: AdditiveArithmetic, Vector {
 
   public static var standardBasis: [Self] {
     var result = Array(repeating: Self.zero, count: 6)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[0].s0 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[1].s1 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[2].s2 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[3].s3 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[4].s4 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[5].s5 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
     return result
   }
 
   public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
     var index = scalars.startIndex
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s0 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s1 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s2 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s3 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s4 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s5 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
   }
 
   public struct Scalars: RandomAccessCollection, MutableCollection {
+    public typealias Indices = Range<Int>
     internal var base: Vector6
     public var startIndex: Int { 0 }
     public var endIndex: Int { base.dimension }
     public subscript(i: Int) -> Double {
       get {
         precondition(i >= 0 && i < endIndex)
-        return withUnsafePointer(to: self) { $0[i] }
+        return withUnsafePointer(to: self) {
+          UnsafeRawPointer($0).assumingMemoryBound(to: Double.self)[i]
+        }
       }
       _modify {
         precondition(i >= 0 && i < endIndex)
-        p = withUnsafeMutablePointer(to: &self) { $0 }
-        yield &p[i]
+        let p = withUnsafeMutablePointer(to: &self) { $0 }
+        let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        yield &q[i]
         _fixLifetime(self)
       }
     }
@@ -832,43 +633,26 @@ extension Vector6: FixedSizeVector {
 
 extension Vector6: ElementaryFunctions {}
 
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^7, with Euclidean inner product.
 public struct Vector7: KeyPathIterable {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s0: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s1: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s2: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s3: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s4: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s5: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s6: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
 
   @differentiable
   public init(_ s0: Double, _ s1: Double, _ s2: Double, _ s3: Double, _ s4: Double, _ s5: Double, _ s6: Double) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s0 = s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s1 = s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s2 = s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s3 = s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s4 = s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s5 = s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s6 = s6
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
   }
 }
 
@@ -876,79 +660,47 @@ public struct Vector7: KeyPathIterable {
 extension Vector7: AdditiveArithmetic, Vector {
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s0 += rhs.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s1 += rhs.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s2 += rhs.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s3 += rhs.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s4 += rhs.s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s5 += rhs.s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s6 += rhs.s6
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
   }
 
   @differentiable
   public static func -= (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s0 -= rhs.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s1 -= rhs.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s2 -= rhs.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s3 -= rhs.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s4 -= rhs.s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s5 -= rhs.s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s6 -= rhs.s6
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
   }
 
   @differentiable
   public static func *= (_ lhs: inout Self, _ rhs: Double) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s0 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s1 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s2 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s3 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s4 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s5 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s6 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
   }
 
   @differentiable
   public func dot(_ other: Self) -> Double {
     var result = Double(0)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s0 * other.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s1 * other.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s2 * other.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s3 * other.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s4 * other.s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s5 * other.s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s6 * other.s6
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
     return result
   }
 
@@ -956,63 +708,51 @@ extension Vector7: AdditiveArithmetic, Vector {
 
   public static var standardBasis: [Self] {
     var result = Array(repeating: Self.zero, count: 7)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[0].s0 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[1].s1 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[2].s2 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[3].s3 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[4].s4 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[5].s5 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[6].s6 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
     return result
   }
 
   public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
     var index = scalars.startIndex
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s0 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s1 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s2 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s3 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s4 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s5 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s6 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
   }
 
   public struct Scalars: RandomAccessCollection, MutableCollection {
+    public typealias Indices = Range<Int>
     internal var base: Vector7
     public var startIndex: Int { 0 }
     public var endIndex: Int { base.dimension }
     public subscript(i: Int) -> Double {
       get {
         precondition(i >= 0 && i < endIndex)
-        return withUnsafePointer(to: self) { $0[i] }
+        return withUnsafePointer(to: self) {
+          UnsafeRawPointer($0).assumingMemoryBound(to: Double.self)[i]
+        }
       }
       _modify {
         precondition(i >= 0 && i < endIndex)
-        p = withUnsafeMutablePointer(to: &self) { $0 }
-        yield &p[i]
+        let p = withUnsafeMutablePointer(to: &self) { $0 }
+        let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        yield &q[i]
         _fixLifetime(self)
       }
     }
@@ -1030,47 +770,28 @@ extension Vector7: FixedSizeVector {
 
 extension Vector7: ElementaryFunctions {}
 
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^8, with Euclidean inner product.
 public struct Vector8: KeyPathIterable {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s0: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s1: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s2: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s3: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s4: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s5: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s6: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s7: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
 
   @differentiable
   public init(_ s0: Double, _ s1: Double, _ s2: Double, _ s3: Double, _ s4: Double, _ s5: Double, _ s6: Double, _ s7: Double) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s0 = s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s1 = s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s2 = s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s3 = s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s4 = s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s5 = s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s6 = s6
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s7 = s7
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
   }
 }
 
@@ -1078,87 +799,51 @@ public struct Vector8: KeyPathIterable {
 extension Vector8: AdditiveArithmetic, Vector {
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s0 += rhs.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s1 += rhs.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s2 += rhs.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s3 += rhs.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s4 += rhs.s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s5 += rhs.s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s6 += rhs.s6
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s7 += rhs.s7
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
   }
 
   @differentiable
   public static func -= (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s0 -= rhs.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s1 -= rhs.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s2 -= rhs.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s3 -= rhs.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s4 -= rhs.s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s5 -= rhs.s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s6 -= rhs.s6
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s7 -= rhs.s7
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
   }
 
   @differentiable
   public static func *= (_ lhs: inout Self, _ rhs: Double) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s0 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s1 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s2 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s3 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s4 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s5 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s6 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s7 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
   }
 
   @differentiable
   public func dot(_ other: Self) -> Double {
     var result = Double(0)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s0 * other.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s1 * other.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s2 * other.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s3 * other.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s4 * other.s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s5 * other.s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s6 * other.s6
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s7 * other.s7
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
     return result
   }
 
@@ -1166,68 +851,54 @@ extension Vector8: AdditiveArithmetic, Vector {
 
   public static var standardBasis: [Self] {
     var result = Array(repeating: Self.zero, count: 8)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[0].s0 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[1].s1 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[2].s2 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[3].s3 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[4].s4 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[5].s5 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[6].s6 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[7].s7 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
     return result
   }
 
   public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
     var index = scalars.startIndex
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s0 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s1 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s2 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s3 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s4 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s5 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s6 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s7 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
   }
 
   public struct Scalars: RandomAccessCollection, MutableCollection {
+    public typealias Indices = Range<Int>
     internal var base: Vector8
     public var startIndex: Int { 0 }
     public var endIndex: Int { base.dimension }
     public subscript(i: Int) -> Double {
       get {
         precondition(i >= 0 && i < endIndex)
-        return withUnsafePointer(to: self) { $0[i] }
+        return withUnsafePointer(to: self) {
+          UnsafeRawPointer($0).assumingMemoryBound(to: Double.self)[i]
+        }
       }
       _modify {
         precondition(i >= 0 && i < endIndex)
-        p = withUnsafeMutablePointer(to: &self) { $0 }
-        yield &p[i]
+        let p = withUnsafeMutablePointer(to: &self) { $0 }
+        let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        yield &q[i]
         _fixLifetime(self)
       }
     }
@@ -1245,51 +916,30 @@ extension Vector8: FixedSizeVector {
 
 extension Vector8: ElementaryFunctions {}
 
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^9, with Euclidean inner product.
 public struct Vector9: KeyPathIterable {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s0: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s1: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s2: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s3: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s4: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s5: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s6: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s7: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s8: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
 
   @differentiable
   public init(_ s0: Double, _ s1: Double, _ s2: Double, _ s3: Double, _ s4: Double, _ s5: Double, _ s6: Double, _ s7: Double, _ s8: Double) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s0 = s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s1 = s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s2 = s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s3 = s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s4 = s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s5 = s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s6 = s6
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s7 = s7
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s8 = s8
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
   }
 }
 
@@ -1297,95 +947,55 @@ public struct Vector9: KeyPathIterable {
 extension Vector9: AdditiveArithmetic, Vector {
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s0 += rhs.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s1 += rhs.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s2 += rhs.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s3 += rhs.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s4 += rhs.s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s5 += rhs.s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s6 += rhs.s6
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s7 += rhs.s7
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s8 += rhs.s8
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
   }
 
   @differentiable
   public static func -= (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s0 -= rhs.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s1 -= rhs.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s2 -= rhs.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s3 -= rhs.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s4 -= rhs.s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s5 -= rhs.s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s6 -= rhs.s6
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s7 -= rhs.s7
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s8 -= rhs.s8
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
   }
 
   @differentiable
   public static func *= (_ lhs: inout Self, _ rhs: Double) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s0 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s1 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s2 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s3 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s4 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s5 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s6 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s7 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s8 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
   }
 
   @differentiable
   public func dot(_ other: Self) -> Double {
     var result = Double(0)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s0 * other.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s1 * other.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s2 * other.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s3 * other.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s4 * other.s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s5 * other.s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s6 * other.s6
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s7 * other.s7
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s8 * other.s8
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
     return result
   }
 
@@ -1393,73 +1003,57 @@ extension Vector9: AdditiveArithmetic, Vector {
 
   public static var standardBasis: [Self] {
     var result = Array(repeating: Self.zero, count: 9)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[0].s0 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[1].s1 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[2].s2 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[3].s3 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[4].s4 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[5].s5 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[6].s6 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[7].s7 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[8].s8 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
     return result
   }
 
   public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
     var index = scalars.startIndex
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s0 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s1 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s2 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s3 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s4 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s5 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s6 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s7 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s8 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
   }
 
   public struct Scalars: RandomAccessCollection, MutableCollection {
+    public typealias Indices = Range<Int>
     internal var base: Vector9
     public var startIndex: Int { 0 }
     public var endIndex: Int { base.dimension }
     public subscript(i: Int) -> Double {
       get {
         precondition(i >= 0 && i < endIndex)
-        return withUnsafePointer(to: self) { $0[i] }
+        return withUnsafePointer(to: self) {
+          UnsafeRawPointer($0).assumingMemoryBound(to: Double.self)[i]
+        }
       }
       _modify {
         precondition(i >= 0 && i < endIndex)
-        p = withUnsafeMutablePointer(to: &self) { $0 }
-        yield &p[i]
+        let p = withUnsafeMutablePointer(to: &self) { $0 }
+        let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        yield &q[i]
         _fixLifetime(self)
       }
     }
@@ -1477,55 +1071,32 @@ extension Vector9: FixedSizeVector {
 
 extension Vector9: ElementaryFunctions {}
 
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^10, with Euclidean inner product.
 public struct Vector10: KeyPathIterable {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s0: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s1: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s2: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s3: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s4: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s5: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s6: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s7: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s8: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s9: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
 
   @differentiable
   public init(_ s0: Double, _ s1: Double, _ s2: Double, _ s3: Double, _ s4: Double, _ s5: Double, _ s6: Double, _ s7: Double, _ s8: Double, _ s9: Double) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s0 = s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s1 = s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s2 = s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s3 = s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s4 = s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s5 = s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s6 = s6
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s7 = s7
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s8 = s8
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s9 = s9
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
   }
 }
 
@@ -1533,103 +1104,59 @@ public struct Vector10: KeyPathIterable {
 extension Vector10: AdditiveArithmetic, Vector {
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s0 += rhs.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s1 += rhs.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s2 += rhs.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s3 += rhs.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s4 += rhs.s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s5 += rhs.s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s6 += rhs.s6
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s7 += rhs.s7
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s8 += rhs.s8
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s9 += rhs.s9
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
   }
 
   @differentiable
   public static func -= (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s0 -= rhs.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s1 -= rhs.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s2 -= rhs.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s3 -= rhs.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s4 -= rhs.s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s5 -= rhs.s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s6 -= rhs.s6
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s7 -= rhs.s7
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s8 -= rhs.s8
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s9 -= rhs.s9
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
   }
 
   @differentiable
   public static func *= (_ lhs: inout Self, _ rhs: Double) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s0 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s1 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s2 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s3 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s4 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s5 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s6 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s7 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s8 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s9 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
   }
 
   @differentiable
   public func dot(_ other: Self) -> Double {
     var result = Double(0)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s0 * other.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s1 * other.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s2 * other.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s3 * other.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s4 * other.s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s5 * other.s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s6 * other.s6
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s7 * other.s7
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s8 * other.s8
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s9 * other.s9
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
     return result
   }
 
@@ -1637,78 +1164,60 @@ extension Vector10: AdditiveArithmetic, Vector {
 
   public static var standardBasis: [Self] {
     var result = Array(repeating: Self.zero, count: 10)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[0].s0 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[1].s1 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[2].s2 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[3].s3 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[4].s4 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[5].s5 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[6].s6 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[7].s7 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[8].s8 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[9].s9 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
     return result
   }
 
   public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
     var index = scalars.startIndex
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s0 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s1 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s2 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s3 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s4 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s5 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s6 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s7 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s8 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s9 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
   }
 
   public struct Scalars: RandomAccessCollection, MutableCollection {
+    public typealias Indices = Range<Int>
     internal var base: Vector10
     public var startIndex: Int { 0 }
     public var endIndex: Int { base.dimension }
     public subscript(i: Int) -> Double {
       get {
         precondition(i >= 0 && i < endIndex)
-        return withUnsafePointer(to: self) { $0[i] }
+        return withUnsafePointer(to: self) {
+          UnsafeRawPointer($0).assumingMemoryBound(to: Double.self)[i]
+        }
       }
       _modify {
         precondition(i >= 0 && i < endIndex)
-        p = withUnsafeMutablePointer(to: &self) { $0 }
-        yield &p[i]
+        let p = withUnsafeMutablePointer(to: &self) { $0 }
+        let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        yield &q[i]
         _fixLifetime(self)
       }
     }
@@ -1726,59 +1235,34 @@ extension Vector10: FixedSizeVector {
 
 extension Vector10: ElementaryFunctions {}
 
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^11, with Euclidean inner product.
 public struct Vector11: KeyPathIterable {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s0: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s1: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s2: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s3: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s4: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s5: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s6: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s7: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s8: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s9: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s10: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
 
   @differentiable
   public init(_ s0: Double, _ s1: Double, _ s2: Double, _ s3: Double, _ s4: Double, _ s5: Double, _ s6: Double, _ s7: Double, _ s8: Double, _ s9: Double, _ s10: Double) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s0 = s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s1 = s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s2 = s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s3 = s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s4 = s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s5 = s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s6 = s6
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s7 = s7
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s8 = s8
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s9 = s9
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s10 = s10
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
   }
 }
 
@@ -1786,111 +1270,63 @@ public struct Vector11: KeyPathIterable {
 extension Vector11: AdditiveArithmetic, Vector {
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s0 += rhs.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s1 += rhs.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s2 += rhs.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s3 += rhs.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s4 += rhs.s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s5 += rhs.s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s6 += rhs.s6
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s7 += rhs.s7
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s8 += rhs.s8
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s9 += rhs.s9
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s10 += rhs.s10
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
   }
 
   @differentiable
   public static func -= (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s0 -= rhs.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s1 -= rhs.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s2 -= rhs.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s3 -= rhs.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s4 -= rhs.s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s5 -= rhs.s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s6 -= rhs.s6
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s7 -= rhs.s7
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s8 -= rhs.s8
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s9 -= rhs.s9
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s10 -= rhs.s10
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
   }
 
   @differentiable
   public static func *= (_ lhs: inout Self, _ rhs: Double) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s0 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s1 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s2 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s3 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s4 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s5 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s6 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s7 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s8 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s9 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s10 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
   }
 
   @differentiable
   public func dot(_ other: Self) -> Double {
     var result = Double(0)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s0 * other.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s1 * other.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s2 * other.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s3 * other.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s4 * other.s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s5 * other.s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s6 * other.s6
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s7 * other.s7
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s8 * other.s8
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s9 * other.s9
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s10 * other.s10
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
     return result
   }
 
@@ -1898,83 +1334,63 @@ extension Vector11: AdditiveArithmetic, Vector {
 
   public static var standardBasis: [Self] {
     var result = Array(repeating: Self.zero, count: 11)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[0].s0 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[1].s1 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[2].s2 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[3].s3 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[4].s4 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[5].s5 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[6].s6 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[7].s7 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[8].s8 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[9].s9 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[10].s10 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
     return result
   }
 
   public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
     var index = scalars.startIndex
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s0 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s1 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s2 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s3 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s4 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s5 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s6 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s7 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s8 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s9 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s10 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
   }
 
   public struct Scalars: RandomAccessCollection, MutableCollection {
+    public typealias Indices = Range<Int>
     internal var base: Vector11
     public var startIndex: Int { 0 }
     public var endIndex: Int { base.dimension }
     public subscript(i: Int) -> Double {
       get {
         precondition(i >= 0 && i < endIndex)
-        return withUnsafePointer(to: self) { $0[i] }
+        return withUnsafePointer(to: self) {
+          UnsafeRawPointer($0).assumingMemoryBound(to: Double.self)[i]
+        }
       }
       _modify {
         precondition(i >= 0 && i < endIndex)
-        p = withUnsafeMutablePointer(to: &self) { $0 }
-        yield &p[i]
+        let p = withUnsafeMutablePointer(to: &self) { $0 }
+        let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        yield &q[i]
         _fixLifetime(self)
       }
     }
@@ -1992,63 +1408,36 @@ extension Vector11: FixedSizeVector {
 
 extension Vector11: ElementaryFunctions {}
 
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 10)
 
 /// An element of R^12, with Euclidean inner product.
 public struct Vector12: KeyPathIterable {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s0: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s1: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s2: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s3: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s4: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s5: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s6: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s7: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s8: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s9: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s10: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 14)
   @differentiable public var s11: Double
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 16)
 
   @differentiable
   public init(_ s0: Double, _ s1: Double, _ s2: Double, _ s3: Double, _ s4: Double, _ s5: Double, _ s6: Double, _ s7: Double, _ s8: Double, _ s9: Double, _ s10: Double, _ s11: Double) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s0 = s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s1 = s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s2 = s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s3 = s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s4 = s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s5 = s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s6 = s6
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s7 = s7
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s8 = s8
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s9 = s9
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s10 = s10
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 20)
     self.s11 = s11
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 22)
   }
 }
 
@@ -2056,119 +1445,67 @@ public struct Vector12: KeyPathIterable {
 extension Vector12: AdditiveArithmetic, Vector {
   @differentiable
   public static func += (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s0 += rhs.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s1 += rhs.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s2 += rhs.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s3 += rhs.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s4 += rhs.s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s5 += rhs.s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s6 += rhs.s6
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s7 += rhs.s7
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s8 += rhs.s8
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s9 += rhs.s9
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s10 += rhs.s10
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 30)
     lhs.s11 += rhs.s11
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 32)
   }
 
   @differentiable
   public static func -= (_ lhs: inout Self, _ rhs: Self) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s0 -= rhs.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s1 -= rhs.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s2 -= rhs.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s3 -= rhs.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s4 -= rhs.s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s5 -= rhs.s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s6 -= rhs.s6
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s7 -= rhs.s7
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s8 -= rhs.s8
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s9 -= rhs.s9
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s10 -= rhs.s10
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 37)
     lhs.s11 -= rhs.s11
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 39)
   }
 
   @differentiable
   public static func *= (_ lhs: inout Self, _ rhs: Double) {
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s0 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s1 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s2 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s3 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s4 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s5 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s6 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s7 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s8 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s9 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s10 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 44)
     lhs.s11 *= rhs
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 46)
   }
 
   @differentiable
   public func dot(_ other: Self) -> Double {
     var result = Double(0)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s0 * other.s0
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s1 * other.s1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s2 * other.s2
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s3 * other.s3
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s4 * other.s4
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s5 * other.s5
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s6 * other.s6
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s7 * other.s7
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s8 * other.s8
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s9 * other.s9
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s10 * other.s10
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 52)
     result += self.s11 * other.s11
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 54)
     return result
   }
 
@@ -2176,88 +1513,66 @@ extension Vector12: AdditiveArithmetic, Vector {
 
   public static var standardBasis: [Self] {
     var result = Array(repeating: Self.zero, count: 12)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[0].s0 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[1].s1 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[2].s2 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[3].s3 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[4].s4 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[5].s5 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[6].s6 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[7].s7 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[8].s8 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[9].s9 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[10].s10 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 62)
     result[11].s11 = 1
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 64)
     return result
   }
 
   public init<Source: Collection>(_ scalars: Source) where Source.Element == Double {
     var index = scalars.startIndex
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s0 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s1 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s2 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s3 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s4 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s5 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s6 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s7 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s8 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s9 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s10 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 70)
     self.s11 = scalars[index]
     index = scalars.index(after: index)
-// ###sourceLocation(file: "/Users/dabrahams/src/SwiftFusion/Sources/SwiftFusion/Core/VectorN.swift.gyb", line: 73)
   }
 
   public struct Scalars: RandomAccessCollection, MutableCollection {
+    public typealias Indices = Range<Int>
     internal var base: Vector12
     public var startIndex: Int { 0 }
     public var endIndex: Int { base.dimension }
     public subscript(i: Int) -> Double {
       get {
         precondition(i >= 0 && i < endIndex)
-        return withUnsafePointer(to: self) { $0[i] }
+        return withUnsafePointer(to: self) {
+          UnsafeRawPointer($0).assumingMemoryBound(to: Double.self)[i]
+        }
       }
       _modify {
         precondition(i >= 0 && i < endIndex)
-        p = withUnsafeMutablePointer(to: &self) { $0 }
-        yield &p[i]
+        let p = withUnsafeMutablePointer(to: &self) { $0 }
+        let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        yield &q[i]
         _fixLifetime(self)
       }
     }

--- a/Sources/SwiftFusion/Core/VectorN.swift.gyb
+++ b/Sources/SwiftFusion/Core/VectorN.swift.gyb
@@ -72,8 +72,27 @@ extension Vector${dim}: AdditiveArithmetic, Vector {
     % end
   }
 
-  public var scalars: [Double] {
-    return [${', '.join(coordinates)}]
+  public struct Scalars: RandomAccessCollection, MutableCollection {
+    internal var base: Vector${dim}
+    public var startIndex: Int { 0 }
+    public var endIndex: Int { base.dimension }
+    public subscript(i: Int) -> Double {
+      get {
+        precondition(i >= 0 && i < endIndex)
+        return withUnsafePointer(to: self) { $0[i] }
+      }
+      _modify {
+        precondition(i >= 0 && i < endIndex)
+        p = withUnsafeMutablePointer(to: &self) { $0 }
+        yield &p[i]
+        _fixLifetime(self)
+      }
+    }
+  }
+  
+  public var scalars: Scalars {
+    get { .init(base: self) }
+    set { self = newValue.base  }
   }
 }
 

--- a/Sources/SwiftFusion/Core/VectorN.swift.gyb
+++ b/Sources/SwiftFusion/Core/VectorN.swift.gyb
@@ -73,18 +73,22 @@ extension Vector${dim}: AdditiveArithmetic, Vector {
   }
 
   public struct Scalars: RandomAccessCollection, MutableCollection {
+    public typealias Indices = Range<Int>
     internal var base: Vector${dim}
     public var startIndex: Int { 0 }
     public var endIndex: Int { base.dimension }
     public subscript(i: Int) -> Double {
       get {
         precondition(i >= 0 && i < endIndex)
-        return withUnsafePointer(to: self) { $0[i] }
+        return withUnsafePointer(to: self) {
+          UnsafeRawPointer($0).assumingMemoryBound(to: Double.self)[i]
+        }
       }
       _modify {
         precondition(i >= 0 && i < endIndex)
-        p = withUnsafeMutablePointer(to: &self) { $0 }
-        yield &p[i]
+        let p = withUnsafeMutablePointer(to: &self) { $0 }
+        let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        yield &q[i]
         _fixLifetime(self)
       }
     }

--- a/Sources/SwiftFusion/Inference/ArrayBuffer+Vector.swift
+++ b/Sources/SwiftFusion/Inference/ArrayBuffer+Vector.swift
@@ -43,12 +43,6 @@ public struct NestedIndex<OuterIndex: Comparable, InnerIndex: Comparable> : Comp
     }
   }
   
-  internal init<C: Collection>(firstValidIn c: C)
-    where C.Index == OuterIndex, C.Element: Collection, C.Element.Index == InnerIndex
-  {
-    self.init(firstValidIn: c) { $0 }
-  }
-  
   internal init<C: Collection>(endIn c: C) where C.Index == OuterIndex
   {
     self.init(outer: c.endIndex, inner: nil)


### PR DESCRIPTION
This does not yet remove accesses to vectors through withUnsafeMutableBufferPointer, but now that scalars are required to be supported, we are in a position to remove that from the protocol. 

No change in performance.