### PR TITLE
#filePath fixes

### DIFF
--- a/Tests/BeeDatasetTests/BeeDatasetTests.swift
+++ b/Tests/BeeDatasetTests/BeeDatasetTests.swift
@@ -48,7 +48,7 @@ final class BeeDatasetTests: XCTestCase {
 
 extension URL {
   /// Creates a URL for the directory containing the caller's source file.
-  static func sourceFileDirectory(file: String = #file) -> URL {
+  static func sourceFileDirectory(file: String = #filePath) -> URL {
     return URL(fileURLWithPath: file).deletingLastPathComponent()
   }
 }

--- a/Tests/SwiftFusionTests/TestUtilities.swift
+++ b/Tests/SwiftFusionTests/TestUtilities.swift
@@ -98,7 +98,7 @@ public enum SimpleGaussianFactorGraph {
 
 extension URL {
   /// Creates a URL for the directory containing the caller's source file.
-  static func sourceFileDirectory(file: String = #file) -> URL {
+  static func sourceFileDirectory(file: String = #filePath) -> URL {
     return URL(fileURLWithPath: file).deletingLastPathComponent()
   }
 }

--- a/Tests/SwiftFusionTests/TestUtilities.swift
+++ b/Tests/SwiftFusionTests/TestUtilities.swift
@@ -11,7 +11,7 @@ func assertEqual<T: TensorFlowFloatingPoint>(
   guard x.shape == y.shape else {
     XCTFail(
       "shape mismatch: \(x.shape) is not equal to \(y.shape)",
-      file: file,
+      file: (file),
       line: line
     )
     return
@@ -19,7 +19,7 @@ func assertEqual<T: TensorFlowFloatingPoint>(
   XCTAssert(
     abs(x - y).max().scalarized() < accuracy,
     "value mismatch:\n\(x)\nis not equal to\n\(y)\nwith accuracy \(accuracy)",
-    file: file,
+    file: (file),
     line: line
   )
 }
@@ -39,7 +39,7 @@ func assertAllKeyPathEqual<T: KeyPathIterable>(
     XCTAssert(
       false,
       "value mismatch:\n\(x)\nis not equal to\n\(y)\nwith accuracy \(accuracy)",
-      file: file,
+      file: (file),
       line: line
     )
   }


### PR DESCRIPTION
* https://github.com/borglab/SwiftFusion/pull/166 fixed warnings on newer toolchains, but now it warns on older toolchains. I added parentheses to suppress warnings on the older toolchains.
* We were using `#file` to get the paths of some test fixtures. This will eventually stop working because of [SE-0274](https://github.com/apple/swift-evolution/blob/master/proposals/0274-magic-file.md). So I changed these to `#filePath`.

Fixes #169.