### PR TITLE
Use insertion ordered dictionary in TypeKeyedArrayBuffers

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/saeta/penguin.git",
         "state": {
           "branch": "master",
-          "revision": "b3a3bea7f1b3237183e446f37b7d28c7b19169b5",
+          "revision": "bb3118efc29779b123caa7a83f1694d9b92e9fa7",
           "version": null
         }
       },
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/google/swift-benchmark.git",
         "state": {
           "branch": "master",
-          "revision": "9a47e0326086f7e0b2a8c69e56217485fd9aa80d",
+          "revision": "34c2f072feb6aa74dcc5f2d8e066fe4f2a0af73c",
           "version": null
         }
       },

--- a/Sources/SwiftFusion/Inference/PenguinExtensions.swift
+++ b/Sources/SwiftFusion/Inference/PenguinExtensions.swift
@@ -754,6 +754,28 @@ extension Dictionary {
   }
 }
 
+extension InsertionOrderedDictionary {
+  /// Accesses the value associated with a key that is known to exist in `self`.
+  ///
+  /// - Precondition: self[k] != `nil`.
+  subscript(existingKey k: Key) -> Value {
+    get { self[k]! }
+    _modify {
+      yield &values[index(forKey: k)!]
+    }
+  }
+
+  /// Invokes `update` to mutate each stored `Value`, passing its corresponding `Key` and the
+  /// `Index` in `self` where that `(Key, Value)` pair is stored.
+  mutating func updateValues(_ update: (Key, inout Value, Index) throws -> Void) rethrows {
+    var i = startIndex
+    while i != endIndex {
+      try update(self[i].key, &values[i], i)
+      formIndex(after: &i)
+    }
+  }
+}
+
 /// The consecutive `SubSequence`s of a `Base` collection having a given maximum size.
 struct Batched<Base: Collection>: Collection {
   public let base: Base


### PR DESCRIPTION
Deterministic ordering will be needed for several reasons: one is for making TypeKeyedArrayBuffers of Vectors into Vectors themselves (need a stable scalar ordering), another is for stability of floating point results in tests (@marcrasi has more details).