### PR TITLE
Improve group actions

### DIFF
--- a/Sources/SwiftFusion/Geometry/Pose2.swift
+++ b/Sources/SwiftFusion/Geometry/Pose2.swift
@@ -85,8 +85,8 @@ extension Pose2 {
 extension Pose2 {
   /// Group action on `Vector2`.
   @differentiable
-  public static func * (lhs: Pose2, rhs: Vector2) -> Vector2 {
-    lhs.coordinate * rhs
+  public static func * (aTb: Pose2, bp: Vector2) -> Vector2 {
+    aTb.coordinate * bp
   }
 }
 
@@ -138,8 +138,8 @@ extension Pose2Coordinate: LieGroupCoordinate {
 extension Pose2Coordinate {
   /// Group action on `Vector2`.
   @differentiable
-  static func * (lhs: Pose2Coordinate, rhs: Vector2) -> Vector2 {
-    lhs.t + lhs.rot * rhs
+  static func * (aTb: Pose2Coordinate, bp: Vector2) -> Vector2 {
+    aTb.rot * bp + aTb.t
   }
 }
 

--- a/Sources/SwiftFusion/Geometry/Pose2.swift
+++ b/Sources/SwiftFusion/Geometry/Pose2.swift
@@ -138,7 +138,7 @@ extension Pose2Coordinate: LieGroupCoordinate {
 extension Pose2Coordinate {
   /// Group action on `Vector2`.
   @differentiable
-  public static func * (lhs: Pose2Coordinate, rhs: Vector2) -> Vector2 {
+  static func * (lhs: Pose2Coordinate, rhs: Vector2) -> Vector2 {
     lhs.t + lhs.rot * rhs
   }
 }

--- a/Sources/SwiftFusion/Geometry/Pose2.swift
+++ b/Sources/SwiftFusion/Geometry/Pose2.swift
@@ -133,7 +133,9 @@ extension Pose2Coordinate: LieGroupCoordinate {
   public func inverse() -> Pose2Coordinate {
     Pose2Coordinate(self.rot.inverse(), self.rot.unrotate(-self.t))
   }
+}
 
+extension Pose2Coordinate {
   /// Group action on `Vector2`.
   @differentiable
   public static func * (lhs: Pose2Coordinate, rhs: Vector2) -> Vector2 {

--- a/Sources/SwiftFusion/Geometry/Pose3.swift
+++ b/Sources/SwiftFusion/Geometry/Pose3.swift
@@ -35,6 +35,14 @@ public struct Pose3: LieGroup, Equatable, KeyPathIterable {
   }
 }
 
+extension Pose3 {
+  /// Group action on `Vector3`.
+  @differentiable
+  public static func * (_ lhs: Pose3, _ rhs: Vector3) -> Vector3 {
+    lhs.coordinate * rhs
+  }
+}
+
 // MARK: - Global Coordinate System
 
 public struct Pose3Coordinate: Equatable, KeyPathIterable {
@@ -94,6 +102,14 @@ extension Pose3Coordinate: LieGroupCoordinate {
   @differentiable
   public func inverse() -> Pose3Coordinate {
     Pose3Coordinate(self.rot.inverse(), self.rot.unrotate(-self.t))
+  }
+}
+
+extension Pose3Coordinate {
+  /// Group action on `Vector3`.
+  @differentiable
+  static func * (_ lhs: Pose3Coordinate, _ rhs: Vector3) -> Vector3 {
+    lhs.t + lhs.rot * rhs
   }
 }
 

--- a/Sources/SwiftFusion/Geometry/Pose3.swift
+++ b/Sources/SwiftFusion/Geometry/Pose3.swift
@@ -38,8 +38,8 @@ public struct Pose3: LieGroup, Equatable, KeyPathIterable {
 extension Pose3 {
   /// Group action on `Vector3`.
   @differentiable
-  public static func * (_ lhs: Pose3, _ rhs: Vector3) -> Vector3 {
-    lhs.coordinate * rhs
+  public static func * (_ aTb: Pose3, _ bp: Vector3) -> Vector3 {
+    aTb.coordinate * bp
   }
 }
 
@@ -108,8 +108,8 @@ extension Pose3Coordinate: LieGroupCoordinate {
 extension Pose3Coordinate {
   /// Group action on `Vector3`.
   @differentiable
-  static func * (_ lhs: Pose3Coordinate, _ rhs: Vector3) -> Vector3 {
-    lhs.t + lhs.rot * rhs
+  static func * (_ aTb: Pose3Coordinate, _ bp: Vector3) -> Vector3 {
+    aTb.rot * bp + aTb.t
   }
 }
 

--- a/Sources/SwiftFusion/Geometry/Rot2.swift
+++ b/Sources/SwiftFusion/Geometry/Rot2.swift
@@ -48,23 +48,25 @@ extension Rot2: CustomDebugStringConvertible {
   }
 }
 
+/// Group actions
 extension Rot2 {
   /// Returns the result of acting `self` on `v`.
   @differentiable
-  func rotate(_ v: Vector2) -> Vector2 {
+  public func rotate(_ v: Vector2) -> Vector2 {
     Vector2(c * v.x - s * v.y, s * v.x + c * v.y)
   }
 
   /// Returns the result of acting the inverse of `self` on `v`.
   @differentiable
-  func unrotate(_ v: Vector2) -> Vector2 {
+  public func unrotate(_ v: Vector2) -> Vector2 {
     Vector2(c * v.x + s * v.y, -s * v.x + c * v.y)
   }
-}
 
-@differentiable
-func * (r: Rot2, p: Vector2) -> Vector2 {
-  r.rotate(p)
+  /// Syntactic sugar for rotate()
+  @differentiable
+  static public func * (r: Rot2, p: Vector2) -> Vector2 {
+    r.rotate(p)
+  }
 }
 
 // MARK: - Global coordinate system

--- a/Sources/SwiftFusion/Geometry/Rot2.swift
+++ b/Sources/SwiftFusion/Geometry/Rot2.swift
@@ -62,10 +62,10 @@ extension Rot2 {
     coordinate.unrotate(v)
   }
 
-  /// Returns the result of acting `self` on `v`.
+  /// Returns the result of acting `aRb` on `bp`.
   @differentiable
-  public static func * (r: Rot2, p: Vector2) -> Vector2 {
-    r.rotate(p)
+  public static func * (aRb: Rot2, bp: Vector2) -> Vector2 {
+    aRb.rotate(bp)
   }
 }
 

--- a/Sources/SwiftFusion/Geometry/Rot2.swift
+++ b/Sources/SwiftFusion/Geometry/Rot2.swift
@@ -62,9 +62,9 @@ extension Rot2 {
     Vector2(c * v.x + s * v.y, -s * v.x + c * v.y)
   }
 
-  /// Syntactic sugar for rotate()
+  /// Returns the result of acting `self` on `v`, syntactic sugar for rotate()
   @differentiable
-  static public func * (r: Rot2, p: Vector2) -> Vector2 {
+  public static func * (r: Rot2, p: Vector2) -> Vector2 {
     r.rotate(p)
   }
 }

--- a/Sources/SwiftFusion/Geometry/Rot2.swift
+++ b/Sources/SwiftFusion/Geometry/Rot2.swift
@@ -48,7 +48,7 @@ extension Rot2: CustomDebugStringConvertible {
   }
 }
 
-/// Group actions
+/// Group actions.
 extension Rot2 {
   /// Returns the result of acting `self` on `v`.
   @differentiable

--- a/Sources/SwiftFusion/Geometry/Rot2.swift
+++ b/Sources/SwiftFusion/Geometry/Rot2.swift
@@ -53,16 +53,16 @@ extension Rot2 {
   /// Returns the result of acting `self` on `v`.
   @differentiable
   public func rotate(_ v: Vector2) -> Vector2 {
-    Vector2(c * v.x - s * v.y, s * v.x + c * v.y)
+    coordinate.rotate(v)
   }
 
   /// Returns the result of acting the inverse of `self` on `v`.
   @differentiable
   public func unrotate(_ v: Vector2) -> Vector2 {
-    Vector2(c * v.x + s * v.y, -s * v.x + c * v.y)
+    coordinate.unrotate(v)
   }
 
-  /// Returns the result of acting `self` on `v`, syntactic sugar for rotate()
+  /// Returns the result of acting `self` on `v`
   @differentiable
   public static func * (r: Rot2, p: Vector2) -> Vector2 {
     r.rotate(p)
@@ -120,6 +120,20 @@ extension Rot2Coordinate: ManifoldCoordinate {
   @differentiable(wrt: global)
   public func localCoordinate(_ global: Self) -> Vector1 {
     Vector1((self.inverse() * global).theta)
+  }
+}
+
+extension Rot2Coordinate {
+  /// Returns the result of acting `self` on `v`.
+  @differentiable
+  func rotate(_ v: Vector2) -> Vector2 {
+    Vector2(c * v.x - s * v.y, s * v.x + c * v.y)
+  }
+
+  /// Returns the result of acting the inverse of `self` on `v`.
+  @differentiable
+  func unrotate(_ v: Vector2) -> Vector2 {
+    Vector2(c * v.x + s * v.y, -s * v.x + c * v.y)
   }
 }
 

--- a/Sources/SwiftFusion/Geometry/Rot2.swift
+++ b/Sources/SwiftFusion/Geometry/Rot2.swift
@@ -62,7 +62,7 @@ extension Rot2 {
     coordinate.unrotate(v)
   }
 
-  /// Returns the result of acting `self` on `v`
+  /// Returns the result of acting `self` on `v`.
   @differentiable
   public static func * (r: Rot2, p: Vector2) -> Vector2 {
     r.rotate(p)

--- a/Sources/SwiftFusion/Geometry/Rot3.swift
+++ b/Sources/SwiftFusion/Geometry/Rot3.swift
@@ -54,7 +54,7 @@ public struct Rot3: LieGroup, Equatable, KeyPathIterable {
   }  
 }
 
-/// Group actions
+/// Group actions.
 extension Rot3 {
   /// Returns the result of acting `self` on `v`.
   @differentiable

--- a/Sources/SwiftFusion/Geometry/Rot3.swift
+++ b/Sources/SwiftFusion/Geometry/Rot3.swift
@@ -68,10 +68,10 @@ extension Rot3 {
     coordinate.unrotate(v)
   }
   
-  /// Returns the result of acting `self` on `v`.
+  /// Returns the result of acting `aRb` on `bp`.
   @differentiable
-  public static func * (r: Rot3, p: Vector3) -> Vector3 {
-    r.rotate(p)
+  public static func * (aRb: Rot3, bp: Vector3) -> Vector3 {
+    aRb.rotate(bp)
   }
 }
 

--- a/Sources/SwiftFusion/Geometry/Rot3.swift
+++ b/Sources/SwiftFusion/Geometry/Rot3.swift
@@ -55,13 +55,13 @@ public struct Rot3: LieGroup, Equatable, KeyPathIterable {
   
   /// Returns the result of acting `self` on `v`.
   @differentiable
-  func rotate(_ v: Vector3) -> Vector3 {
+  public func rotate(_ v: Vector3) -> Vector3 {
     return coordinate.rotate(v)
   }
   
   /// Returns the result of acting the inverse of `self` on `v`.
   @differentiable
-  func unrotate(_ v: Vector3) -> Vector3 {
+  public func unrotate(_ v: Vector3) -> Vector3 {
     return coordinate.unrotate(v)
   }
   

--- a/Sources/SwiftFusion/Geometry/Rot3.swift
+++ b/Sources/SwiftFusion/Geometry/Rot3.swift
@@ -67,7 +67,7 @@ public struct Rot3: LieGroup, Equatable, KeyPathIterable {
   
   /// Returns the result of acting `self` on `v`.
   @differentiable
-  static func * (r: Rot3, p: Vector3) -> Vector3 {
+  public static func * (r: Rot3, p: Vector3) -> Vector3 {
     r.rotate(p)
   }
 }

--- a/Sources/SwiftFusion/Geometry/Rot3.swift
+++ b/Sources/SwiftFusion/Geometry/Rot3.swift
@@ -51,18 +51,21 @@ public struct Rot3: LieGroup, Equatable, KeyPathIterable {
       txy+twz, 1.0-(txx+tzz), tyz-twx,
       txz-twy, tyz+twx, 1.0-(txx+tyy)
     )
-  }
-  
+  }  
+}
+
+/// Group actions
+extension Rot3 {
   /// Returns the result of acting `self` on `v`.
   @differentiable
   public func rotate(_ v: Vector3) -> Vector3 {
-    return coordinate.rotate(v)
+    coordinate.rotate(v)
   }
   
   /// Returns the result of acting the inverse of `self` on `v`.
   @differentiable
   public func unrotate(_ v: Vector3) -> Vector3 {
-    return coordinate.unrotate(v)
+    coordinate.unrotate(v)
   }
   
   /// Returns the result of acting `self` on `v`.
@@ -146,12 +149,12 @@ extension Matrix3Coordinate: LieGroupCoordinate {
 
   @differentiable(wrt: v)
   public func Adjoint(_ v: Vector3) -> Vector3 {
-    return rotate(v)
+    rotate(v)
   }
 
   @differentiable(wrt: v)
   public func AdjointTranspose(_ v: Vector3) -> Vector3 {
-    return unrotate(v)
+    unrotate(v)
   }
 }
 
@@ -160,13 +163,13 @@ extension Matrix3Coordinate {
   /// Returns the result of acting `self` on `v`.
   @differentiable
   func rotate(_ v: Vector3) -> Vector3 {
-    return matvec(R, v)
+    matvec(R, v)
   }
 
   /// Returns the result of acting the inverse of `self` on `v`.
   @differentiable
   func unrotate(_ v: Vector3) -> Vector3 {
-    return matvec(R.transposed(), v)
+    matvec(R.transposed(), v)
   }
 }
 

--- a/Tests/SwiftFusionTests/Geometry/Pose2Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Pose2Tests.swift
@@ -357,8 +357,30 @@ final class Pose2Tests: XCTestCase {
     }
   }
 
-  // Check group action
-  func testAction() {
+  /// Tests group action: translate only
+  func testActionTranslate() {
+    let x = Vector2(1.0, -2.0)
+    let pose = Pose2(-3.0, 4.0, 0.0)
+
+    let expected = Vector2(-2.0, 2.0)
+    let actual = pose * x
+
+    assertAllKeyPathEqual(actual, expected, accuracy: 1e-9)
+  }
+
+  /// Tests group action: rotate only
+  func testActionRotate() {
+    let x = Vector2(1.0, 2.0)
+    let pose = Pose2(0.0, 0.0, 0.5)
+
+    let expected = Vector2(-0.08126851531803325,  2.2345906623849485)
+    let actual = pose * x
+
+    assertAllKeyPathEqual(actual, expected, accuracy: 1e-9)
+  }
+
+  /// Tests group action: translate and rotate
+  func testActionTranslateRotate() {
     let x = Vector2(1.0, -2.0)
     let pose = Pose2(-3.0, 4.0, 0.5)
 

--- a/Tests/SwiftFusionTests/Geometry/Pose2Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Pose2Tests.swift
@@ -365,7 +365,6 @@ final class Pose2Tests: XCTestCase {
     let expected = Vector2(-1.1635663609012212, 2.7242604148234575)
     let actual = pose * x
 
-    XCTAssertEqual(actual.x, expected.x, accuracy: 1e-9)
-    XCTAssertEqual(actual.y, expected.y, accuracy: 1e-9)
+    assertAllKeyPathEqual(actual, expected, accuracy: 1e-9)
   }
 }

--- a/Tests/SwiftFusionTests/Geometry/Pose2Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Pose2Tests.swift
@@ -359,33 +359,35 @@ final class Pose2Tests: XCTestCase {
 
   /// Tests group action: translate only
   func testActionTranslate() {
-    let x = Vector2(1.0, -2.0)
-    let pose = Pose2(-3.0, 4.0, 0.0)
+    let p = Vector2(4.0, -2.0)
+    let T = Pose2(-3.0, 4.0, 0.0)
 
-    let expected = Vector2(-2.0, 2.0)
-    let actual = pose * x
+    let expected = Vector2(1.0, 2.0)
+    let actual = T * p
 
     assertAllKeyPathEqual(actual, expected, accuracy: 1e-9)
   }
 
   /// Tests group action: rotate only
   func testActionRotate() {
-    let x = Vector2(1.0, 2.0)
-    let pose = Pose2(0.0, 0.0, 0.5)
+    let p = Vector2(4.0, -2.0)
+    let T = Pose2(0.0, 0.0, 60.0 * .pi / 180.0)
 
-    let expected = Vector2(-0.08126851531803325,  2.2345906623849485)
-    let actual = pose * x
+    // Rotation by +60 deg
+    let expected = Vector2(2.0 + .sqrt(3.0), 2.0 * .sqrt(3.0) - 1.0)
+    let actual = T * p
 
     assertAllKeyPathEqual(actual, expected, accuracy: 1e-9)
   }
 
   /// Tests group action: translate and rotate
   func testActionTranslateRotate() {
-    let x = Vector2(1.0, -2.0)
-    let pose = Pose2(-3.0, 4.0, 0.5)
+    let p = Vector2(4.0, -2.0)
+    let T = Pose2(-3.0, 4.0, 60.0 * .pi / 180.0)
 
-    let expected = Vector2(-1.1635663609012212, 2.7242604148234575)
-    let actual = pose * x
+    // Rotation by +60 deg followed by translation by -3.0, 4.0
+    let expected = Vector2(-1.0 + .sqrt(3.0), 2.0 * .sqrt(3.0) + 3.0)
+    let actual = T * p
 
     assertAllKeyPathEqual(actual, expected, accuracy: 1e-9)
   }

--- a/Tests/SwiftFusionTests/Geometry/Pose2Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Pose2Tests.swift
@@ -356,4 +356,16 @@ final class Pose2Tests: XCTestCase {
       }
     }
   }
+
+  // Check group action
+  func testAction() {
+    let x = Vector2(1.0, -2.0)
+    let pose = Pose2(-3.0, 4.0, 0.5)
+
+    let expected = Vector2(-1.1635663609012212, 2.7242604148234575)
+    let actual = pose * x
+
+    XCTAssertEqual(actual.x, expected.x, accuracy: 1e-9)
+    XCTAssertEqual(actual.y, expected.y, accuracy: 1e-9)
+  }
 }

--- a/Tests/SwiftFusionTests/Geometry/Pose3Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Pose3Tests.swift
@@ -159,33 +159,49 @@ final class Pose3Tests: XCTestCase {
 
   /// Tests group action: translate only
   func testActionTranslate() {
-    let x = Vector3(1.0, -2.0, 3.0)
-    let pose = Pose3(Rot3(), Vector3(3.0, -4.0, -5.0))
+    let p = Vector3(1.0, -2.0, 3.0)
+    let T = Pose3(Rot3(), Vector3(3.0, -4.0, -5.0))
 
     let expected = Vector3(4.0, -6.0, -2.0)
-    let actual = pose * x
+    let actual = T * p
 
     assertAllKeyPathEqual(actual, expected, accuracy: 1e-9)
   }
 
-  /// Tests group action: rotate only
+  /// Tests group action: rotate only, basic rotations
   func testActionRotate() {
-    let x = Vector3(1.0, -2.0, 3.0)
-    let pose = Pose3(Rot3.fromTangent(Vector3(0.1, 0.2, -0.3)), Vector3(0, 0, 0))
+    let p = Vector3(2.0, -4.0, 6.0)
+    let Tx = Pose3(Rot3.fromTangent(Vector3(60.0 * .pi / 180.0, 0.0, 0.0)), Vector3(0.0, 0.0, 0.0))
+    let Ty = Pose3(Rot3.fromTangent(Vector3(0.0, -30.0 * .pi / 180.0, 0.0)), Vector3(0.0, 0.0, 0.0))
+    let Tz = Pose3(Rot3.fromTangent(Vector3(0.0, 0.0, 150.0 * .pi / 180.0)), Vector3(0.0, 0.0, 0.0))
 
-    let expected = Vector3(0.871509606555838, -2.5663299211301474, 2.5796165880985145)
-    let actual = pose * x
+    // Basic rotations along coordinate axes
+    let expectedRx = Vector3(2.0, -2.0 - 3.0 * .sqrt(3.0), -2.0 * .sqrt(3.0) + 3.0)
+    let expectedRy = Vector3(.sqrt(3.0) - 3.0, -4.0, 1.0 + 3.0 * .sqrt(3.0))
+    let expectedRz = Vector3(-.sqrt(3.0) + 2.0, 1.0 + 2.0 * .sqrt(3.0), 6.0)
 
-    assertAllKeyPathEqual(actual, expected, accuracy: 1e-9)
+    let actualRx = Tx * p
+    let actualRy = Ty * p
+    let actualRz = Tz * p
+
+    assertAllKeyPathEqual(actualRx, expectedRx, accuracy: 1e-9)
+    assertAllKeyPathEqual(actualRy, expectedRy, accuracy: 1e-9)
+    assertAllKeyPathEqual(actualRz, expectedRz, accuracy: 1e-9)
   }
 
   /// Tests group action: translate and rotate
   func testActionTranslateRotate() {
-    let x = Vector3(1.0, -2.0, 3.0)
-    let pose = Pose3(Rot3.fromTangent(Vector3(0.1, 0.2, -0.3)), Vector3(3.0, -4.0, -5.0))
+    let p = Vector3(1.0, -2.0, 3.0)
+    let T = Pose3(Rot3.fromTangent(Vector3(0.1, 0.2, -0.3)), Vector3(3.0, -4.0, -5.0))
 
+    // Expected value generated using the following Python script:
+    // import numpy as np
+    // import cv2
+    // np.set_printoptions(precision=16)
+    // R = cv2.Rodrigues(np.array([0.1, 0.2, -0.3]))[0]
+    // R.dot(np.array([1.0, -2.0, 3.0])) + np.array([3.0, -4.0, -5.0])
     let expected = Vector3(3.871509606555838, -6.566329921130148, -2.4203834119014855)
-    let actual = pose * x
+    let actual = T * p
 
     assertAllKeyPathEqual(actual, expected, accuracy: 1e-9)
   }

--- a/Tests/SwiftFusionTests/Geometry/Pose3Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Pose3Tests.swift
@@ -156,4 +156,37 @@ final class Pose3Tests: XCTestCase {
       }
     }
   }
+
+  /// Tests group action: translate only
+  func testActionTranslate() {
+    let x = Vector3(1.0, -2.0, 3.0)
+    let pose = Pose3(Rot3(), Vector3(3.0, -4.0, -5.0))
+
+    let expected = Vector3(4.0, -6.0, -2.0)
+    let actual = pose * x
+
+    assertAllKeyPathEqual(actual, expected, accuracy: 1e-9)
+  }
+
+  /// Tests group action: rotate only
+  func testActionRotate() {
+    let x = Vector3(1.0, -2.0, 3.0)
+    let pose = Pose3(Rot3.fromTangent(Vector3(0.1, 0.2, -0.3)), Vector3(0, 0, 0))
+
+    let expected = Vector3(0.871509606555838, -2.5663299211301474, 2.5796165880985145)
+    let actual = pose * x
+
+    assertAllKeyPathEqual(actual, expected, accuracy: 1e-9)
+  }
+
+  /// Tests group action: translate and rotate
+  func testActionTranslateRotate() {
+    let x = Vector3(1.0, -2.0, 3.0)
+    let pose = Pose3(Rot3.fromTangent(Vector3(0.1, 0.2, -0.3)), Vector3(3.0, -4.0, -5.0))
+
+    let expected = Vector3(3.871509606555838, -6.566329921130148, -2.4203834119014855)
+    let actual = pose * x
+
+    assertAllKeyPathEqual(actual, expected, accuracy: 1e-9)
+  }
 }

--- a/Tests/SwiftFusionTests/Geometry/Rot2Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Rot2Tests.swift
@@ -116,11 +116,8 @@ final class Rot2Tests: XCTestCase {
     let actual1 = R.rotate(x)
     let actual2 = R * x
 
-    XCTAssertEqual(actual1.x, expected.x, accuracy: 1e-9)
-    XCTAssertEqual(actual1.y, expected.y, accuracy: 1e-9)
-
-    XCTAssertEqual(actual2.x, expected.x, accuracy: 1e-9)
-    XCTAssertEqual(actual2.y, expected.y, accuracy: 1e-9)
+    assertAllKeyPathEqual(actual1, expected, accuracy: 1e-9)
+    assertAllKeyPathEqual(actual2, expected, accuracy: 1e-9)
   }
 
   // Check group action: unrotate
@@ -130,7 +127,6 @@ final class Rot2Tests: XCTestCase {
 
     let actual = R.unrotate(R.rotate(x))
 
-    XCTAssertEqual(actual.x, x.x, accuracy: 1e-9)
-    XCTAssertEqual(actual.y, x.y, accuracy: 1e-9)
+    assertAllKeyPathEqual(actual, x, accuracy: 1e-9)
   }
 }

--- a/Tests/SwiftFusionTests/Geometry/Rot2Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Rot2Tests.swift
@@ -113,9 +113,14 @@ final class Rot2Tests: XCTestCase {
     let R = Rot2(0.5)
 
     let expected = Vector2(-0.08126851531803325,  2.2345906623849485)
+    let actual1 = R.rotate(x)
+    let actual2 = R * x
 
-    XCTAssertEqual(R.rotate(x), expected)
-    XCTAssertEqual(R * x, expected)
+    XCTAssertEqual(actual1.x, expected.x, accuracy: 1e-9)
+    XCTAssertEqual(actual1.y, expected.y, accuracy: 1e-9)
+
+    XCTAssertEqual(actual2.x, expected.x, accuracy: 1e-9)
+    XCTAssertEqual(actual2.y, expected.y, accuracy: 1e-9)
   }
 
   // Check group action: unrotate
@@ -123,6 +128,9 @@ final class Rot2Tests: XCTestCase {
     let x = Vector2(1.0, 2.0)
     let R = Rot2(0.5)
 
-    XCTAssertEqual(R.unrotate(R.rotate(x)), x)
+    let actual = R.unrotate(R.rotate(x))
+
+    XCTAssertEqual(actual.x, x.x, accuracy: 1e-9)
+    XCTAssertEqual(actual.y, x.y, accuracy: 1e-9)
   }
 }

--- a/Tests/SwiftFusionTests/Geometry/Rot2Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Rot2Tests.swift
@@ -109,12 +109,13 @@ final class Rot2Tests: XCTestCase {
 
   // Check group action: rotate
   func testRotate() {
-    let x = Vector2(1.0, 2.0)
-    let R = Rot2(0.5)
+    let p = Vector2(4.0, -2.0)
+    let R = Rot2(60.0 * .pi / 180.0)
 
-    let expected = Vector2(-0.08126851531803325,  2.2345906623849485)
-    let actual1 = R.rotate(x)
-    let actual2 = R * x
+    // Rotation by +60 deg
+    let expected = Vector2(2.0 + .sqrt(3.0), 2.0 * .sqrt(3.0) - 1.0)
+    let actual1 = R.rotate(p)
+    let actual2 = R * p
 
     assertAllKeyPathEqual(actual1, expected, accuracy: 1e-9)
     assertAllKeyPathEqual(actual2, expected, accuracy: 1e-9)
@@ -122,11 +123,12 @@ final class Rot2Tests: XCTestCase {
 
   // Check group action: unrotate
   func testUnrotate() {
-    let x = Vector2(1.0, 2.0)
-    let R = Rot2(0.5)
+    let p = Vector2(4.0, -2.0)
+    let R = Rot2(60.0 * .pi / 180.0)
 
-    let actual = R.unrotate(R.rotate(x))
+    // Should be identity
+    let actual = R.unrotate(R.rotate(p))
 
-    assertAllKeyPathEqual(actual, x, accuracy: 1e-9)
+    assertAllKeyPathEqual(actual, p, accuracy: 1e-9)
   }
 }

--- a/Tests/SwiftFusionTests/Geometry/Rot2Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Rot2Tests.swift
@@ -106,4 +106,23 @@ final class Rot2Tests: XCTestCase {
 
     XCTAssertEqual(R1.theta, R2.theta, accuracy: 1e-5)
   }
+
+  // Check group action: rotate
+  func testRotate() {
+    let x = Vector2(1.0, 2.0)
+    let R = Rot2(0.5)
+
+    let expected = Vector2(-0.08126851531803325,  2.2345906623849485)
+
+    XCTAssertEqual(R.rotate(x), expected)
+    XCTAssertEqual(R * x, expected)
+  }
+
+  // Check group action: unrotate
+  func testUnrotate() {
+    let x = Vector2(1.0, 2.0)
+    let R = Rot2(0.5)
+
+    XCTAssertEqual(R.unrotate(R.rotate(x)), x)
+  }
 }

--- a/Tests/SwiftFusionTests/Geometry/Rot3Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Rot3Tests.swift
@@ -189,4 +189,34 @@ final class Rot3Tests: XCTestCase {
     let diff_normal = R1.localCoordinate(R2)
     assertAllKeyPathEqual(diff, diff_normal, accuracy: 1e-2)
   }
+
+    // Check group action: rotate
+  func testRotate() {
+    let x = Vector3(1.0, -2.0, 3.0)
+    let R = Rot3.fromTangent(Vector3(0.1, 0.2, -0.3))
+
+    let expected = Vector3(0.871509606555838, -2.5663299211301474, 2.5796165880985145)
+    let actual1 = R.rotate(x)
+    let actual2 = R * x
+
+    XCTAssertEqual(actual1.x, expected.x, accuracy: 1e-9)
+    XCTAssertEqual(actual1.y, expected.y, accuracy: 1e-9)
+    XCTAssertEqual(actual1.z, expected.z, accuracy: 1e-9)
+
+    XCTAssertEqual(actual2.x, expected.x, accuracy: 1e-9)
+    XCTAssertEqual(actual2.y, expected.y, accuracy: 1e-9)
+    XCTAssertEqual(actual2.z, expected.z, accuracy: 1e-9)
+  }
+
+  // Check group action: unrotate
+  func testUnrotate() {
+    let x = Vector3(1.0, -2.0, 3.0)
+    let R = Rot3.fromTangent(Vector3(0.1, 0.2, -0.3))
+
+    let actual = R.unrotate(R.rotate(x))
+
+    XCTAssertEqual(actual.x, x.x, accuracy: 1e-9)
+    XCTAssertEqual(actual.y, x.y, accuracy: 1e-9)
+    XCTAssertEqual(actual.z, x.z, accuracy: 1e-9)
+  }
 }

--- a/Tests/SwiftFusionTests/Geometry/Rot3Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Rot3Tests.swift
@@ -190,7 +190,7 @@ final class Rot3Tests: XCTestCase {
     assertAllKeyPathEqual(diff, diff_normal, accuracy: 1e-2)
   }
 
-    // Check group action: rotate
+  // Check group action: rotate
   func testRotate() {
     let x = Vector3(1.0, -2.0, 3.0)
     let R = Rot3.fromTangent(Vector3(0.1, 0.2, -0.3))

--- a/Tests/SwiftFusionTests/Geometry/Rot3Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Rot3Tests.swift
@@ -190,14 +190,47 @@ final class Rot3Tests: XCTestCase {
     assertAllKeyPathEqual(diff, diff_normal, accuracy: 1e-2)
   }
 
-  // Check group action: rotate
-  func testRotate() {
-    let x = Vector3(1.0, -2.0, 3.0)
+  // Check group action: basic rotations
+  func testRotateBasic() {
+    let p = Vector3(2.0, -4.0, 6.0)
+    let Rx = Rot3.fromTangent(Vector3(60.0 * .pi / 180.0, 0.0, 0.0))
+    let Ry = Rot3.fromTangent(Vector3(0.0, -30.0 * .pi / 180.0, 0.0))
+    let Rz = Rot3.fromTangent(Vector3(0.0, 0.0, 150.0 * .pi / 180.0))
+
+    // Basic rotations along coordinate axes
+    let expectedRx = Vector3(2.0, -2.0 - 3.0 * .sqrt(3.0), -2.0 * .sqrt(3.0) + 3.0)
+    let expectedRy = Vector3(.sqrt(3.0) - 3.0, -4.0, 1.0 + 3.0 * .sqrt(3.0))
+    let expectedRz = Vector3(-.sqrt(3.0) + 2.0, 1.0 + 2.0 * .sqrt(3.0), 6.0)
+
+    let actualRx1 = Rx.rotate(p)
+    let actualRx2 = Rx * p
+    let actualRy1 = Ry.rotate(p)
+    let actualRy2 = Ry * p
+    let actualRz1 = Rz.rotate(p)
+    let actualRz2 = Rz * p
+
+    assertAllKeyPathEqual(actualRx1, expectedRx, accuracy: 1e-9)
+    assertAllKeyPathEqual(actualRx2, expectedRx, accuracy: 1e-9)
+    assertAllKeyPathEqual(actualRy1, expectedRy, accuracy: 1e-9)
+    assertAllKeyPathEqual(actualRy2, expectedRy, accuracy: 1e-9)
+    assertAllKeyPathEqual(actualRz1, expectedRz, accuracy: 1e-9)
+    assertAllKeyPathEqual(actualRz2, expectedRz, accuracy: 1e-9)
+  }
+
+  // Check group action: rotation along arbitrary axis
+  func testRotateArbitrary() {
+    let p = Vector3(1.0, -2.0, 3.0)
     let R = Rot3.fromTangent(Vector3(0.1, 0.2, -0.3))
 
+    // Expected value generated using the following Python script:
+    // import numpy as np
+    // import cv2
+    // np.set_printoptions(precision=16)
+    // R = cv2.Rodrigues(np.array([0.1, 0.2, -0.3]))[0]
+    // R.dot(np.array([1.0, -2.0, 3.0]))
     let expected = Vector3(0.871509606555838, -2.5663299211301474, 2.5796165880985145)
-    let actual1 = R.rotate(x)
-    let actual2 = R * x
+    let actual1 = R.rotate(p)
+    let actual2 = R * p
 
     assertAllKeyPathEqual(actual1, expected, accuracy: 1e-9)
     assertAllKeyPathEqual(actual2, expected, accuracy: 1e-9)
@@ -205,11 +238,12 @@ final class Rot3Tests: XCTestCase {
 
   // Check group action: unrotate
   func testUnrotate() {
-    let x = Vector3(1.0, -2.0, 3.0)
+    let p = Vector3(1.0, -2.0, 3.0)
     let R = Rot3.fromTangent(Vector3(0.1, 0.2, -0.3))
 
-    let actual = R.unrotate(R.rotate(x))
+    // Should be identity
+    let actual = R.unrotate(R.rotate(p))
 
-    assertAllKeyPathEqual(actual, x, accuracy: 1e-9)
+    assertAllKeyPathEqual(actual, p, accuracy: 1e-9)
   }
 }

--- a/Tests/SwiftFusionTests/Geometry/Rot3Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Rot3Tests.swift
@@ -199,13 +199,8 @@ final class Rot3Tests: XCTestCase {
     let actual1 = R.rotate(x)
     let actual2 = R * x
 
-    XCTAssertEqual(actual1.x, expected.x, accuracy: 1e-9)
-    XCTAssertEqual(actual1.y, expected.y, accuracy: 1e-9)
-    XCTAssertEqual(actual1.z, expected.z, accuracy: 1e-9)
-
-    XCTAssertEqual(actual2.x, expected.x, accuracy: 1e-9)
-    XCTAssertEqual(actual2.y, expected.y, accuracy: 1e-9)
-    XCTAssertEqual(actual2.z, expected.z, accuracy: 1e-9)
+    assertAllKeyPathEqual(actual1, expected, accuracy: 1e-9)
+    assertAllKeyPathEqual(actual2, expected, accuracy: 1e-9)
   }
 
   // Check group action: unrotate
@@ -215,8 +210,6 @@ final class Rot3Tests: XCTestCase {
 
     let actual = R.unrotate(R.rotate(x))
 
-    XCTAssertEqual(actual.x, x.x, accuracy: 1e-9)
-    XCTAssertEqual(actual.y, x.y, accuracy: 1e-9)
-    XCTAssertEqual(actual.z, x.z, accuracy: 1e-9)
+    assertAllKeyPathEqual(actual, x, accuracy: 1e-9)
   }
 }


### PR DESCRIPTION
`Rot2`:

- [x] Make public
- [x] Create group actions in `Rot2Coordinate`
- [x] Move group actions to a separate extension

`Rot3`:

- [x] Make public
- [x] Move group actions to a separate extension

`Pose2`:

- [x] Move group action in `Pose2Coordinate` to a separate extension

`Pose3`:

- [x] Create group action