### PR TITLE
add RAE bee tracking model

### DIFF
--- a/Examples/BeeTrackingTool/main.swift
+++ b/Examples/BeeTrackingTool/main.swift
@@ -1,0 +1,109 @@
+import ArgumentParser
+import BeeDataset
+import BeeTracking
+import PythonKit
+import SwiftFusion
+import TensorFlow
+
+struct BeeTrackingTool: ParsableCommand {
+  static var configuration = CommandConfiguration(
+    subcommands: [TrainRAE.self, InferTrack.self])
+}
+
+/// The dimension of the hidden layer in the appearance model.
+let kHiddenDimension = 500
+
+/// The dimension of the latent code in the appearance model.
+let kLatentDimension = 10
+
+/// Returns a `[N, h, w, c]` batch of normalized frames from a bee video, and returns the statistics
+/// used to normalize them.
+func makeBeeBatch() -> (normalized: Tensor<Double>, statistics: FrameStatistics) {
+  let data = BeeVideo(videoName: "bee_video_1")
+  let num_samples = 80
+  let images = (0..<num_samples).map { (i: Int) -> Tensor<Double> in
+    return data!.frames[i].patch(at: data!.tracks[1][i].location)
+  }
+  let stacked = Tensor(stacking: images)
+  let statistics = FrameStatistics(stacked)
+  return (statistics.normalized(stacked), statistics)
+}
+
+struct TrainRAE: ParsableCommand {
+  @Option(help: "Load weights from this file before training")
+  var loadWeights: String?
+
+  @Option(help: "Save weights to this file after training")
+  var saveWeights: String
+
+  @Option(help: "Number of epochs to train")
+  var epochCount: Int = 20
+
+  func run() {
+    let np = Python.import("numpy")
+
+    let (beeBatch, _) = makeBeeBatch()
+    print("Bee batch shape: \(beeBatch.shape)")
+
+    let (imageHeight, imageWidth, imageChannels) =
+      (beeBatch.shape[1], beeBatch.shape[2], beeBatch.shape[3])
+
+    var model = DenseRAE(
+      imageHeight: imageHeight, imageWidth: imageWidth, imageChannels: imageChannels,
+      hiddenDimension: kHiddenDimension, latentDimension: kLatentDimension)
+    if let loadWeights = loadWeights {
+      let weights = np.load(loadWeights, allow_pickle: true)
+      model.load(weights: weights)
+    }
+
+    let loss = DenseRAELoss()
+    _ = loss(model, beeBatch, printLoss: true)
+
+    // Use ADAM as optimizer
+    let optimizer = Adam(for: model)
+    optimizer.learningRate = 1e-3
+
+    // Thread-local variable that model layers read to know their mode
+    Context.local.learningPhase = .training
+
+    for i in 0..<epochCount {
+      print("Step \(i), loss: \(loss(model, beeBatch))")
+
+      let grad = gradient(at: model) { loss($0, beeBatch) }
+      optimizer.update(&model, along: grad)
+    }
+
+    _ = loss(model, beeBatch, printLoss: true)
+
+    np.save(saveWeights, np.array(model.numpyWeights, dtype: Python.object))
+  }
+}
+
+struct InferTrack: ParsableCommand {
+  @Option(help: "Load weights from this file")
+  var loadWeights: String
+
+  func run() {
+    let np = Python.import("numpy")
+
+    let video = BeeVideo(videoName: "bee_video_1")!
+    let (beeBatch, frameStatistics) = makeBeeBatch()
+    let (imageHeight, imageWidth, imageChannels) =
+      (beeBatch.shape[1], beeBatch.shape[2], beeBatch.shape[3])
+
+    var model = DenseRAE(
+      imageHeight: imageHeight, imageWidth: imageWidth, imageChannels: imageChannels,
+      hiddenDimension: kHiddenDimension, latentDimension: kLatentDimension)
+    model.load(weights: np.load(loadWeights, allow_pickle: true))
+
+    let tracker = TrackingFactorGraph(
+      model, video, frameStatistics, trackId: 0, indexStart: 0, length: 10)
+    var v = tracker.v
+
+    var optimizer = LM(precision: 1e1, max_iteration: 400)
+    optimizer.verbosity = .SUMMARY
+    try? optimizer.optimize(graph: tracker.fg, initial: &v)
+  }
+}
+
+BeeTrackingTool.main()

--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,7 @@ let package = Package(
     .package(url: "https://github.com/ProfFan/tensorboardx-s4tf.git", from: "0.1.3"),
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("swift-5.2-branch")),
     .package(url: "https://github.com/tensorflow/swift-models.git", .branch("99f323e550f7f0c3ed32d31a3c5d11a0f3c51e4b")),
+    .package(url: "https://github.com/apple/swift-argument-parser", from: "0.2.0"),
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -49,9 +50,23 @@ let package = Package(
         .product(name: "ModelSupport", package: "swift-models"),
       ]),
     .target(
+      name: "BeeTracking",
+      dependencies: [
+        "BeeDataset",
+        "SwiftFusion",
+      ]),
+    .target(
       name: "Pose3SLAMG2O",
       dependencies: ["SwiftFusion", "TensorBoardX", "SwiftToolsSupport"],
       path: "Examples/Pose3SLAMG2O"),
+    .target(
+      name: "BeeTrackingTool",
+      dependencies: [
+        "BeeDataset",
+        "BeeTracking",
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
+      ],
+      path: "Examples/BeeTrackingTool"),
     .testTarget(
       name: "SwiftFusionTests",
       dependencies: [
@@ -62,4 +77,7 @@ let package = Package(
     .testTarget(
       name: "BeeDatasetTests",
       dependencies: ["BeeDataset"]),
+    .testTarget(
+      name: "BeeTrackingTests",
+      dependencies: ["BeeTracking"]),
   ])

--- a/Sources/BeeTracking/AppearanceRAE+Serialization.swift
+++ b/Sources/BeeTracking/AppearanceRAE+Serialization.swift
@@ -1,0 +1,74 @@
+import PythonKit
+import TensorFlow
+
+extension Dense where Scalar: NumpyScalarCompatible {
+  /// Loads weights and bias from the numpy arrays in `weights`.
+  ///
+  /// `weights[0]` is the dense weight matrix and `weights[1]` is the bias.
+  mutating func load(weights: PythonObject) {
+    let weight = Tensor<Scalar>(numpy: weights[0])!
+    let bias = Tensor<Scalar>(numpy: weights[1])!
+    precondition(
+      self.weight.shape == weight.shape,
+      "expected weight matrix \(self.weight.shape) but got \(weight.shape)")
+    precondition(
+      self.bias.shape == bias.shape, "expected bias \(self.bias.shape) but got \(bias.shape)")
+    self.weight = weight
+    self.bias = bias
+  }
+
+  /// The weight and bias as numpy arrays.
+  ///
+  /// `numpyWeights[0]` is the dense weight matrix and `numpyWeights[1]` is the bias.
+  var numpyWeights: PythonObject {
+    Python.list([self.weight.makeNumpyArray(), self.bias.makeNumpyArray()])
+  }
+}
+
+extension Conv2D where Scalar: NumpyScalarCompatible {
+  /// Loads filter and bias from the numpy arrays in `weights`.
+  ///
+  /// `weights[0]` is the filter and `weights[1]` is the bias.
+  mutating func load(weights: PythonObject) {
+    let filter = Tensor<Scalar>(numpy: weights[0])!
+    let bias = Tensor<Scalar>(numpy: weights[1])!
+    precondition(
+      self.filter.shape == filter.shape,
+      "expected filter matrix \(self.filter.shape) but got \(filter.shape)")
+    precondition(
+      self.bias.shape == bias.shape, "expected bias \(self.bias.shape) but got \(bias.shape)")
+    self.filter = filter
+    self.bias = bias
+  }
+
+  /// The filter and bias as numpy arrays.
+  ///
+  /// `numpyWeights[0]` is the filter and `numpyWeights[1]` is the bias.
+  var numpyWeights: PythonObject {
+    Python.list([self.filter.makeNumpyArray(), self.bias.makeNumpyArray()])
+  }
+}
+
+extension DenseRAE {
+  /// Loads model weights from the numpy arrays in `weights`.
+  public mutating func load(weights: PythonObject) {
+    self.encoder_conv1.load(weights: weights[0..<2])
+    self.encoder1.load(weights: weights[2..<4])
+    self.encoder2.load(weights: weights[4..<6])
+    self.decoder1.load(weights: weights[6..<8])
+    self.decoder2.load(weights: weights[8..<10])
+    self.decoder_conv1.load(weights: weights[10..<12])
+  }
+
+  /// The model weights as numpy arrays.
+  public var numpyWeights: PythonObject {
+    [
+      self.encoder_conv1.numpyWeights,
+      self.encoder1.numpyWeights,
+      self.encoder2.numpyWeights,
+      self.decoder1.numpyWeights,
+      self.decoder2.numpyWeights,
+      self.decoder_conv1.numpyWeights
+    ].reduce([], +)
+  }
+}

--- a/Sources/BeeTracking/AppearanceRAE.swift
+++ b/Sources/BeeTracking/AppearanceRAE.swift
@@ -1,0 +1,256 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import TensorFlow
+
+// MARK: - The Regularized Autoencoder model.
+
+/// A Regularized Autoencoder (RAE) [1] that encodes the appearance of an image patch.
+///
+/// [1] https://openreview.net/forum?id=S1g7tpEYDS
+public struct DenseRAE: Layer {
+  /// The height of the input image in pixels.
+  @noDerivative public let imageHeight: Int
+
+  /// The width of the input image in pixels.
+  @noDerivative public let imageWidth: Int
+
+  /// The number of channels in the input image.
+  @noDerivative public let imageChannels: Int
+
+  /// The number of activations in the hidden layer.
+  @noDerivative public let hiddenDimension: Int
+
+  /// The number of activations in the appearance code.
+  @noDerivative public let latentDimension: Int
+
+  /// First conv to downside the image
+  var encoder_conv1: Conv2D<Double>
+
+  /// Max pooling of factor 2
+  var encoder_pool1: MaxPool2D<Double>
+
+  /// First FCN encoding layer goes from image to hidden dimension
+  var encoder1: Dense<Double>
+
+  /// Second goes from dense features to latent code
+  var encoder2: Dense<Double>
+
+  /// Decode from latent to dense hidden layer with same dimsnions as before
+  var decoder1: Dense<Double>
+
+  /// Finally, reconstruct grayscale (or RGB) image
+  var decoder2: Dense<Double>
+
+  var decoder_upsample1: UpSampling2D<Double>
+
+  var decoder_conv1: Conv2D<Double>
+
+  /// Creates an instance for images with size `[imageHeight, imageWidth, imageChannels]`, with
+  /// hidden and latent dimensions given by `hiddenDimension` and `latentDimension`.
+  public init(
+    imageHeight: Int, imageWidth: Int, imageChannels: Int,
+    hiddenDimension: Int, latentDimension: Int
+  ) {
+    self.imageHeight = imageHeight
+    self.imageWidth = imageWidth
+    self.imageChannels = imageChannels
+    self.hiddenDimension = hiddenDimension
+    self.latentDimension = latentDimension
+
+    encoder_conv1 = Conv2D<Double>(filterShape: (3, 3, 3, 3), padding: .same, activation: relu)
+
+    encoder_pool1 = MaxPool2D<Double>(poolSize: (2, 2), strides: (2, 2), padding: .same)
+
+    encoder1 = Dense<Double>(
+      inputSize: imageHeight * imageWidth * imageChannels / 4,
+      outputSize: hiddenDimension,
+      activation: relu)
+
+    encoder2 = Dense<Double>(
+      inputSize: hiddenDimension,
+      outputSize: latentDimension)
+
+    decoder1 = Dense<Double>(
+      inputSize: latentDimension,
+      outputSize: hiddenDimension,
+      activation: relu)
+
+    decoder2 = Dense<Double>(
+      inputSize: hiddenDimension,
+      outputSize: imageHeight * imageWidth * imageChannels / 4)
+
+    decoder_upsample1 = UpSampling2D<Double>(size: 2)
+
+    decoder_conv1 = Conv2D<Double>(filterShape: (3, 3, 3, 3), padding: .same, activation: identity)
+  }
+
+  /// Differentiable encoder
+  @differentiable
+  public func encode(_ imageBatch: Tensor<Double>) -> Tensor<Double> {
+    let batchSize = imageBatch.shape[0]
+    let expectedShape: TensorShape = [batchSize, imageHeight, imageWidth, imageChannels]
+    precondition(
+        imageBatch.shape == expectedShape,
+        "input shape is \(imageBatch.shape), but expected \(expectedShape)")
+    return imageBatch
+      .sequenced(through: encoder_conv1, encoder_pool1).reshaped(to: [batchSize, imageHeight * imageWidth * imageChannels / 4])
+      .sequenced(through: encoder1, encoder2)
+  }
+
+  /// Differentiable decoder
+  @differentiable
+  public func decode(_ latent: Tensor<Double>) -> Tensor<Double> {
+    let batchSize = latent.shape[0]
+    precondition(
+      latent.shape == [batchSize, latentDimension],
+      "expected latent shape \([batchSize, latentDimension]), but got \(latent.shape)")
+    return decoder_upsample1(latent.sequenced(through: decoder1, decoder2)
+      .reshaped(to: [batchSize, imageHeight / 2,  imageWidth / 2, imageChannels]))
+  }
+
+  /// Standard: add syntactic sugar to apply model as a function call.
+  @differentiable
+  public func callAsFunction(_ imageBatch: Tensor<Double>) -> DenseRAEOutput {
+    let latent = encode(imageBatch)
+    let reconstruction = decode(latent)
+    return .init(latent: latent, reconstruction: reconstruction)
+  }
+}
+
+/// The latent code and reconstructed image that an `DenseRAE` produces given an input image.
+public struct DenseRAEOutput: Differentiable {
+  /// The latent code for the input image.
+  public var latent: Tensor<Double>
+
+  /// The reconstruction of the input image.
+  public var reconstruction: Tensor<Double>
+
+  /// Creates an instance with the given `latent` and `reconstruction`.
+  @differentiable
+  public init(latent: Tensor<Double>, reconstruction: Tensor<Double>) {
+    self.latent = latent
+    self.reconstruction = reconstruction
+  }
+}
+
+extension DenseRAE {
+  /// Jacobian of the `dense` method.
+  ///
+  /// This is a hand implementation that is much faster than the AD-generated Jacobian.
+  public func decodeJacobian(_ latent: Tensor<Double>) -> Tensor<Double> {
+    precondition(
+      latent.shape == [1, latentDimension],
+      "expected latent shape \([1, latentDimension]), but got \(latent.shape)")
+    let y_decoder1 = (matmul(latent, decoder1.weight) + decoder1.bias).squeezingShape(at: 0)
+    let relu_H_y_decoder1 = Tensor<Double>(y_decoder1 .> Tensor(0)).diagonal()
+    // let y2 = matmul(y .> Tensor(0), decoder2.weight)
+    let jacobian_decoder2 = matmul(
+      decoder2.weight, transposed: true,
+      matmul(relu_H_y_decoder1, transposed: false, decoder1.weight, transposed: true))
+    let jacobian_reshaped = jacobian_decoder2
+      .reshaped(to: [1, imageHeight / 2,  imageWidth / 2, imageChannels * latentDimension])
+
+    let shape = jacobian_reshaped.shape
+    let size = 2
+    let (batchSize, height, width, channels) = (shape[0], shape[1], shape[2], shape[3])
+    let scaleOnes = Tensor<Double>(ones: [1, 1, size, 1, size, 1])
+    let upSampling = jacobian_reshaped
+      .reshaped(to: [batchSize, height, 1, width, 1, channels]) * scaleOnes
+
+    let jacobian_upscaled = upSampling
+      .reshaped(to: [1, imageHeight,  imageWidth, imageChannels, latentDimension])
+    return jacobian_upscaled
+  }
+}
+
+// MARK: - The loss function for the RAE model.
+
+extension DenseRAEOutput {
+  // Reconstruction loss is just mean-squared error (defined in s4tf).
+  @differentiable
+  public func reconstructionLoss(_ data: Tensor<Double>) -> Tensor<Double> {
+    return meanSquaredError(predicted: reconstruction, expected: data)
+  }
+
+  // Regularization loss is just a unit covariance multivariate Gaussian.
+  @differentiable
+  public func latentRegularizationLoss() -> Tensor<Double> {
+    return latent.squared().mean()
+  }
+}
+
+extension Dense {
+  /// A regularization loss for the parameters of `self`.
+  @differentiable
+  public func parameterRegularizationLoss() -> Tensor<Scalar> {
+    return weight.squared().mean() + bias.squared().mean()
+  }
+}
+extension DenseRAE {
+  /// A regularization loss for the parameters of `self`.
+  @differentiable
+  func parameterRegularizationLoss() -> Tensor<Double> {
+    return encoder1.parameterRegularizationLoss() + encoder2.parameterRegularizationLoss()
+      + decoder1.parameterRegularizationLoss() + decoder2.parameterRegularizationLoss()
+  }
+}
+
+/// The loss function for the `DenseRAE`.
+public struct DenseRAELoss {
+  public let weightReconstruction: Double
+  public let weightLatentRegularization: Double
+  public let weightParameterRegularization: Double
+
+  /// Creates an instance with default values for the weights of the loss components.
+  public init() {
+    self.weightReconstruction = 1e0
+    self.weightLatentRegularization = 1e-2
+    self.weightParameterRegularization = 1e-3
+  }
+
+  /// Creates an instance with the given values for the weights of the loss components.
+  public init(
+    weightReconstruction: Double,
+    weightLatentRegularization: Double,
+    weightParameterRegularization: Double
+  ) {
+    self.weightReconstruction = weightReconstruction
+    self.weightLatentRegularization = weightLatentRegularization
+    self.weightParameterRegularization = weightParameterRegularization
+  }
+
+  /// Return the loss of `model` on `imageBatch`.
+  ///
+  /// Parameter printLoss: Whether to print the loss and its components.
+  @differentiable
+  public func callAsFunction(
+    _ model: DenseRAE, _ imageBatch: Tensor<Double>, printLoss: Bool = false
+  ) -> Tensor<Double> {
+    let output = model(imageBatch)
+    let reconstructionLoss = weightReconstruction * output.reconstructionLoss(imageBatch)
+    let latentRegularizationLoss = weightLatentRegularization * output.latentRegularizationLoss()
+    let parameterRegularizationLoss = weightParameterRegularization * model.parameterRegularizationLoss()
+    let totalLoss = reconstructionLoss + latentRegularizationLoss + parameterRegularizationLoss
+
+    if printLoss {
+      print("Reconstruction loss: \(reconstructionLoss)")
+      print("Latent regularization loss: \(latentRegularizationLoss)")
+      print("Parameter regularization loss: \(parameterRegularizationLoss)")
+      print("Total loss: \(totalLoss)")
+    }
+
+    return totalLoss
+  }
+}

--- a/Sources/BeeTracking/FrameStatistics.swift
+++ b/Sources/BeeTracking/FrameStatistics.swift
@@ -1,0 +1,26 @@
+import TensorFlow
+
+/// The mean and standard deviation of a collection of frames.
+public struct FrameStatistics {
+  var mean: Tensor<Double>
+  var standardDeviation: Tensor<Double>
+
+  /// Creates an instance containing the statistics for `frames`.
+  public init(_ frames: Tensor<Double>) {
+    self.mean = frames.mean()
+    self.standardDeviation = frames.standardDeviation()
+  }
+
+  /// Returns `v`, normalized to have mean `0` and standard deviation `1`.
+  public func normalized(_ v: Tensor<Double>) -> Tensor<Double> {
+    return (v - mean) / standardDeviation
+  }
+
+  /// Returns `n` scaled and shifted so that its mean and standard deviation are `self.mean`
+  /// and `self.standardDeviation`.
+  ///
+  /// Requires that `n` has mean `0` and standard deviation `1`.
+  public func unnormalized(_ n: Tensor<Double>) -> Tensor<Double> {
+    return n * standardDeviation + mean
+  }
+}

--- a/Sources/BeeTracking/TrackingFactorGraph.swift
+++ b/Sources/BeeTracking/TrackingFactorGraph.swift
@@ -1,0 +1,92 @@
+import BeeDataset
+import PenguinStructures
+import SwiftFusion
+
+/// A factor that specifies a prior on a pose.
+public struct WeightedPriorFactor<Pose: LieGroup>: LinearizableFactor1 {
+  public let edges: Variables.Indices
+  public let prior: Pose
+  public let weight: Double
+
+  public init(_ id: TypedID<Pose>, _ prior: Pose, weight: Double) {
+    self.edges = Tuple1(id)
+    self.prior = prior
+    self.weight = weight
+  }
+
+  @differentiable
+  public func errorVector(_ x: Pose) -> Pose.TangentVector {
+    return weight * prior.localCoordinate(x)
+  }
+}
+
+/// A factor graph that tracks a target using an appearance model.
+public struct TrackingFactorGraph {
+  /// The factors.
+  public var fg = FactorGraph()
+
+  /// An initial guess for the variable values.
+  public var v = VariableAssignments()
+
+  /// The ids of the poses in the factor graph.
+  public var poseIds: [TypedID<Pose2>] = []
+
+  /// The ids of the latent codes in the factor graph.
+  public var latentIds: [TypedID<Vector10>] = []
+
+  /// Create an instance that tracks `trackId` in `video`, starting at `indexStart`, for `length`
+  /// steps.
+  ///
+  /// Parameter model: The appearance model.
+  /// Parameter statistics: The statistics used to normalize the frames before encoding.
+  public init(
+    _ model: DenseRAE,
+    _ video: BeeVideo,
+    _ statistics: FrameStatistics,
+    trackId: Int,
+    indexStart: Int,
+    length: Int
+  ) {
+    let expectedLatentDimension = 10
+    precondition(
+      model.latentDimension == expectedLatentDimension,
+      "expected latent dimension \(expectedLatentDimension) but got \(model.latentDimension)")
+    precondition(
+      trackId < video.tracks.count,
+      "track \(trackId) out of bounds, there are \(video.tracks.count) tracks")
+    precondition(
+      indexStart + length <= video.tracks[trackId].count,
+      "final index \(indexStart + length) out of bounds, " +
+        "there are \(video.tracks[trackId].count) frames")
+
+    let initialPatch = statistics.normalized(
+      video.loadFrame(indexStart)!.patch(at: video.tracks[trackId][indexStart].location))
+    let initialLatent = Vector10(flatTensor: model.encode(initialPatch.expandingShape(at: 0)))
+
+    for i in 0..<length {
+      print(i)
+      poseIds.append(v.store(video.tracks[trackId][indexStart].location.center))
+      latentIds.append(v.store(initialLatent))
+
+      fg.store(
+        AppearanceTrackingFactor<Vector10>(
+          poseIds[i], latentIds[i],
+          measurement: statistics.normalized(video.loadFrame(indexStart + i)!),
+          appearanceModel: { x in
+            (
+              model.decode(x.expandingShape(at: 0)).squeezingShape(at: 0),
+              model.decodeJacobian(x.expandingShape(at: 0))
+                .reshaped(to: [model.imageHeight, model.imageWidth, model.imageChannels, model.latentDimension]))
+          }))
+
+      if i == 0 {
+        fg.store(WeightedPriorFactor(latentIds[i], initialLatent, weight: 1e0))
+      }
+    }
+
+    for i in 0..<(length-1) {
+      fg.store(BetweenFactor<Vector10>(latentIds[i], latentIds[i+1], Vector10.zero))
+      fg.store(BetweenFactor<Pose2>(poseIds[i], poseIds[i+1], Pose2(0,0,0)))
+    }
+  }
+}

--- a/Tests/BeeTrackingTests/AppearanceRAETests.swift
+++ b/Tests/BeeTrackingTests/AppearanceRAETests.swift
@@ -1,0 +1,63 @@
+// Copyright 2020 The SwiftFusion Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import TensorFlow
+import XCTest
+
+import BeeTracking
+
+class BeeTrackingTests: XCTestCase {
+  /// Test that the hand-coded Jacobian for the decode method gives the same results as the
+  /// AD-generated Jacobian.
+  func testDecodeJacobian() {
+    // Size of the images.
+    let h = 10
+    let w = 10
+    let c = 10
+
+    // Number of batches to test. (`decodeJacobian` currently only supports one batch at a time).
+    let batchCount = 1
+
+    // Model size parameters.
+    let latentDimension = 5
+    let hiddenDimension = 100
+
+    // A random model and a random latent code to decode.
+    let model = DenseRAE(
+      imageHeight: h, imageWidth: w, imageChannels: c,
+      hiddenDimension: hiddenDimension, latentDimension: latentDimension)
+    let latent = Tensor<Double>(randomNormal: [batchCount, latentDimension])
+
+    // The hand-coded Jacobian.
+    let actualJacobian = model.decodeJacobian(latent)
+
+    // The AD-generated pullback function.
+    let pb = pullback(at: latent) { model.decode($0) }
+
+    // Pass all the unit vectors throught the AD-generated pullback function and check that the
+    // results match the hand-coded Jacobian.
+    for batch in 0..<batchCount {
+      for i in 0..<h {
+        for j in 0..<w {
+          for k in 0..<c {
+            var unit = Tensor<Double>(zeros: [batchCount, h, w, c])
+            unit[batch, i, j, k] = Tensor(1)
+            XCTAssertLessThan(
+              (actualJacobian[batch, i, j, k] - pb(unit)).squared().sum().scalar!, 1e-6)
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adapts pieces of https://colab.sandbox.google.com/drive/1cE0gvS4KADvoX2xF6js6LopsE51vg9do#scrollTo=k_kr6IL2d-e0 into a module "BeeTracking" and a binary "BeeTrackingTool" that runs model training and factor graph inference.

My next step will be to try to profile it and make it faster. My initial attempts at profiling just say it's spending a bunch of time in "libx10", without giving any information about what it's doing there, and this isn't very useful. So I'll try to get some more useful profiles.