### PR TITLE
generalize mechanism for custom linearizations

### DIFF
--- a/Sources/SwiftFusion/Inference/AppearanceTrackingFactor.swift
+++ b/Sources/SwiftFusion/Inference/AppearanceTrackingFactor.swift
@@ -88,6 +88,18 @@ public struct AppearanceTrackingFactor<LatentCode: FixedSizeVector>: Linearizabl
       errorVector_H_latent: generatedAppearance_H_latent,
       edges: Variables.linearized(edges))
   }
+
+  /// Returns the linearizations of `factors` at `x`.
+  ///
+  /// Note: This causes factor graph linearization to use our custom linearization,
+  /// `LinearizedPPCATrackingFactor` instead of the default AD-generated linearization.
+  public static func linearized<C: Collection>(_ factors: C, at x: VariableAssignments)
+    -> AnyGaussianFactorArrayBuffer where C.Element == Self
+  {
+     .init(Variables.withBufferBaseAddresses(x) { varsBufs in
+       .init(factors.lazy.map { f in f.linearized(at: Variables(at: f.edges, in: varsBufs)) })
+     })
+  }
 }
 
 /// A linear approximation to `AppearanceTrackingFactor`, at a certain linearization point.

--- a/Sources/SwiftFusion/Inference/PPCATrackingFactor.swift
+++ b/Sources/SwiftFusion/Inference/PPCATrackingFactor.swift
@@ -76,6 +76,18 @@ public struct PPCATrackingFactor: LinearizableFactor2 {
   private func region(_ center: Pose2) -> OrientedBoundingBox {
     OrientedBoundingBox(center: center, rows: mu.shape[0], cols: mu.shape[1])
   }
+
+  /// Returns the linearizations of `factors` at `x`.
+  ///
+  /// Note: This causes factor graph linearization to use our custom linearization,
+  /// `LinearizedPPCATrackingFactor` instead of the default AD-generated linearization.
+  public static func linearized<C: Collection>(_ factors: C, at x: VariableAssignments)
+    -> AnyGaussianFactorArrayBuffer where C.Element == Self
+  {
+     .init(Variables.withBufferBaseAddresses(x) { varsBufs in
+       .init(factors.lazy.map { f in f.linearized(at: Variables(at: f.edges, in: varsBufs)) })
+     })
+  }
 }
 
 /// A linear approximation to `PPCATrackingFactor`, at a certain linearization point.


### PR DESCRIPTION
This adds a `static func linearized` to the Factor protocol, with a default implementation that does the default linearization using AD. This allows conformances to customize the linearization. This replaces the ad-hoc code that we had in FactorsStorage.swift that gave certain specific factors custom linearizations.

I'm planning to use this for my performance work in https://github.com/borglab/SwiftFusion/pull/202, but it's complicated and self-contained enough that I thought it should be a separate PR too.