### PR TITLE
Pinhole camera first draft

### DIFF
--- a/Sources/SwiftFusion/Geometry/Cal3_S2.swift
+++ b/Sources/SwiftFusion/Geometry/Cal3_S2.swift
@@ -34,15 +34,15 @@ public struct Cal3_S2: CameraCalibration, Equatable {
 /// CameraCalibration protocol conformance.
 extension Cal3_S2 {
   @differentiable
-  public func uncalibrate(_ pNormalized: Vector2) -> Vector2 {
+  public func uncalibrate(_ np: Vector2) -> Vector2 {
     Vector2(
-      fx * pNormalized.x + s * pNormalized.y + u0,
-      fy * pNormalized.y + v0)
+      fx * np.x + s * np.y + u0,
+      fy * np.y + v0)
   }
 
   @differentiable
-  public func calibrate(_ pImage: Vector2) -> Vector2 {
-    let (du, dv) = (pImage.x - u0, pImage.y - v0)
+  public func calibrate(_ ip: Vector2) -> Vector2 {
+    let (du, dv) = (ip.x - u0, ip.y - v0)
     let (fxInv, fyInv) = (1.0 / fx, 1.0 / fy)
     return Vector2(
       fxInv * du - s * fxInv * fyInv * dv,

--- a/Sources/SwiftFusion/Geometry/Cal3_S2.swift
+++ b/Sources/SwiftFusion/Geometry/Cal3_S2.swift
@@ -1,6 +1,6 @@
 
 /// The five-parameter camera calibration.
-public struct Cal3_S2: CameraCalibration, Manifold, Equatable {
+public struct Cal3_S2: Manifold, Equatable {
   public typealias Coordinate = Cal3_S2Coordinate
   public typealias TangentVector = Vector5
 
@@ -25,8 +25,8 @@ public struct Cal3_S2: CameraCalibration, Manifold, Equatable {
   }
 }
 
-/// CameraCalibration protocol conformance.
-extension Cal3_S2 {
+/// CameraCalibration conformance.
+extension Cal3_S2: CameraCalibration {
   @differentiable
   public func uncalibrate(_ np: Vector2) -> Vector2 {
     coordinate.uncalibrate(np)
@@ -38,9 +38,9 @@ extension Cal3_S2 {
   }
 }
 
-public struct Cal3_S2Coordinate: ManifoldCoordinate, Equatable {
-  public typealias LocalCoordinate = Vector5
 
+/// Manifold coordinate for Cal3_S2.
+public struct Cal3_S2Coordinate: Equatable {
   /// Focal length in X direction.
   public var fx: Double
 
@@ -85,6 +85,21 @@ public struct Cal3_S2Coordinate: ManifoldCoordinate, Equatable {
   }
 }
 
+/// ManifoldCoordinate conformance.
+extension Cal3_S2Coordinate: ManifoldCoordinate {
+  public typealias LocalCoordinate = Vector5
+
+  @differentiable(wrt: local)
+  public func retract(_ local: Vector5) -> Cal3_S2Coordinate {
+    Cal3_S2Coordinate(asVector() + local)
+  }
+
+  @differentiable(wrt: global)
+  public func localCoordinate(_ global: Cal3_S2Coordinate) -> Vector5 {
+    global.asVector() - asVector()
+  }
+}
+
 /// Operations on a point.
 extension Cal3_S2Coordinate {
   @differentiable
@@ -101,18 +116,5 @@ extension Cal3_S2Coordinate {
     return Vector2(
       fxInv * du - s * fxInv * fyInv * dv,
       fyInv * dv)
-  }
-}
-
-/// ManifoldCoordinate conformance.
-extension Cal3_S2Coordinate {
-  @differentiable(wrt: local)
-  public func retract(_ local: Vector5) -> Cal3_S2Coordinate {
-    Cal3_S2Coordinate(asVector() + local)
-  }
-
-  @differentiable(wrt: global)
-  public func localCoordinate(_ global: Cal3_S2Coordinate) -> Vector5 {
-    global.asVector() - asVector()
   }
 }

--- a/Sources/SwiftFusion/Geometry/Cal3_S2.swift
+++ b/Sources/SwiftFusion/Geometry/Cal3_S2.swift
@@ -104,17 +104,13 @@ extension Cal3_S2Coordinate: ManifoldCoordinate {
 extension Cal3_S2Coordinate {
   @differentiable
   public func uncalibrate(_ np: Vector2) -> Vector2 {
-    Vector2(
-      fx * np.x + s * np.y + u0,
-      fy * np.y + v0)
+    Vector2(fx * np.x + s * np.y + u0, fy * np.y + v0)
   }
 
   @differentiable
   public func calibrate(_ ip: Vector2) -> Vector2 {
     let (du, dv) = (ip.x - u0, ip.y - v0)
     let (fxInv, fyInv) = (1.0 / fx, 1.0 / fy)
-    return Vector2(
-      fxInv * du - s * fxInv * fyInv * dv,
-      fyInv * dv)
+    return Vector2(fxInv * du - s * fxInv * fyInv * dv, fyInv * dv)
   }
 }

--- a/Sources/SwiftFusion/Geometry/Cal3_S2.swift
+++ b/Sources/SwiftFusion/Geometry/Cal3_S2.swift
@@ -1,6 +1,46 @@
 
 /// The five-parameter camera calibration.
-public struct Cal3_S2: CameraCalibration, Equatable {
+public struct Cal3_S2: CameraCalibration, Manifold, Equatable {
+  public typealias Coordinate = Cal3_S2Coordinate
+  public typealias TangentVector = Vector5
+
+  public var coordinateStorage: Cal3_S2Coordinate
+
+  public init() {
+    self.init(coordinateStorage: Cal3_S2Coordinate())
+  }
+
+  public init(coordinateStorage: Cal3_S2Coordinate) {
+    self.coordinateStorage = coordinateStorage
+  }
+
+  /// Initializes from individual values.
+  public init(fx: Double, fy: Double, s: Double, u0: Double, v0: Double) {
+    self.init(coordinateStorage: Cal3_S2Coordinate(fx: fx, fy: fy, s: s, u0: u0, v0: v0))
+  }
+
+  /// Moves the parameter values by the specified direction.
+  public mutating func move(along direction: Vector5) {
+    coordinateStorage = coordinateStorage.retract(direction)
+  }
+}
+
+/// CameraCalibration protocol conformance.
+extension Cal3_S2 {
+  @differentiable
+  public func uncalibrate(_ np: Vector2) -> Vector2 {
+    coordinate.uncalibrate(np)
+  }
+
+  @differentiable
+  public func calibrate(_ ip: Vector2) -> Vector2 {
+    coordinate.calibrate(ip)
+  }
+}
+
+public struct Cal3_S2Coordinate: ManifoldCoordinate, Equatable {
+  public typealias LocalCoordinate = Vector5
+
   /// Focal length in X direction.
   public var fx: Double
 
@@ -25,14 +65,28 @@ public struct Cal3_S2: CameraCalibration, Equatable {
     self.v0 = v0
   }
 
+  /// Initializes from a vector.
+  public init(_ params: Vector5) {
+    self.fx = params.s0
+    self.fy = params.s1
+    self.s = params.s2
+    self.u0 = params.s3
+    self.v0 = params.s4
+  }
+
   /// Initializes with default values, corresponding to the identity element.
   public init() {
     self.init(fx: 1.0, fy: 1.0, s: 0.0, u0: 0.0, v0: 0.0)
   }
+
+  /// Returns the parameters as a vector.
+  public func asVector() -> Vector5 {
+    Vector5(fx, fy, s, u0, v0)
+  }
 }
 
-/// CameraCalibration protocol conformance.
-extension Cal3_S2 {
+/// Operations on a point.
+extension Cal3_S2Coordinate {
   @differentiable
   public func uncalibrate(_ np: Vector2) -> Vector2 {
     Vector2(
@@ -47,5 +101,18 @@ extension Cal3_S2 {
     return Vector2(
       fxInv * du - s * fxInv * fyInv * dv,
       fyInv * dv)
+  }
+}
+
+/// ManifoldCoordinate conformance.
+extension Cal3_S2Coordinate {
+  @differentiable(wrt: local)
+  public func retract(_ local: Vector5) -> Cal3_S2Coordinate {
+    Cal3_S2Coordinate(asVector() + local)
+  }
+
+  @differentiable(wrt: global)
+  public func localCoordinate(_ global: Cal3_S2Coordinate) -> Vector5 {
+    global.asVector() - asVector()
   }
 }

--- a/Sources/SwiftFusion/Geometry/Cal3_S2.swift
+++ b/Sources/SwiftFusion/Geometry/Cal3_S2.swift
@@ -1,0 +1,51 @@
+
+/// The five-parameter camera calibration.
+public struct Cal3_S2: CameraCalibration, Equatable {
+  /// Focal length in X direction.
+  public var fx: Double
+
+  /// Focal length in Y direction.
+  public var fy: Double
+
+  /// Skew factor.
+  public var s: Double
+
+  /// Image center in X direction.
+  public var u0: Double
+
+  /// Image center in Y direction.
+  public var v0: Double
+
+  /// Initializes from individual values.
+  public init(fx: Double, fy: Double, s: Double, u0: Double, v0: Double) {
+    self.fx = fx
+    self.fy = fy
+    self.s = s
+    self.u0 = u0
+    self.v0 = v0
+  }
+
+  /// Initializes with default values, corresponding to the identity element.
+  public init() {
+    self.init(fx: 1.0, fy: 1.0, s: 0.0, u0: 0.0, v0: 0.0)
+  }
+}
+
+/// CameraCalibration protocol conformance.
+extension Cal3_S2 {
+  @differentiable
+  public func uncalibrate(_ pNormalized: Vector2) -> Vector2 {
+    Vector2(
+      fx * pNormalized.x + s * pNormalized.y + u0,
+      fy * pNormalized.y + v0)
+  }
+
+  @differentiable
+  public func calibrate(_ pImage: Vector2) -> Vector2 {
+    let (du, dv) = (pImage.x - u0, pImage.y - v0)
+    let (fxInv, fyInv) = (1.0 / fx, 1.0 / fy)
+    return Vector2(
+      fxInv * du - s * fxInv * fyInv * dv,
+      fyInv * dv)
+  }
+}

--- a/Sources/SwiftFusion/Geometry/CameraCalibration.swift
+++ b/Sources/SwiftFusion/Geometry/CameraCalibration.swift
@@ -1,5 +1,5 @@
 
-/// A type for camera calibration parameters.
+/// A protocol for camera calibration parameters.
 public protocol CameraCalibration: Differentiable {
   /// Initializes to default (usually identity).
   init()

--- a/Sources/SwiftFusion/Geometry/CameraCalibration.swift
+++ b/Sources/SwiftFusion/Geometry/CameraCalibration.swift
@@ -1,14 +1,14 @@
 
 /// A type for camera calibration parameters.
 public protocol CameraCalibration: Differentiable {
-  /// Initializes to identity.
+  /// Initializes to default (usually identity).
   init()
 
   /// Converts from image coordinate to normalized coordinate.
   @differentiable
-  func calibrate(_ pImage: Vector2) -> Vector2
+  func calibrate(_ ip: Vector2) -> Vector2
 
   /// Converts from normalized coordinate to image coordinate.
   @differentiable
-  func uncalibrate(_ pNormalized: Vector2) -> Vector2
+  func uncalibrate(_ np: Vector2) -> Vector2
 }

--- a/Sources/SwiftFusion/Geometry/CameraCalibration.swift
+++ b/Sources/SwiftFusion/Geometry/CameraCalibration.swift
@@ -1,11 +1,14 @@
 
 /// A type for camera calibration parameters.
 public protocol CameraCalibration: Differentiable {
-  /// Converts from image coordinate to normalized coordinate
+  /// Initializes to identity.
+  init()
+
+  /// Converts from image coordinate to normalized coordinate.
   @differentiable
   func calibrate(_ pImage: Vector2) -> Vector2
 
-  /// Converts from normalized coordinate to image coordinate
+  /// Converts from normalized coordinate to image coordinate.
   @differentiable
   func uncalibrate(_ pNormalized: Vector2) -> Vector2
 }

--- a/Sources/SwiftFusion/Geometry/CameraCalibration.swift
+++ b/Sources/SwiftFusion/Geometry/CameraCalibration.swift
@@ -1,0 +1,11 @@
+
+/// A type for camera calibration parameters.
+public protocol CameraCalibration: Differentiable {
+  /// Converts from image coordinate to normalized coordinate
+  @differentiable
+  func calibrate(_ pImage: Vector2) -> Vector2
+
+  /// Converts from normalized coordinate to image coordinate
+  @differentiable
+  func uncalibrate(_ pNormalized: Vector2) -> Vector2
+}

--- a/Sources/SwiftFusion/Geometry/PinholeCamera.swift
+++ b/Sources/SwiftFusion/Geometry/PinholeCamera.swift
@@ -20,7 +20,7 @@ public struct PinholeCamera<Calibration: CameraCalibration>: Differentiable {
     self.init(calibration, Pose3())
   }
 
-  /// Initializes to default (identity calibration and pose).
+  /// Initializes to default.
   public init() {
     self.init(Calibration(), Pose3())
   }
@@ -36,7 +36,7 @@ extension PinholeCamera {
     return ip
   }
 
-  /// Backprojects a 2D image point into 3D point in the world frame with the specified depth.
+  /// Backprojects a 2D image point into 3D point in the world frame at given depth.
   @differentiable
   public func backproject(_ ip: Vector2, _ depth: Double) -> Vector3 {
     let np = calibration.calibrate(ip)
@@ -51,7 +51,7 @@ extension PinholeCamera {
     projectToNormalized(wp).ip
   }
 
-  /// Computes the derivative of projection function wrt to self and the point wp.
+  /// Computes the derivative of the projection function wrt to self and the point wp.
   @usableFromInline
   @derivative(of: projectToNormalized)
   func vjpProjectToNormalized(_ wp: Vector3) -> 

--- a/Sources/SwiftFusion/Geometry/PinholeCamera.swift
+++ b/Sources/SwiftFusion/Geometry/PinholeCamera.swift
@@ -1,0 +1,104 @@
+
+/// Pinhole camera model.
+public struct PinholeCamera<Calibration: CameraCalibration>: Differentiable {
+  /// Camera pose in the world/reference frame.
+  public var wTc: Pose3
+
+  /// Camera calibration.
+  public var calibration: Calibration
+
+  /// Initializes from camera pose and calibration.
+  @differentiable
+  public init(_ calibration: Calibration, _ wTc: Pose3) {
+    self.calibration = calibration
+    self.wTc = wTc
+  }
+
+  /// Initializes with identity pose.
+  @differentiable
+  public init(_ calibration: Calibration) {
+    self.init(calibration, Pose3())
+  }
+
+  /// Initializes to default (identity calibration and pose).
+  public init() {
+    self.init(Calibration(), Pose3())
+  }
+}
+
+/// Project and backproject.
+extension PinholeCamera {
+    /// Projects a 3D point in the world frame to 2D point in the image.
+  @differentiable
+  public func project(_ wp: Vector3) -> Vector2 {
+    let np: Vector2 = projectToNormalized(wp)
+    let ip = calibration.uncalibrate(np)
+    return ip
+  }
+
+  /// Backprojects a 2D image point into 3D point in the world frame with the specified depth.
+  @differentiable
+  public func backproject(_ ip: Vector2, _ depth: Double) -> Vector3 {
+    let np = calibration.calibrate(ip)
+    let cp = Vector3(np.x * depth, np.y * depth, depth)
+    let wp = wTc * cp
+    return wp
+  }
+
+  /// Projects a 3D point in the world frame to 2D normalized coordinate.
+  @differentiable
+  func projectToNormalized(_ wp: Vector3) -> Vector2 {
+    projectToNormalized(wp).ip
+  }
+
+  /// Computes the derivative of projection function wrt to self and the point wp.
+  @usableFromInline
+  @derivative(of: projectToNormalized)
+  func vjpProjectToNormalized(_ wp: Vector3) -> 
+    (value: Vector2, pullback: (Vector2) -> (TangentVector, Vector3))
+  {
+    let (ip, cRw, zInv) = projectToNormalized(wp)
+    let (u, v) = (ip.x, ip.y)
+    let R = cRw.coordinate.R
+    return (
+      value: ip,
+      pullback: { p in 
+        let dpose = Vector6(
+          p.x * (u * v) + p.y * (1 + v * v),
+          p.x * -(1 + u * u) + p.y * -(u * v),
+          p.x * v + p.y * -u,
+          p.x * -zInv,
+          p.y * -zInv,
+          p.x * (zInv * u) + p.y * (zInv * v))
+
+        let dpoint = zInv * Vector3(
+          p.x * (R[0, 0] - u * R[2, 0]) + p.y * (R[1, 0] - v * R[2, 0]),
+          p.x * (R[0, 1] - u * R[2, 1]) + p.y * (R[1, 1] - v * R[2, 1]),
+          p.x * (R[0, 2] - u * R[2, 2]) + p.y * (R[1, 2] - v * R[2, 2]))
+
+        return (
+          TangentVector(wTc: dpose, calibration: calibration.zeroTangentVector),
+          dpoint)
+      }
+    )
+  }
+
+  /// Projects a 3D point in the world frame to 2D normalized coordinate and returns intermediate values.
+  func projectToNormalized(_ wp: Vector3) ->
+    (ip: Vector2, cRw: Rot3, zInv: Double)
+  {
+    // Transform the point to camera coordinate
+    let cTw = wTc.inverse()
+    let cp = cTw * wp
+
+    // TODO: check for cheirality (whether the point is behind the camera)
+
+    // Project to normalized coordinate
+    let zInv = 1.0 / cp.z
+    
+    return (
+      ip: Vector2(cp.x * zInv, cp.y * zInv),
+      cRw: cTw.rot,
+      zInv: zInv)
+  }
+}

--- a/Tests/SwiftFusionTests/Geometry/Cal3_S2Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Cal3_S2Tests.swift
@@ -29,4 +29,18 @@ final class Cal3_S2Tests: XCTestCase {
 
     XCTAssertEqual(K.calibrate(K.uncalibrate(np)), np)
   }
+
+  /// Tests manifold.
+  func testManifold() {
+    var K1 = Cal3_S2(fx: 200.0, fy: 200.0, s: 1.0, u0: 320.0, v0: 240.0)
+    let K2 = Cal3_S2(fx: 201.0, fy: 202.0, s: 4.0, u0: 324.0, v0: 245.0)
+    let dK = Vector5(1.0, 2.0, 3.0, 4.0, 5.0)
+
+    XCTAssertEqual(K1.retract(dK), K2)
+    XCTAssertEqual(K1.localCoordinate(K2), dK)
+
+    K1.move(along: dK)
+    
+    XCTAssertEqual(K1, K2)
+  }
 }

--- a/Tests/SwiftFusionTests/Geometry/Cal3_S2Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Cal3_S2Tests.swift
@@ -15,18 +15,18 @@ final class Cal3_S2Tests: XCTestCase {
   /// Tests uncalibrate.
   func testCalibrateUncalibrate() {
     let K = Cal3_S2(fx: 200.0, fy: 200.0, s: 1.0, u0: 320.0, v0: 240.0)
-    let pNormalized = Vector2(1.0, 2.0)
+    let np = Vector2(1.0, 2.0)
     
     let expected = Vector2(522.0, 640.0)  // Manually calculated
 
-    XCTAssertEqual(K.uncalibrate(pNormalized), expected)
+    XCTAssertEqual(K.uncalibrate(np), expected)
   }
 
   /// Tests calibrate identity.
   func testCalibrateIdentity() {
     let K = Cal3_S2(fx: 200.0, fy: 200.0, s: 1.0, u0: 320.0, v0: 240.0)
-    let pNormalized = Vector2(1.0, 2.0)
+    let np = Vector2(1.0, 2.0)
 
-    XCTAssertEqual(K.calibrate(K.uncalibrate(pNormalized)), pNormalized)
+    XCTAssertEqual(K.calibrate(K.uncalibrate(np)), np)
   }
 }

--- a/Tests/SwiftFusionTests/Geometry/Cal3_S2Tests.swift
+++ b/Tests/SwiftFusionTests/Geometry/Cal3_S2Tests.swift
@@ -1,0 +1,32 @@
+
+import SwiftFusion
+import TensorFlow
+
+import XCTest
+
+final class Cal3_S2Tests: XCTestCase {
+  /// Tests default constructor.
+  func testConstructorDefault() {
+    let K1 = Cal3_S2()
+    let K2 = Cal3_S2(fx: 1.0, fy: 1.0, s: 0.0, u0: 0.0, v0: 0.0)
+    XCTAssertEqual(K1, K2)
+  }
+
+  /// Tests uncalibrate.
+  func testCalibrateUncalibrate() {
+    let K = Cal3_S2(fx: 200.0, fy: 200.0, s: 1.0, u0: 320.0, v0: 240.0)
+    let pNormalized = Vector2(1.0, 2.0)
+    
+    let expected = Vector2(522.0, 640.0)  // Manually calculated
+
+    XCTAssertEqual(K.uncalibrate(pNormalized), expected)
+  }
+
+  /// Tests calibrate identity.
+  func testCalibrateIdentity() {
+    let K = Cal3_S2(fx: 200.0, fy: 200.0, s: 1.0, u0: 320.0, v0: 240.0)
+    let pNormalized = Vector2(1.0, 2.0)
+
+    XCTAssertEqual(K.calibrate(K.uncalibrate(pNormalized)), pNormalized)
+  }
+}

--- a/Tests/SwiftFusionTests/Geometry/PinholeCameraTests.swift
+++ b/Tests/SwiftFusionTests/Geometry/PinholeCameraTests.swift
@@ -44,17 +44,17 @@ final class PinholeCameraTests: XCTestCase {
 
     // Manually compute the expected output. Example for wp1:
     // - Point in camera frame cp = (0.1, -0.1, 1.0)
-    // - Project into normalized coordinate pNormalized = (0.1, -0.1)
-    // - Uncalibrate to image coordinate pImage = (330, 230)
-    let pImage1 = Vector2(330.0, 230.0)
-    let pImage2 = Vector2(330.0, 250.0)
-    let pImage3 = Vector2(310.0, 250.0)
-    let pImage4 = Vector2(310.0, 230.0)
+    // - Project into normalized coordinate np = (0.1, -0.1)
+    // - Uncalibrate to image coordinate ip = (330, 230)
+    let ip1 = Vector2(330.0, 230.0)
+    let ip2 = Vector2(330.0, 250.0)
+    let ip3 = Vector2(310.0, 250.0)
+    let ip4 = Vector2(310.0, 230.0)
 
-    XCTAssertEqual(camera.project(wp1), pImage1)
-    XCTAssertEqual(camera.project(wp2), pImage2)
-    XCTAssertEqual(camera.project(wp3), pImage3)
-    XCTAssertEqual(camera.project(wp4), pImage4)
+    XCTAssertEqual(camera.project(wp1), ip1)
+    XCTAssertEqual(camera.project(wp2), ip2)
+    XCTAssertEqual(camera.project(wp3), ip3)
+    XCTAssertEqual(camera.project(wp4), ip4)
   }
 
   /// Tests the custom derivative for project to normalized coordinate.
@@ -76,10 +76,14 @@ final class PinholeCameraTests: XCTestCase {
 
     // Expected values computed by running through AD (disabling the custom derivative)
     let dxExpected = (
-      PinholeCamera<Cal3_S2>.TangentVector(wTc: Vector6(-1.0, -2.0, -1.0, -1.0, 0.0, 1.0), calibration: K.zeroTangentVector),
+      PinholeCamera<Cal3_S2>.TangentVector(
+        wTc: Vector6(-1.0, -2.0, -1.0, -1.0, 0.0, 1.0), 
+        calibration: K.zeroTangentVector),
       Vector3(1.0, 0.0, 1.0))
     let dyExpected = (
-      PinholeCamera<Cal3_S2>.TangentVector(wTc: Vector6(2.0, 1.0, -1.0, 0.0, -1.0, -1.0), calibration: K.zeroTangentVector),
+      PinholeCamera<Cal3_S2>.TangentVector(
+        wTc: Vector6(2.0, 1.0, -1.0, 0.0, -1.0, -1.0), 
+        calibration: K.zeroTangentVector),
       Vector3(0.0, -1.0, -1.0))
 
     assertAllKeyPathEqual(p, Vector2(1.0, -1.0), accuracy: 1e-10)
@@ -113,10 +117,7 @@ final class PinholeCameraTests: XCTestCase {
     let wp3 = Vector3(-0.1, -0.1, 0.0)
     let wp4 = Vector3(-0.1, 0.1, 0.0)
 
-    // Manually compute the expected output. Example for wp1:
-    // - Point in camera frame cp = (0.1, -0.1, 1.0)
-    // - Project into normalized coordinate pNormalized = (0.1, -0.1)
-    // - Uncalibrate to image coordinate pImage = (330, 230)
+    // See test for project
     let ip1 = Vector2(330.0, 230.0)
     let ip2 = Vector2(330.0, 250.0)
     let ip3 = Vector2(310.0, 250.0)

--- a/Tests/SwiftFusionTests/Geometry/PinholeCameraTests.swift
+++ b/Tests/SwiftFusionTests/Geometry/PinholeCameraTests.swift
@@ -1,0 +1,131 @@
+
+@testable import SwiftFusion
+import TensorFlow
+
+import XCTest
+
+final class PinholeCameraTests: XCTestCase {
+  /// Tests constructor for identity pose.
+  func testConstructorIdentityPose() {
+    let K = Cal3_S2(fx: 100.0, fy: 100.0, s: 0.0, u0: 320.0, v0: 240.0)
+    let camera = PinholeCamera(K)
+
+    XCTAssertEqual(camera.calibration, K)
+    XCTAssertEqual(camera.wTc, Pose3())
+  }
+
+  /// Tests default constructor.
+  func testConstructorDefault() {
+    let camera = PinholeCamera<Cal3_S2>()
+
+    XCTAssertEqual(camera.calibration, Cal3_S2())
+    XCTAssertEqual(camera.wTc, Pose3())
+  }
+
+  /// Tests project.
+  func testProject() {
+    let K = Cal3_S2(fx: 100.0, fy: 100.0, s: 0.0, u0: 320.0, v0: 240.0)
+
+    // Camera 1 unit away looking into the the world origin, X axes are aligned
+    let wTc = Pose3(
+      Rot3(
+        1, 0, 0,
+        0, -1, 0,
+        0, 0, -1), 
+      Vector3(0, 0, 1))
+    
+    let camera = PinholeCamera(K, wTc)
+
+    // A square of side 0.2 around the world origin
+    let wp1 = Vector3(0.1, 0.1, 0.0)
+    let wp2 = Vector3(0.1, -0.1, 0.0)
+    let wp3 = Vector3(-0.1, -0.1, 0.0)
+    let wp4 = Vector3(-0.1, 0.1, 0.0)
+
+    // Manually compute the expected output. Example for wp1:
+    // - Point in camera frame cp = (0.1, -0.1, 1.0)
+    // - Project into normalized coordinate pNormalized = (0.1, -0.1)
+    // - Uncalibrate to image coordinate pImage = (330, 230)
+    let pImage1 = Vector2(330.0, 230.0)
+    let pImage2 = Vector2(330.0, 250.0)
+    let pImage3 = Vector2(310.0, 250.0)
+    let pImage4 = Vector2(310.0, 230.0)
+
+    XCTAssertEqual(camera.project(wp1), pImage1)
+    XCTAssertEqual(camera.project(wp2), pImage2)
+    XCTAssertEqual(camera.project(wp3), pImage3)
+    XCTAssertEqual(camera.project(wp4), pImage4)
+  }
+
+  /// Tests the custom derivative for project to normalized coordinate.
+  func testPullbackProjectToNormalized() {
+    let K = Cal3_S2(fx: 100.0, fy: 100.0, s: 0.0, u0: 320.0, v0: 240.0)
+    let wTc = Pose3(
+      Rot3(
+        1, 0, 0,
+        0, -1, 0,
+        0, 0, -1), 
+      Vector3(0, 0, 1))
+    let camera = PinholeCamera(K, wTc)
+    
+    let wp = Vector3(1, 1, 0)
+
+    let (p, pb) = valueWithPullback(at: camera, wp) { $0.projectToNormalized($1) }
+    let dx = pb(Vector2(1, 0))
+    let dy = pb(Vector2(0, 1))
+
+    // Expected values computed by running through AD (disabling the custom derivative)
+    let dxExpected = (
+      PinholeCamera<Cal3_S2>.TangentVector(wTc: Vector6(-1.0, -2.0, -1.0, -1.0, 0.0, 1.0), calibration: K.zeroTangentVector),
+      Vector3(1.0, 0.0, 1.0))
+    let dyExpected = (
+      PinholeCamera<Cal3_S2>.TangentVector(wTc: Vector6(2.0, 1.0, -1.0, 0.0, -1.0, -1.0), calibration: K.zeroTangentVector),
+      Vector3(0.0, -1.0, -1.0))
+
+    assertAllKeyPathEqual(p, Vector2(1.0, -1.0), accuracy: 1e-10)
+
+    assertAllKeyPathEqual(dx.0.wTc, dxExpected.0.wTc, accuracy: 1e-10)
+    XCTAssertEqual(dx.0.calibration, dxExpected.0.calibration)
+    assertAllKeyPathEqual(dx.1, dxExpected.1, accuracy: 1e-10)
+    
+    assertAllKeyPathEqual(dy.0.wTc, dyExpected.0.wTc, accuracy: 1e-10)
+    XCTAssertEqual(dy.0.calibration, dyExpected.0.calibration)
+    assertAllKeyPathEqual(dy.1, dyExpected.1, accuracy: 1e-10)
+  }
+
+  /// Tests backproject
+  func testBackproject() {
+    let K = Cal3_S2(fx: 100.0, fy: 100.0, s: 0.0, u0: 320.0, v0: 240.0)
+
+    // Camera 1 unit away looking into the the world origin, X axes are aligned
+    let wTc = Pose3(
+      Rot3(
+        1, 0, 0,
+        0, -1, 0,
+        0, 0, -1), 
+      Vector3(0, 0, 1))
+    
+    let camera = PinholeCamera(K, wTc)
+
+    // A square of side 0.2 around the world origin
+    let wp1 = Vector3(0.1, 0.1, 0.0)
+    let wp2 = Vector3(0.1, -0.1, 0.0)
+    let wp3 = Vector3(-0.1, -0.1, 0.0)
+    let wp4 = Vector3(-0.1, 0.1, 0.0)
+
+    // Manually compute the expected output. Example for wp1:
+    // - Point in camera frame cp = (0.1, -0.1, 1.0)
+    // - Project into normalized coordinate pNormalized = (0.1, -0.1)
+    // - Uncalibrate to image coordinate pImage = (330, 230)
+    let ip1 = Vector2(330.0, 230.0)
+    let ip2 = Vector2(330.0, 250.0)
+    let ip3 = Vector2(310.0, 250.0)
+    let ip4 = Vector2(310.0, 230.0)
+
+    // Depth is 1 since the camera is 1 unit away
+    XCTAssertEqual(camera.backproject(ip1, 1.0), wp1)
+    XCTAssertEqual(camera.backproject(ip2, 1.0), wp2)
+    XCTAssertEqual(camera.backproject(ip3, 1.0), wp3)
+    XCTAssertEqual(camera.backproject(ip4, 1.0), wp4)
+  }
+}


### PR DESCRIPTION
Here's my first draft of the pinhole camera implementation. I based the structure on GTSAM. Some notes:
- Personally I feel like the name `Cal3_S2` is a bit confusing. I think the `3` and `2` seem redundant if we consider a camera to be a mapping from 3D world to 2D image, unless we extend the definition of a camera. Also it isn't immediately apparent what the `_S` part means. Maybe change it to something like `SimpleCalibration` or `CalSimple` or `CalSimpleWithSkew`?
- Not all calibration model has a closed-form inverse, especially for the distortion part. Most models are defined in the `uncalibrate()` direction from normalized coordinate to image coordinate. Requiring `calibrate()` in `CameraCalibration` means that some implementations may need to find solution through iteration. It feels like an additional layer of complexity hidden from user. However, `calibrate()` is needed to implement `backproject()`. I just think it's worth mentioning so that we are aware of the potential issue.

Let me know what you guys think!