### PR TITLE
test vector semantics

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-protobuf.git",
         "state": {
           "branch": null,
-          "revision": "cc10a0a3149579d36bc546d97064884cb818f324",
-          "version": "1.11.0"
+          "revision": "0279688c9fc5a40028e1b5bb0cb56534a45a6020",
+          "version": "1.12.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -56,6 +56,7 @@ let package = Package(
       name: "SwiftFusionTests",
       dependencies: [
         "SwiftFusion",
+        "PenguinTesting",
         .product(name: "ModelSupport", package: "swift-models"),
       ]),
     .testTarget(

--- a/Sources/SwiftFusion/Core/FixedShapeTensor.swift
+++ b/Sources/SwiftFusion/Core/FixedShapeTensor.swift
@@ -70,10 +70,6 @@ extension FixedShapeTensor {
   }
 
   public static var zero: Self { .init(Tensor(zeros: Self.shape)) }
-
-  public var zeroTangentVectorInitializer: () -> Self {
-    { .init(Tensor(zeros: Self.shape)) }
-  }
 }
 
 // Copy this implementation and modify the `shape` to create `FixedShapeTensor`s with other shapes.

--- a/Sources/SwiftFusion/Core/FixedShapeTensor.swift
+++ b/Sources/SwiftFusion/Core/FixedShapeTensor.swift
@@ -70,6 +70,10 @@ extension FixedShapeTensor {
   }
 
   public static var zero: Self { .init(Tensor(zeros: Self.shape)) }
+
+  public var zeroTangentVectorInitializer: () -> Self {
+    { .init(Tensor(zeros: Self.shape)) }
+  }
 }
 
 // Copy this implementation and modify the `shape` to create `FixedShapeTensor`s with other shapes.

--- a/Sources/SwiftFusion/Inference/ArrayBuffer+Vector.swift
+++ b/Sources/SwiftFusion/Inference/ArrayBuffer+Vector.swift
@@ -158,6 +158,7 @@ extension ArrayBuffer: Vector where Element: Vector {
   @differentiable
   private static func minus (_ lhs: ArrayBuffer, _ rhs: ArrayBuffer) -> ArrayBuffer {
     if rhs.isEmpty { return lhs }
+    if lhs.isEmpty { return .init(rhs.lazy.map { $0.zeroValue - $0 }) }
     return .init(elementwise: lhs, rhs, -)
   }
 

--- a/Sources/SwiftFusion/Inference/ValuesStorage.swift
+++ b/Sources/SwiftFusion/Inference/ValuesStorage.swift
@@ -226,7 +226,7 @@ public class VectorArrayDispatch: DifferentiableArrayDispatch {
 
 extension AnyArrayBuffer where Dispatch == VectorArrayDispatch {
   /// Creates an instance from a typed buffer of `Element`
-  init<Element: Vector>(_ src: ArrayBuffer<Element>) {
+  public init<Element: Vector>(_ src: ArrayBuffer<Element>) {
     self.init(
       storage: src.storage,
       dispatch: VectorArrayDispatch(Type<Element>()))

--- a/Tests/SwiftFusionTests/Core/FixedShapeTensorTests.swift
+++ b/Tests/SwiftFusionTests/Core/FixedShapeTensorTests.swift
@@ -51,7 +51,9 @@ class FixedShapeTensorTests: XCTestCase {
   func testVectorConformance() {
     let s = (0..<100).lazy.map { Double($0) }
     let v = Tensor10x10(Tensor(rangeFrom: 0, to: 100, stride: 1).reshaped(to: Tensor10x10.shape))
-    v.checkVectorSemantics(expecting: s, writing: (100..<200).lazy.map { Double($0) })
+    v.checkVectorSemantics(
+      expectingScalars: s,
+      writingScalars: (100..<200).lazy.map { Double($0) })
     v.scalars.checkRandomAccessCollectionSemantics(expecting: s)
   }
 }

--- a/Tests/SwiftFusionTests/Core/FixedShapeTensorTests.swift
+++ b/Tests/SwiftFusionTests/Core/FixedShapeTensorTests.swift
@@ -47,12 +47,11 @@ class FixedShapeTensorTests: XCTestCase {
       }
     }
   }
-}
 
-class FixedShapeTensorVectorTests: XCTestCase, FixedSizeVectorTests {
-  typealias Testee = Tensor10x10
-  static var dimension: Int { 100 }
-  func testAll() {
-    runAllFixedSizeVectorTests()
+  func testVectorConformance() {
+    let s = (0..<100).lazy.map { Double($0) }
+    let v = Tensor10x10(Tensor(rangeFrom: 0, to: 100, stride: 1).reshaped(to: Tensor10x10.shape))
+    v.checkVectorSemantics(expecting: s, writing: (100..<200).lazy.map { Double($0) })
+    v.scalars.checkRandomAccessCollectionSemantics(expecting: s)
   }
 }

--- a/Tests/SwiftFusionTests/Core/FixedSizeMatrixTests.swift
+++ b/Tests/SwiftFusionTests/Core/FixedSizeMatrixTests.swift
@@ -24,6 +24,18 @@ fileprivate typealias Matrix3x2 = FixedSizeMatrix<Array3<Vector2>>
 fileprivate typealias Matrix3x2_3x3 = FixedSizeMatrix<Array3<Tuple2<Vector2, Vector3>>>
 
 class FixedSizeMatrixTests: XCTestCase {
+  func testVectorConformance() {
+    let s1 = (0..<6).lazy.map { Double($0) }
+    let v1 = Matrix3x2(s1)
+    v1.checkVectorSemantics(expecting: s1, writing: (6..<12).lazy.map { Double($0) })
+    v1.scalars.checkRandomAccessCollectionSemantics(expecting: s1)
+
+    let s2 = (0..<9).lazy.map { Double($0) }
+    let v2 = Matrix3(s2)
+    v2.checkVectorSemantics(expecting: s2, writing: (9..<18).lazy.map { Double($0) })
+    v2.scalars.checkRandomAccessCollectionSemantics(expecting: s2)
+  }
+
   func testShape() {
     XCTAssertEqual(Matrix3.shape, Array2(3, 3))
     XCTAssertEqual(Matrix3x2.shape, Array2(3, 2))

--- a/Tests/SwiftFusionTests/Core/FixedSizeMatrixTests.swift
+++ b/Tests/SwiftFusionTests/Core/FixedSizeMatrixTests.swift
@@ -27,12 +27,12 @@ class FixedSizeMatrixTests: XCTestCase {
   func testVectorConformance() {
     let s1 = (0..<6).lazy.map { Double($0) }
     let v1 = Matrix3x2(s1)
-    v1.checkVectorSemantics(expecting: s1, writing: (6..<12).lazy.map { Double($0) })
+    v1.checkVectorSemantics(expectingScalars: s1, writingScalars: (6..<12).lazy.map { Double($0) })
     v1.scalars.checkRandomAccessCollectionSemantics(expecting: s1)
 
     let s2 = (0..<9).lazy.map { Double($0) }
     let v2 = Matrix3(s2)
-    v2.checkVectorSemantics(expecting: s2, writing: (9..<18).lazy.map { Double($0) })
+    v2.checkVectorSemantics(expectingScalars: s2, writingScalars: (9..<18).lazy.map { Double($0) })
     v2.scalars.checkRandomAccessCollectionSemantics(expecting: s2)
   }
 

--- a/Tests/SwiftFusionTests/Core/VectorNTests.swift
+++ b/Tests/SwiftFusionTests/Core/VectorNTests.swift
@@ -20,8 +20,8 @@ class VectorNTests: XCTestCase {
     let s = (0..<1).lazy.map { Double($0) }
     let v = Vector1(0)
     v.checkVectorSemantics(
-      expecting: s,
-      writing: (1..<2).lazy.map { Double($0) },
+      expectingScalars: s,
+      writingScalars: (1..<2).lazy.map { Double($0) },
       maxSupportedScalarCount: 1)
     v.scalars.checkRandomAccessCollectionSemantics(
       expecting: s,
@@ -39,8 +39,8 @@ class VectorNTests: XCTestCase {
     let s = (0..<2).lazy.map { Double($0) }
     let v = Vector2(0, 1)
     v.checkVectorSemantics(
-      expecting: s,
-      writing: (2..<4).lazy.map { Double($0) },
+      expectingScalars: s,
+      writingScalars: (2..<4).lazy.map { Double($0) },
       maxSupportedScalarCount: 2)
     v.scalars.checkRandomAccessCollectionSemantics(
       expecting: s,
@@ -59,8 +59,8 @@ class VectorNTests: XCTestCase {
     let s = (0..<3).lazy.map { Double($0) }
     let v = Vector3(0, 1, 2)
     v.checkVectorSemantics(
-      expecting: s,
-      writing: (3..<6).lazy.map { Double($0) },
+      expectingScalars: s,
+      writingScalars: (3..<6).lazy.map { Double($0) },
       maxSupportedScalarCount: 3)
     v.scalars.checkRandomAccessCollectionSemantics(
       expecting: s,
@@ -80,8 +80,8 @@ class VectorNTests: XCTestCase {
     let s = (0..<4).lazy.map { Double($0) }
     let v = Vector4(0, 1, 2, 3)
     v.checkVectorSemantics(
-      expecting: s,
-      writing: (4..<8).lazy.map { Double($0) },
+      expectingScalars: s,
+      writingScalars: (4..<8).lazy.map { Double($0) },
       maxSupportedScalarCount: 4)
     v.scalars.checkRandomAccessCollectionSemantics(
       expecting: s,
@@ -102,8 +102,8 @@ class VectorNTests: XCTestCase {
     let s = (0..<5).lazy.map { Double($0) }
     let v = Vector5(0, 1, 2, 3, 4)
     v.checkVectorSemantics(
-      expecting: s,
-      writing: (5..<10).lazy.map { Double($0) },
+      expectingScalars: s,
+      writingScalars: (5..<10).lazy.map { Double($0) },
       maxSupportedScalarCount: 5)
     v.scalars.checkRandomAccessCollectionSemantics(
       expecting: s,
@@ -125,8 +125,8 @@ class VectorNTests: XCTestCase {
     let s = (0..<6).lazy.map { Double($0) }
     let v = Vector6(0, 1, 2, 3, 4, 5)
     v.checkVectorSemantics(
-      expecting: s,
-      writing: (6..<12).lazy.map { Double($0) },
+      expectingScalars: s,
+      writingScalars: (6..<12).lazy.map { Double($0) },
       maxSupportedScalarCount: 6)
     v.scalars.checkRandomAccessCollectionSemantics(
       expecting: s,
@@ -149,8 +149,8 @@ class VectorNTests: XCTestCase {
     let s = (0..<7).lazy.map { Double($0) }
     let v = Vector7(0, 1, 2, 3, 4, 5, 6)
     v.checkVectorSemantics(
-      expecting: s,
-      writing: (7..<14).lazy.map { Double($0) },
+      expectingScalars: s,
+      writingScalars: (7..<14).lazy.map { Double($0) },
       maxSupportedScalarCount: 7)
     v.scalars.checkRandomAccessCollectionSemantics(
       expecting: s,
@@ -174,8 +174,8 @@ class VectorNTests: XCTestCase {
     let s = (0..<8).lazy.map { Double($0) }
     let v = Vector8(0, 1, 2, 3, 4, 5, 6, 7)
     v.checkVectorSemantics(
-      expecting: s,
-      writing: (8..<16).lazy.map { Double($0) },
+      expectingScalars: s,
+      writingScalars: (8..<16).lazy.map { Double($0) },
       maxSupportedScalarCount: 8)
     v.scalars.checkRandomAccessCollectionSemantics(
       expecting: s,
@@ -200,8 +200,8 @@ class VectorNTests: XCTestCase {
     let s = (0..<9).lazy.map { Double($0) }
     let v = Vector9(0, 1, 2, 3, 4, 5, 6, 7, 8)
     v.checkVectorSemantics(
-      expecting: s,
-      writing: (9..<18).lazy.map { Double($0) },
+      expectingScalars: s,
+      writingScalars: (9..<18).lazy.map { Double($0) },
       maxSupportedScalarCount: 9)
     v.scalars.checkRandomAccessCollectionSemantics(
       expecting: s,

--- a/Tests/SwiftFusionTests/Core/VectorNTests.swift
+++ b/Tests/SwiftFusionTests/Core/VectorNTests.swift
@@ -8,7 +8,7 @@ import XCTest
 import SwiftFusion
 
 
-class ConcreteVectorTests: XCTestCase {
+class VectorNTests: XCTestCase {
 
   /// Test that initializing a vector from coordinate values works.
   func testVector1Init() {
@@ -16,6 +16,17 @@ class ConcreteVectorTests: XCTestCase {
     XCTAssertEqual(vector1.x, 1)
   }
 
+  func testVector1VectorConformance() {
+    let s = (0..<1).lazy.map { Double($0) }
+    let v = Vector1(0)
+    v.checkVectorSemantics(
+      expecting: s,
+      writing: (1..<2).lazy.map { Double($0) },
+      maxSupportedScalarCount: 1)
+    v.scalars.checkRandomAccessCollectionSemantics(
+      expecting: s,
+      maxSupportedCount: 1)
+  }
 
   /// Test that initializing a vector from coordinate values works.
   func testVector2Init() {
@@ -24,6 +35,17 @@ class ConcreteVectorTests: XCTestCase {
     XCTAssertEqual(vector1.y, 2)
   }
 
+  func testVector2VectorConformance() {
+    let s = (0..<2).lazy.map { Double($0) }
+    let v = Vector2(0, 1)
+    v.checkVectorSemantics(
+      expecting: s,
+      writing: (2..<4).lazy.map { Double($0) },
+      maxSupportedScalarCount: 2)
+    v.scalars.checkRandomAccessCollectionSemantics(
+      expecting: s,
+      maxSupportedCount: 2)
+  }
 
   /// Test that initializing a vector from coordinate values works.
   func testVector3Init() {
@@ -33,6 +55,17 @@ class ConcreteVectorTests: XCTestCase {
     XCTAssertEqual(vector1.z, 3)
   }
 
+  func testVector3VectorConformance() {
+    let s = (0..<3).lazy.map { Double($0) }
+    let v = Vector3(0, 1, 2)
+    v.checkVectorSemantics(
+      expecting: s,
+      writing: (3..<6).lazy.map { Double($0) },
+      maxSupportedScalarCount: 3)
+    v.scalars.checkRandomAccessCollectionSemantics(
+      expecting: s,
+      maxSupportedCount: 3)
+  }
 
   /// Test that initializing a vector from coordinate values works.
   func testVector4Init() {
@@ -43,6 +76,17 @@ class ConcreteVectorTests: XCTestCase {
     XCTAssertEqual(vector1.s3, 4)
   }
 
+  func testVector4VectorConformance() {
+    let s = (0..<4).lazy.map { Double($0) }
+    let v = Vector4(0, 1, 2, 3)
+    v.checkVectorSemantics(
+      expecting: s,
+      writing: (4..<8).lazy.map { Double($0) },
+      maxSupportedScalarCount: 4)
+    v.scalars.checkRandomAccessCollectionSemantics(
+      expecting: s,
+      maxSupportedCount: 4)
+  }
 
   /// Test that initializing a vector from coordinate values works.
   func testVector5Init() {
@@ -54,6 +98,17 @@ class ConcreteVectorTests: XCTestCase {
     XCTAssertEqual(vector1.s4, 5)
   }
 
+  func testVector5VectorConformance() {
+    let s = (0..<5).lazy.map { Double($0) }
+    let v = Vector5(0, 1, 2, 3, 4)
+    v.checkVectorSemantics(
+      expecting: s,
+      writing: (5..<10).lazy.map { Double($0) },
+      maxSupportedScalarCount: 5)
+    v.scalars.checkRandomAccessCollectionSemantics(
+      expecting: s,
+      maxSupportedCount: 5)
+  }
 
   /// Test that initializing a vector from coordinate values works.
   func testVector6Init() {
@@ -66,6 +121,17 @@ class ConcreteVectorTests: XCTestCase {
     XCTAssertEqual(vector1.s5, 6)
   }
 
+  func testVector6VectorConformance() {
+    let s = (0..<6).lazy.map { Double($0) }
+    let v = Vector6(0, 1, 2, 3, 4, 5)
+    v.checkVectorSemantics(
+      expecting: s,
+      writing: (6..<12).lazy.map { Double($0) },
+      maxSupportedScalarCount: 6)
+    v.scalars.checkRandomAccessCollectionSemantics(
+      expecting: s,
+      maxSupportedCount: 6)
+  }
 
   /// Test that initializing a vector from coordinate values works.
   func testVector7Init() {
@@ -79,6 +145,17 @@ class ConcreteVectorTests: XCTestCase {
     XCTAssertEqual(vector1.s6, 7)
   }
 
+  func testVector7VectorConformance() {
+    let s = (0..<7).lazy.map { Double($0) }
+    let v = Vector7(0, 1, 2, 3, 4, 5, 6)
+    v.checkVectorSemantics(
+      expecting: s,
+      writing: (7..<14).lazy.map { Double($0) },
+      maxSupportedScalarCount: 7)
+    v.scalars.checkRandomAccessCollectionSemantics(
+      expecting: s,
+      maxSupportedCount: 7)
+  }
 
   /// Test that initializing a vector from coordinate values works.
   func testVector8Init() {
@@ -93,6 +170,17 @@ class ConcreteVectorTests: XCTestCase {
     XCTAssertEqual(vector1.s7, 8)
   }
 
+  func testVector8VectorConformance() {
+    let s = (0..<8).lazy.map { Double($0) }
+    let v = Vector8(0, 1, 2, 3, 4, 5, 6, 7)
+    v.checkVectorSemantics(
+      expecting: s,
+      writing: (8..<16).lazy.map { Double($0) },
+      maxSupportedScalarCount: 8)
+    v.scalars.checkRandomAccessCollectionSemantics(
+      expecting: s,
+      maxSupportedCount: 8)
+  }
 
   /// Test that initializing a vector from coordinate values works.
   func testVector9Init() {
@@ -108,77 +196,15 @@ class ConcreteVectorTests: XCTestCase {
     XCTAssertEqual(vector1.s8, 9)
   }
 
-}
-
-/// Tests the `Vector` requirements.
-class Vector1VectorTests: XCTestCase, FixedSizeVectorTests {
-  typealias Testee = Vector1
-  static var dimension: Int { return 1 }
-  func testAll() {
-    runAllFixedSizeVectorTests()
-  }
-}
-/// Tests the `Vector` requirements.
-class Vector2VectorTests: XCTestCase, FixedSizeVectorTests {
-  typealias Testee = Vector2
-  static var dimension: Int { return 2 }
-  func testAll() {
-    runAllFixedSizeVectorTests()
-  }
-}
-/// Tests the `Vector` requirements.
-class Vector3VectorTests: XCTestCase, FixedSizeVectorTests {
-  typealias Testee = Vector3
-  static var dimension: Int { return 3 }
-  func testAll() {
-    runAllFixedSizeVectorTests()
-  }
-}
-/// Tests the `Vector` requirements.
-class Vector4VectorTests: XCTestCase, FixedSizeVectorTests {
-  typealias Testee = Vector4
-  static var dimension: Int { return 4 }
-  func testAll() {
-    runAllFixedSizeVectorTests()
-  }
-}
-/// Tests the `Vector` requirements.
-class Vector5VectorTests: XCTestCase, FixedSizeVectorTests {
-  typealias Testee = Vector5
-  static var dimension: Int { return 5 }
-  func testAll() {
-    runAllFixedSizeVectorTests()
-  }
-}
-/// Tests the `Vector` requirements.
-class Vector6VectorTests: XCTestCase, FixedSizeVectorTests {
-  typealias Testee = Vector6
-  static var dimension: Int { return 6 }
-  func testAll() {
-    runAllFixedSizeVectorTests()
-  }
-}
-/// Tests the `Vector` requirements.
-class Vector7VectorTests: XCTestCase, FixedSizeVectorTests {
-  typealias Testee = Vector7
-  static var dimension: Int { return 7 }
-  func testAll() {
-    runAllFixedSizeVectorTests()
-  }
-}
-/// Tests the `Vector` requirements.
-class Vector8VectorTests: XCTestCase, FixedSizeVectorTests {
-  typealias Testee = Vector8
-  static var dimension: Int { return 8 }
-  func testAll() {
-    runAllFixedSizeVectorTests()
-  }
-}
-/// Tests the `Vector` requirements.
-class Vector9VectorTests: XCTestCase, FixedSizeVectorTests {
-  typealias Testee = Vector9
-  static var dimension: Int { return 9 }
-  func testAll() {
-    runAllFixedSizeVectorTests()
+  func testVector9VectorConformance() {
+    let s = (0..<9).lazy.map { Double($0) }
+    let v = Vector9(0, 1, 2, 3, 4, 5, 6, 7, 8)
+    v.checkVectorSemantics(
+      expecting: s,
+      writing: (9..<18).lazy.map { Double($0) },
+      maxSupportedScalarCount: 9)
+    v.scalars.checkRandomAccessCollectionSemantics(
+      expecting: s,
+      maxSupportedCount: 9)
   }
 }

--- a/Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb
+++ b/Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb
@@ -29,8 +29,8 @@ class VectorNTests: XCTestCase {
     let s = (0..<${dim}).lazy.map { Double($0) }
     let v = Vector${dim}(${', '.join([str(v) for v in range(dim)])})
     v.checkVectorSemantics(
-      expecting: s,
-      writing: (${dim}..<${2 * dim}).lazy.map { Double($0) },
+      expectingScalars: s,
+      writingScalars: (${dim}..<${2 * dim}).lazy.map { Double($0) },
       maxSupportedScalarCount: ${dim})
     v.scalars.checkRandomAccessCollectionSemantics(
       expecting: s,

--- a/Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb
+++ b/Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb
@@ -7,7 +7,7 @@ import SwiftFusion
 % import math
 % dims = range(1, 10)
 
-class ConcreteVectorTests: XCTestCase {
+class VectorNTests: XCTestCase {
   % for dim in dims:
   % if dim <= 3:
   %   coordinates = ['x', 'y', 'z'][0:dim]
@@ -25,16 +25,16 @@ class ConcreteVectorTests: XCTestCase {
     % end
   }
 
+  func testVector${dim}VectorConformance() {
+    let s = (0..<${dim}).lazy.map { Double($0) }
+    let v = Vector${dim}(${', '.join([str(v) for v in range(dim)])})
+    v.checkVectorSemantics(
+      expecting: s,
+      writing: (${dim}..<${2 * dim}).lazy.map { Double($0) },
+      maxSupportedScalarCount: ${dim})
+    v.scalars.checkRandomAccessCollectionSemantics(
+      expecting: s,
+      maxSupportedCount: ${dim})
+  }
   % end
 }
-
-% for dim in dims:
-/// Tests the `Vector` requirements.
-class Vector${dim}VectorTests: XCTestCase, FixedSizeVectorTests {
-  typealias Testee = Vector${dim}
-  static var dimension: Int { return ${dim} }
-  func testAll() {
-    runAllFixedSizeVectorTests()
-  }
-}
-% end

--- a/Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb
+++ b/Tests/SwiftFusionTests/Core/VectorNTests.swift.gyb
@@ -5,36 +5,36 @@ import XCTest
 import SwiftFusion
 
 % import math
-% dims = range(1, 10)
+% vectorSizes = range(1, 10)
 
 class VectorNTests: XCTestCase {
-  % for dim in dims:
-  % if dim <= 3:
-  %   coordinates = ['x', 'y', 'z'][0:dim]
+  % for N in vectorSizes:
+  % if N <= 3:
+  %   coordinates = ['x', 'y', 'z'][0:N]
   % else:
-  %   coordinates = ['s%d' % i for i in range(dim)]
+  %   coordinates = ['s%d' % i for i in range(N)]
   % end
-  % values1 = range(1, dim + 1)
-  % values2 = range(dim + 1, 2 * dim + 1)
+  % values1 = range(1, N + 1)
+  % values2 = range(N + 1, 2 * N + 1)
 
   /// Test that initializing a vector from coordinate values works.
-  func testVector${dim}Init() {
-    let vector1 = Vector${dim}(${', '.join([str(v) for v in values1])})
+  func testVector${N}Init() {
+    let vector1 = Vector${N}(${', '.join([str(v) for v in values1])})
     % for (index, coordinate) in enumerate(coordinates):
     XCTAssertEqual(vector1.${coordinate}, ${values1[index]})
     % end
   }
 
-  func testVector${dim}VectorConformance() {
-    let s = (0..<${dim}).lazy.map { Double($0) }
-    let v = Vector${dim}(${', '.join([str(v) for v in range(dim)])})
+  func testVector${N}VectorConformance() {
+    let s = (0..<${N}).lazy.map { Double($0) }
+    let v = Vector${N}(${', '.join([str(v) for v in range(N)])})
     v.checkVectorSemantics(
       expectingScalars: s,
-      writingScalars: (${dim}..<${2 * dim}).lazy.map { Double($0) },
-      maxSupportedScalarCount: ${dim})
+      writingScalars: (${N}..<${2 * N}).lazy.map { Double($0) },
+      maxSupportedScalarCount: ${N})
     v.scalars.checkRandomAccessCollectionSemantics(
       expecting: s,
-      maxSupportedCount: ${dim})
+      maxSupportedCount: ${N})
   }
   % end
 }

--- a/Tests/SwiftFusionTests/Inference/AnyArrayBufferTests.swift
+++ b/Tests/SwiftFusionTests/Inference/AnyArrayBufferTests.swift
@@ -1,0 +1,28 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import TensorFlow
+import XCTest
+
+import PenguinStructures
+import SwiftFusion
+
+class AnyArrayBufferTests: XCTestCase {
+  // TODO(#184): Make this test pass.
+  // func testVectorSemantics() {
+  //   let v = AnyVectorArrayBuffer(ArrayBuffer([Vector2(1, 2), Vector2(3, 4)]))
+  //   v.checkVectorSemantics(expecting: [1, 2, 3, 4], writing: [5, 6, 7, 8])
+  // }
+}

--- a/Tests/SwiftFusionTests/Inference/AnyArrayBufferTests.swift
+++ b/Tests/SwiftFusionTests/Inference/AnyArrayBufferTests.swift
@@ -23,6 +23,6 @@ class AnyArrayBufferTests: XCTestCase {
   // TODO(#184): Make this test pass.
   // func testVectorSemantics() {
   //   let v = AnyVectorArrayBuffer(ArrayBuffer([Vector2(1, 2), Vector2(3, 4)]))
-  //   v.checkVectorSemantics(expecting: [1, 2, 3, 4], writing: [5, 6, 7, 8])
+  //   v.checkVectorSemantics(expectingScalars: [1, 2, 3, 4], writingScalars: [5, 6, 7, 8])
   // }
 }


### PR DESCRIPTION
Adds a `checkVectorSemantics` method that checks the recently-added `Scalars` and `scalars` requirements.

Migrates all the existing vector semantics checks to be inside of `checkVectorSemantics` too.