### PR TITLE
Eliminate as many uses of `static var zero` as possible

### DIFF
--- a/Sources/SwiftFusion/Core/Dictionary+Differentiable.swift
+++ b/Sources/SwiftFusion/Core/Dictionary+Differentiable.swift
@@ -16,7 +16,7 @@ extension Dictionary: Differentiable where Value: Differentiable {
   }
 
   public var zeroTangentVectorInitializer: () -> TangentVector {
-    { mapValues { v in v.zeroTangentVectorInitializer() } }
+    { mapValues { v in v.zeroTangentVector } }
   }
 }
 

--- a/Sources/SwiftFusion/Core/Dictionary+Differentiable.swift
+++ b/Sources/SwiftFusion/Core/Dictionary+Differentiable.swift
@@ -16,7 +16,7 @@ extension Dictionary: Differentiable where Value: Differentiable {
   }
 
   public var zeroTangentVectorInitializer: () -> TangentVector {
-    { mapValues { _ in .zero } }
+    { mapValues { v in v.zeroTangentVectorInitializer() } }
   }
 }
 

--- a/Sources/SwiftFusion/Core/LieGroup.swift
+++ b/Sources/SwiftFusion/Core/LieGroup.swift
@@ -165,7 +165,7 @@ extension LieGroupCoordinate {
   /// their implementation against the default implementation.
   public func defaultAdjointTranspose(_ v: LocalCoordinate) -> LocalCoordinate {
     // This works because the pullback of a linear function is its transpose.
-    return pullback(at: v.zeroTangentVectorInitializer(), in: { self.Adjoint($0) })(v)
+    return pullback(at: v.zeroTangentVector, in: { self.Adjoint($0) })(v)
   }
 }
 

--- a/Sources/SwiftFusion/Core/LieGroup.swift
+++ b/Sources/SwiftFusion/Core/LieGroup.swift
@@ -32,7 +32,7 @@ extension LieGroup {
   func vjpInverse() -> (value: Self, pullback: (TangentVector) -> TangentVector) {
     // Derivative from https://github.com/borglab/gtsam/blob/develop/doc/math.pdf section 5.3. We
     // use the transpose of the Adjoint because the pullback is the transpose of the differential.
-    return (self.inverse(), { TangentVector.zero - self.AdjointTranspose($0) })
+    return (self.inverse(), { -1 * self.AdjointTranspose($0) })
   }
 
   /// The group operation.
@@ -165,7 +165,7 @@ extension LieGroupCoordinate {
   /// their implementation against the default implementation.
   public func defaultAdjointTranspose(_ v: LocalCoordinate) -> LocalCoordinate {
     // This works because the pullback of a linear function is its transpose.
-    return pullback(at: LocalCoordinate.zero, in: { self.Adjoint($0) })(v)
+    return pullback(at: v.zeroTangentVectorInitializer(), in: { self.Adjoint($0) })(v)
   }
 }
 

--- a/Sources/SwiftFusion/Core/Manifold.swift
+++ b/Sources/SwiftFusion/Core/Manifold.swift
@@ -99,7 +99,7 @@ extension Manifold where Self.TangentVector == Coordinate.LocalCoordinate {
 
     return (
       value: coordinateStorage,
-      pullback(at: zeroTangentVectorInitializer()) { self.coordinateStorage.retract($0) }
+      pullback(at: zeroTangentVector) { self.coordinateStorage.retract($0) }
     )
   }
 

--- a/Sources/SwiftFusion/Core/Manifold.swift
+++ b/Sources/SwiftFusion/Core/Manifold.swift
@@ -99,7 +99,7 @@ extension Manifold where Self.TangentVector == Coordinate.LocalCoordinate {
 
     return (
       value: coordinateStorage,
-      pullback(at: Coordinate.LocalCoordinate.zero) { self.coordinateStorage.retract($0) }
+      pullback(at: zeroTangentVectorInitializer()) { self.coordinateStorage.retract($0) }
     )
   }
 

--- a/Sources/SwiftFusion/Core/Tuple+Vector.swift
+++ b/Sources/SwiftFusion/Core/Tuple+Vector.swift
@@ -43,7 +43,7 @@ extension Empty: Differentiable {
   public mutating func move(along direction: TangentVector) {}
   
   public var zeroTangentVectorInitializer: () -> TangentVector {
-    { .zero }
+    { .init() }
   }
 }
 
@@ -55,7 +55,7 @@ where Head: Differentiable, Tail: Differentiable, Tail.TangentVector: TupleProto
     tail.move(along: direction.tail)
   }
   public var zeroTangentVectorInitializer: () -> TangentVector {
-    { .zero }
+    { .init(head: head.zeroTangentVectorInitializer(), tail: tail.zeroTangentVectorInitializer()) }
   }
 }
 

--- a/Sources/SwiftFusion/Core/Tuple+Vector.swift
+++ b/Sources/SwiftFusion/Core/Tuple+Vector.swift
@@ -55,7 +55,7 @@ where Head: Differentiable, Tail: Differentiable, Tail.TangentVector: TupleProto
     tail.move(along: direction.tail)
   }
   public var zeroTangentVectorInitializer: () -> TangentVector {
-    { .init(head: head.zeroTangentVectorInitializer(), tail: tail.zeroTangentVectorInitializer()) }
+    { .init(head: head.zeroTangentVector, tail: tail.zeroTangentVector) }
   }
 }
 

--- a/Sources/SwiftFusion/Core/Vector.swift
+++ b/Sources/SwiftFusion/Core/Vector.swift
@@ -216,8 +216,7 @@ extension FixedSizeVector {
   @differentiable
   public init<V: FixedSizeVector>(_ v: V) {
     precondition(Self.dimension == V.dimension)
-    self = Self.zero
-    self.scalars.assign(v.scalars)
+    self.init(v.scalars)
   }
 
   @derivative(of: init(_:))
@@ -235,8 +234,7 @@ extension FixedSizeVector {
   @differentiable
   public init<V1: FixedSizeVector, V2: FixedSizeVector>(concatenating v1: V1, _ v2: V2) {
     precondition(Self.dimension == V1.dimension + V2.dimension)
-    self = Self.zero
-    scalars.assign(v1.scalars.concatenated(to: v2.scalars))
+    self.init(v1.scalars.concatenated(to: v2.scalars))
   }
 
   @derivative(of: init(concatenating:_:))
@@ -248,11 +246,8 @@ extension FixedSizeVector {
     return (
       Self(concatenating: v1, v2),
       { t in
-        var r: (V1, V2) = (.zero, .zero)
         let p = t.scalars.index(atOffset: V1.dimension)
-        r.0.scalars.assign(t.scalars[..<p])
-        r.1.scalars.assign(t.scalars[p...])
-        return r
+        return (.init(t.scalars[..<p]), .init(t.scalars[p...]))
       }
     )
   }

--- a/Sources/SwiftFusion/Image/Patch.swift
+++ b/Sources/SwiftFusion/Image/Patch.swift
@@ -46,7 +46,7 @@ extension ArrayImage {
     let channels = self.channels
     func outerPb(_ dOut: TangentVector) -> OrientedBoundingBox.TangentVector {
       var idx = 0
-      var dBox = region.zeroTangentVectorInitializer()
+      var dBox = region.zeroTangentVector
       for i in 0..<region.rows {
         for j in 0..<region.cols {
           // The position of the destination pixel in the destination image, in `(u, v)` coordinates.

--- a/Sources/SwiftFusion/Image/Patch.swift
+++ b/Sources/SwiftFusion/Image/Patch.swift
@@ -46,7 +46,7 @@ extension ArrayImage {
     let channels = self.channels
     func outerPb(_ dOut: TangentVector) -> OrientedBoundingBox.TangentVector {
       var idx = 0
-      var dBox = OrientedBoundingBox.TangentVector.zero
+      var dBox = region.zeroTangentVectorInitializer()
       for i in 0..<region.rows {
         for j in 0..<region.cols {
           // The position of the destination pixel in the destination image, in `(u, v)` coordinates.

--- a/Sources/SwiftFusion/Inference/AnyArrayBuffer+Differentiable.swift
+++ b/Sources/SwiftFusion/Inference/AnyArrayBuffer+Differentiable.swift
@@ -77,6 +77,6 @@ extension AnyArrayBuffer: Differentiable where Dispatch: DifferentiableArrayDisp
   }
 
   public var zeroTangentVectorInitializer: () -> TangentVector {
-    { .zero }
+    { .init(ArrayBuffer<Vector1>()) }
   }
 }

--- a/Sources/SwiftFusion/Inference/ArrayBuffer+Tensor.swift
+++ b/Sources/SwiftFusion/Inference/ArrayBuffer+Tensor.swift
@@ -135,7 +135,7 @@ extension ArrayBuffer: AdditiveArithmetic where Element: AdditiveArithmetic {
     -> (value: ArrayBuffer, pullback: (TangentVector)->(TangentVector, TangentVector))
   where Element: Differentiable
   {
-    (lhs - rhs, { x in (x, .zero - x) })
+    (lhs - rhs, { x in (x, x.zeroTangentVectorInitializer() - x) })
   }
   
   /// Replaces `lhs` with the sum of `lhs` and `rhs`
@@ -175,7 +175,7 @@ extension ArrayBuffer: AdditiveArithmetic where Element: AdditiveArithmetic {
   where Element: Differentiable
   {
     lhs -= rhs
-    return ((), { x in .zero - x })
+    return ((), { x in x.zeroTangentVectorInitializer() - x })
   }
 }
 

--- a/Sources/SwiftFusion/Inference/ArrayBuffer+Tensor.swift
+++ b/Sources/SwiftFusion/Inference/ArrayBuffer+Tensor.swift
@@ -135,7 +135,7 @@ extension ArrayBuffer: AdditiveArithmetic where Element: AdditiveArithmetic {
     -> (value: ArrayBuffer, pullback: (TangentVector)->(TangentVector, TangentVector))
   where Element: Differentiable
   {
-    (lhs - rhs, { x in (x, x.zeroTangentVectorInitializer() - x) })
+    (lhs - rhs, { x in (x, x.zeroTangentVector - x) })
   }
   
   /// Replaces `lhs` with the sum of `lhs` and `rhs`
@@ -175,7 +175,7 @@ extension ArrayBuffer: AdditiveArithmetic where Element: AdditiveArithmetic {
   where Element: Differentiable
   {
     lhs -= rhs
-    return ((), { x in x.zeroTangentVectorInitializer() - x })
+    return ((), { x in x.zeroTangentVector - x })
   }
 }
 

--- a/Sources/SwiftFusion/Inference/ArrayBuffer+Vector.swift
+++ b/Sources/SwiftFusion/Inference/ArrayBuffer+Vector.swift
@@ -64,7 +64,7 @@ extension ArrayBuffer: Vector where Element: Vector {
   @differentiable
   public static func *= (lhs: inout ArrayBuffer, rhs: Double) -> Void {
     if lhs.isEmpty { return }
-    if rhs == 0 { lhs = .zero }
+    if rhs == 0 { lhs = .init() }
     else {
       lhs.update(elementwise: rhs, *=, { l, r in r * l })
     }
@@ -88,7 +88,7 @@ extension ArrayBuffer: Vector where Element: Vector {
   @differentiable
   public static func * (lhs: Double, rhs: ArrayBuffer) -> ArrayBuffer {
     if rhs.isEmpty { return rhs }
-    if lhs == 0 { return .zero }
+    if lhs == 0 { return .init() }
     return .init(rhs.lazy.map { lhs * $0 })
   }
 
@@ -165,7 +165,7 @@ extension ArrayBuffer: Vector where Element: Vector {
   private static func vjp_minus(lhs: ArrayBuffer, rhs: ArrayBuffer) 
     -> (value: ArrayBuffer, pullback: (TangentVector)->(TangentVector, TangentVector))
   {
-    (lhs - rhs, { x in (x, .zero - x) })
+    (lhs - rhs, { x in (x, -1 * x) })
   }
   
   /// Replaces `lhs` with the sum of `lhs` and `rhs`
@@ -217,6 +217,6 @@ extension ArrayBuffer: Vector where Element: Vector {
     -> (value: Void, pullback: (inout TangentVector)->(TangentVector))
   {
     lhs -= rhs
-    return ((), { x in .zero - x })
+    return ((), { x in -1 * x })
   }
 }

--- a/Sources/SwiftFusion/Inference/JacobianFactor.swift
+++ b/Sources/SwiftFusion/Inference/JacobianFactor.swift
@@ -86,6 +86,7 @@ where
   }
 
   public func errorVector_linearComponent_adjoint(_ y: ErrorVector) -> Variables {
+    // TODO(marcrasi): I was unable to remove .zero here.
     // We use `UnsafeBufferPointer`s to avoid forming collections that can't be optimized away.
     let r = y.withUnsafeBufferPointer { scalars in
       jacobian.withContiguousStorageIfAvailable { rows in


### PR DESCRIPTION
3.3% speedup on Pose3SLAM benchmark.
1.1% on Pose2SLAM