### PR TITLE
defer all code that must run post-yield.

### DIFF
--- a/Sources/SwiftFusion/Core/VectorN.swift
+++ b/Sources/SwiftFusion/Core/VectorN.swift
@@ -73,8 +73,8 @@ extension Vector1: AdditiveArithmetic, Vector {
         precondition(i >= 0 && i < endIndex)
         let p = withUnsafeMutablePointer(to: &self) { $0 }
         let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        defer { _fixLifetime(self) }
         yield &q[i]
-        _fixLifetime(self)
       }
     }
   }
@@ -170,8 +170,8 @@ extension Vector2: AdditiveArithmetic, Vector {
         precondition(i >= 0 && i < endIndex)
         let p = withUnsafeMutablePointer(to: &self) { $0 }
         let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        defer { _fixLifetime(self) }
         yield &q[i]
-        _fixLifetime(self)
       }
     }
   }
@@ -275,8 +275,8 @@ extension Vector3: AdditiveArithmetic, Vector {
         precondition(i >= 0 && i < endIndex)
         let p = withUnsafeMutablePointer(to: &self) { $0 }
         let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        defer { _fixLifetime(self) }
         yield &q[i]
-        _fixLifetime(self)
       }
     }
   }
@@ -388,8 +388,8 @@ extension Vector4: AdditiveArithmetic, Vector {
         precondition(i >= 0 && i < endIndex)
         let p = withUnsafeMutablePointer(to: &self) { $0 }
         let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        defer { _fixLifetime(self) }
         yield &q[i]
-        _fixLifetime(self)
       }
     }
   }
@@ -509,8 +509,8 @@ extension Vector5: AdditiveArithmetic, Vector {
         precondition(i >= 0 && i < endIndex)
         let p = withUnsafeMutablePointer(to: &self) { $0 }
         let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        defer { _fixLifetime(self) }
         yield &q[i]
-        _fixLifetime(self)
       }
     }
   }
@@ -638,8 +638,8 @@ extension Vector6: AdditiveArithmetic, Vector {
         precondition(i >= 0 && i < endIndex)
         let p = withUnsafeMutablePointer(to: &self) { $0 }
         let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        defer { _fixLifetime(self) }
         yield &q[i]
-        _fixLifetime(self)
       }
     }
   }
@@ -775,8 +775,8 @@ extension Vector7: AdditiveArithmetic, Vector {
         precondition(i >= 0 && i < endIndex)
         let p = withUnsafeMutablePointer(to: &self) { $0 }
         let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        defer { _fixLifetime(self) }
         yield &q[i]
-        _fixLifetime(self)
       }
     }
   }
@@ -920,8 +920,8 @@ extension Vector8: AdditiveArithmetic, Vector {
         precondition(i >= 0 && i < endIndex)
         let p = withUnsafeMutablePointer(to: &self) { $0 }
         let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        defer { _fixLifetime(self) }
         yield &q[i]
-        _fixLifetime(self)
       }
     }
   }
@@ -1073,8 +1073,8 @@ extension Vector9: AdditiveArithmetic, Vector {
         precondition(i >= 0 && i < endIndex)
         let p = withUnsafeMutablePointer(to: &self) { $0 }
         let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        defer { _fixLifetime(self) }
         yield &q[i]
-        _fixLifetime(self)
       }
     }
   }
@@ -1234,8 +1234,8 @@ extension Vector10: AdditiveArithmetic, Vector {
         precondition(i >= 0 && i < endIndex)
         let p = withUnsafeMutablePointer(to: &self) { $0 }
         let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        defer { _fixLifetime(self) }
         yield &q[i]
-        _fixLifetime(self)
       }
     }
   }
@@ -1403,8 +1403,8 @@ extension Vector11: AdditiveArithmetic, Vector {
         precondition(i >= 0 && i < endIndex)
         let p = withUnsafeMutablePointer(to: &self) { $0 }
         let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        defer { _fixLifetime(self) }
         yield &q[i]
-        _fixLifetime(self)
       }
     }
   }
@@ -1580,8 +1580,8 @@ extension Vector12: AdditiveArithmetic, Vector {
         precondition(i >= 0 && i < endIndex)
         let p = withUnsafeMutablePointer(to: &self) { $0 }
         let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        defer { _fixLifetime(self) }
         yield &q[i]
-        _fixLifetime(self)
       }
     }
   }

--- a/Sources/SwiftFusion/Core/VectorN.swift.gyb
+++ b/Sources/SwiftFusion/Core/VectorN.swift.gyb
@@ -91,8 +91,8 @@ extension Vector${dim}: AdditiveArithmetic, Vector {
         precondition(i >= 0 && i < endIndex)
         let p = withUnsafeMutablePointer(to: &self) { $0 }
         let q = UnsafeMutableRawPointer(p).assumingMemoryBound(to: Double.self)
+        defer { _fixLifetime(self) }
         yield &q[i]
-        _fixLifetime(self)
       }
     }
   }

--- a/Sources/SwiftFusion/Inference/ArrayBuffer+Vector.swift
+++ b/Sources/SwiftFusion/Inference/ArrayBuffer+Vector.swift
@@ -53,8 +53,8 @@ extension ArrayBuffer: Vector where Element: Vector {
     _modify {
       var io = Scalars(base: self)
       self = ArrayBuffer() // Avoid CoWs
+      defer { swap(&self, &io.base) }
       yield &io
-      swap(&self, &io.base)
     }
   }
   


### PR DESCRIPTION
Otherwise code after yield won't run when the yielded-to code throws:
https://forums.swift.org/t/modify-accessors/31872/280

(`_fixLifetime` doesn't technically need to move, but it's best to be uniform).