### PR TITLE
fix Package.swift

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/saeta/penguin.git",
         "state": {
           "branch": "master",
-          "revision": "056ba98601ea5273647893d1c00ecf82919382d4",
+          "revision": "5b7f5b297b5273bcbfc1cb9ebc2ada45ee69b0df",
           "version": null
         }
       },
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "3e7d2fe99da091dcc1e4a7dd22fc3cfc2dca7937",
-          "version": "0.2.2"
+          "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
+          "version": "0.3.1"
         }
       },
       {
@@ -32,8 +32,8 @@
         "package": "swift-models",
         "repositoryURL": "https://github.com/tensorflow/swift-models.git",
         "state": {
-          "branch": null,
-          "revision": "99f323e550f7f0c3ed32d31a3c5d11a0f3c51e4b",
+          "branch": "swiftfusion",
+          "revision": "e5dd47f292413610215833811eac2e9338384a8a",
           "version": null
         }
       },
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-protobuf.git",
         "state": {
           "branch": null,
-          "revision": "cc10a0a3149579d36bc546d97064884cb818f324",
-          "version": "1.11.0"
+          "revision": "0279688c9fc5a40028e1b5bb0cb56534a45a6020",
+          "version": "1.12.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
 
     .package(url: "https://github.com/ProfFan/tensorboardx-s4tf.git", from: "0.1.3"),
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("swift-5.2-branch")),
-    .package(url: "https://github.com/tensorflow/swift-models.git", .branch("99f323e550f7f0c3ed32d31a3c5d11a0f3c51e4b")),
+    .package(url: "https://github.com/tensorflow/swift-models.git", .branch("swiftfusion")),
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
A dependency published a new version that prevented swiftpm dependency resolution from working. I patched swift-models to fix the dependency, and this PR updates SwiftFusion to used the patched swift-models.