### PR TITLE
Remove more nondeterminism in MCMC test

### DIFF
--- a/Sources/SwiftFusion/MCMC/RandomWalkMetropolis.swift
+++ b/Sources/SwiftFusion/MCMC/RandomWalkMetropolis.swift
@@ -21,13 +21,13 @@ public class RandomWalkMetropolis<State> : TransitionKernel {
   public typealias Results = Double // target_log_prob_fn of previously accepted state
   
   let target_log_prob_fn: (State) -> Double
-  let new_state_fn : (State)->State
+  let new_state_fn : (State, inout AnyRandomNumberGenerator)->State
   var sourceOfEntropy: AnyRandomNumberGenerator
   
   public init(
     sourceOfEntropy: RandomNumberGenerator = SystemRandomNumberGenerator(),
     target_log_prob_fn: @escaping (State) -> Double,
-    new_state_fn : @escaping (State)->State
+    new_state_fn : @escaping (State, inout AnyRandomNumberGenerator)->State
   ) {
     self.target_log_prob_fn = target_log_prob_fn
     self.new_state_fn = new_state_fn
@@ -39,7 +39,7 @@ public class RandomWalkMetropolis<State> : TransitionKernel {
   public func one_step(_ current_state: State, _ previous_kernel_results: Results) -> (State, Results) {
     
     // calculate next state, and new log probability
-    let new_state = new_state_fn(current_state)
+    let new_state = new_state_fn(current_state, &sourceOfEntropy)
     let new_log_prob = target_log_prob_fn(new_state)
     
     // Calculate log of acceptance ratio p(x')/p(x) = log p(x') - log p(x)

--- a/Tests/SwiftFusionTests/MCMC/MCMCTests.swift
+++ b/Tests/SwiftFusionTests/MCMC/MCMCTests.swift
@@ -15,7 +15,7 @@ class MCMCTests: XCTestCase {
   /// Sampling from the Standard Normal Distribution.
   /// Inspired by testRWM1DUniform from tfp
   func testRWM1DUniform() throws {
-    var deterministicEntropy = ARC4RandomNumberGenerator(seed: 42)
+    let deterministicEntropy = ARC4RandomNumberGenerator(seed: 42)
     
     // Create kernel for MCMC sampler:
     // target_log_prob_fn is proportional to log p(x), where p is a zero-mean Gaussian
@@ -23,8 +23,8 @@ class MCMCTests: XCTestCase {
     // in this case perturbing x with uniformly sampled perturbations.
     let kernel = RandomWalkMetropolis(
       sourceOfEntropy: deterministicEntropy,
-      target_log_prob_fn: {(x:Double) in -0.5*x*x}, //  tfd.Normal(loc=dtype(0), scale=dtype(1))
-      new_state_fn: {(x:Double) in x + Double.random(in: -1..<1, using: &deterministicEntropy)}
+      target_log_prob_fn: {(x: Double) in -0.5*x*x}, //  tfd.Normal(loc=dtype(0), scale=dtype(1))
+      new_state_fn: {(x: Double, r: inout AnyRandomNumberGenerator) in x + Double.random(in: -1..<1, using: &r)}
     )
     
     // Run the sampler for 2500 steps, discarding the first 500 asa burn-in

--- a/Tests/SwiftFusionTests/MCMC/MCMCTests.swift
+++ b/Tests/SwiftFusionTests/MCMC/MCMCTests.swift
@@ -15,14 +15,16 @@ class MCMCTests: XCTestCase {
   /// Sampling from the Standard Normal Distribution.
   /// Inspired by testRWM1DUniform from tfp
   func testRWM1DUniform() throws {
+    var deterministicEntropy = ARC4RandomNumberGenerator(seed: 42)
+    
     // Create kernel for MCMC sampler:
     // target_log_prob_fn is proportional to log p(x), where p is a zero-mean Gaussian
     // new_state_fn is a symmetric (required for Metropolis) proposal density,
     // in this case perturbing x with uniformly sampled perturbations.
     let kernel = RandomWalkMetropolis(
-      sourceOfEntropy: ARC4RandomNumberGenerator(seed: 42),
+      sourceOfEntropy: deterministicEntropy,
       target_log_prob_fn: {(x:Double) in -0.5*x*x}, //  tfd.Normal(loc=dtype(0), scale=dtype(1))
-      new_state_fn: {(x:Double) in x + Double.random(in: -1..<1)}
+      new_state_fn: {(x:Double) in x + Double.random(in: -1..<1, using: &deterministicEntropy)}
     )
     
     // Run the sampler for 2500 steps, discarding the first 500 asa burn-in


### PR DESCRIPTION
Addresses, but by itself does not fix, #143.  Currently, the test fails deterministically.

@dellaert please take a look and make sure the test is correct.