### PR TITLE
remove algorithms that are in penguin now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@master
       - name: Install toolchain
         run: |
-          sudo xcode-select -s /Applications/Xcode_12_beta.app
+          sudo xcode-select -s /Applications/Xcode_12.2.app
           wget https://storage.googleapis.com/swift-tensorflow-artifacts/macos-toolchains/swift-tensorflow-DEVELOPMENT-2020-08-26-a-osx.pkg
           sudo installer -pkg swift-tensorflow-DEVELOPMENT-2020-08-26-a-osx.pkg -target /
           echo "::set-env name=PATH::/Library/Developer/Toolchains/swift-latest/usr/bin:${PATH}"

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/saeta/penguin.git",
         "state": {
           "branch": "master",
-          "revision": "056ba98601ea5273647893d1c00ecf82919382d4",
+          "revision": "b3a3bea7f1b3237183e446f37b7d28c7b19169b5",
           "version": null
         }
       },
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/google/swift-benchmark.git",
         "state": {
           "branch": "master",
-          "revision": "f70bf472b00aeaa05e2374373568c2fe459c11c7",
+          "revision": "9a47e0326086f7e0b2a8c69e56217485fd9aa80d",
           "version": null
         }
       },

--- a/Sources/SwiftFusion/Core/Vector.swift
+++ b/Sources/SwiftFusion/Core/Vector.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PenguinStructures
 import TensorFlow
 
 /// A vector, in a Euclidean vector space with standard orthonormal basis.

--- a/Sources/SwiftFusion/Inference/PenguinExtensions.swift
+++ b/Sources/SwiftFusion/Inference/PenguinExtensions.swift
@@ -754,66 +754,6 @@ extension Dictionary {
   }
 }
 
-extension MutableCollection {
-  mutating func writePrefix<I: IteratorProtocol>(from source: inout I)
-    -> (writtenCount: Int, unwrittenStart: Index)
-    where I.Element == Element
-  {
-    var writtenCount = 0
-    var unwrittenStart = startIndex
-    while unwrittenStart != endIndex {
-      guard let x = source.next() else { break }
-      self[unwrittenStart] = x
-      self.formIndex(after: &unwrittenStart)
-      writtenCount += 1
-    }
-    return (writtenCount, unwrittenStart)
-  }
-
-  mutating func writePrefix<Source: Collection>(from source: Source)
-    -> (writtenCount: Int, unwrittenStart: Index, unreadStart: Source.Index)
-    where Source.Element == Element
-  {
-    var writtenCount = 0
-    var unwrittenStart = startIndex
-    var unreadStart = source.startIndex
-    while unwrittenStart != endIndex && unreadStart != source.endIndex {
-      self[unwrittenStart] = source[unreadStart]
-      self.formIndex(after: &unwrittenStart)
-      source.formIndex(after: &unreadStart)
-      writtenCount += 1
-    }
-    return (writtenCount, unwrittenStart, unreadStart)
-  }
-
-  @discardableResult
-  mutating func assign<Source: Sequence>(_ sourceElements: Source) -> Int
-    where Source.Element == Element
-  {
-    var stream = sourceElements.makeIterator()
-    let (count, unwritten) = writePrefix(from: &stream)
-    precondition(unwritten == endIndex, "source too short")
-    precondition(stream.next() == nil, "source too long")
-    return count
-  }
-  
-  @discardableResult
-  mutating func assign<Source: Collection>(_ sourceElements: Source) -> Int
-    where Source.Element == Element
-  {
-    let (writtenCount, unwritten, unread) = writePrefix(from: sourceElements)
-    precondition(unwritten == endIndex, "source too short")
-    precondition(unread == sourceElements.endIndex, "source too long")
-    return writtenCount
-  }
-}
-
-extension Collection {
-  func index(atOffset n: Int) -> Index {
-    index(startIndex, offsetBy: n)
-  }
-}
-
 /// The consecutive `SubSequence`s of a `Base` collection having a given maximum size.
 struct Batched<Base: Collection>: Collection {
   public let base: Base


### PR DESCRIPTION
https://github.com/saeta/penguin/pull/120 moved these into Penguin.

For some reason, defining them in both places causes a compiler crash.

This PR fixes https://github.com/borglab/SwiftFusion/issues/194.