### PR TITLE
make tracking faster

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -64,6 +64,7 @@ let package = Package(
       dependencies: [
         "BeeDataset",
         "BeeTracking",
+        "PenguinParallelWithFoundation",
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ],
       path: "Examples/BeeTrackingTool"),

--- a/Sources/BeeTracking/TrackingFactorGraph.swift
+++ b/Sources/BeeTracking/TrackingFactorGraph.swift
@@ -64,7 +64,6 @@ public struct TrackingFactorGraph {
     let initialLatent = Vector10(flatTensor: model.encode(initialPatch.expandingShape(at: 0)))
 
     for i in 0..<length {
-      print(i)
       poseIds.append(v.store(video.tracks[trackId][indexStart].location.center))
       latentIds.append(v.store(initialLatent))
 
@@ -73,10 +72,11 @@ public struct TrackingFactorGraph {
           poseIds[i], latentIds[i],
           measurement: statistics.normalized(video.loadFrame(indexStart + i)!),
           appearanceModel: { x in
-            (
-              model.decode(x.expandingShape(at: 0)).squeezingShape(at: 0),
-              model.decodeJacobian(x.expandingShape(at: 0))
-                .reshaped(to: [model.imageHeight, model.imageWidth, model.imageChannels, model.latentDimension]))
+            model.decode(x.expandingShape(at: 0)).squeezingShape(at: 0)
+          },
+          appearanceModelJacobian: { x in
+            model.decodeJacobian(x.expandingShape(at: 0))
+              .reshaped(to: [model.imageHeight, model.imageWidth, model.imageChannels, model.latentDimension])
           }))
 
       if i == 0 {

--- a/Sources/SwiftFusion/Core/Timer.swift
+++ b/Sources/SwiftFusion/Core/Timer.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Utilities for timing and couting regions of code.
+///
+/// NOT threadsafe, which we should probably fix soon.
+
+fileprivate var startedTimers: [String: UInt64] = [:]
+fileprivate var accumulatedTimers: [String: UInt64] = [:]
+
+/// Start the `name` timer.
+///
+/// Precondition: The `name` timer is not running.
+public func startTimer(_ name: String) {
+  guard startedTimers[name] == nil else { preconditionFailure("timer \(name) is already started") }
+  startedTimers[name] = DispatchTime.now().uptimeNanoseconds
+}
+
+/// Stop the `name` timer.
+///
+/// Precondition: The `name` timer is running.
+public func stopTimer(_ name: String) {
+  guard let start = startedTimers[name] else { preconditionFailure("timer \(name) is not running") }
+  startedTimers[name] = nil
+  accumulatedTimers[name, default: 0] += DispatchTime.now().uptimeNanoseconds - start
+}
+
+/// Print the total times accumulated for each timer.
+public func printTimers() {
+  guard startedTimers.count == 0 else { preconditionFailure("timers are still running: \(startedTimers)") }
+  for (name, duration) in accumulatedTimers {
+    print("\(name): \(Double(duration) / 1e9) seconds")
+  }
+}
+
+fileprivate var counters: [String: Int] = [:]
+
+/// Increment the `name` counter.
+public func incrementCounter(_ name: String) {
+  counters[name, default: 0] += 1
+}
+
+/// Print the total counts for each counter.
+public func printCounters() {
+  for (name, count) in counters {
+    print("\(name): \(count)")
+  }
+}

--- a/Sources/SwiftFusion/Inference/FactorGraph.swift
+++ b/Sources/SwiftFusion/Inference/FactorGraph.swift
@@ -85,6 +85,8 @@ public struct FactorGraph {
 
   /// Returns the total error, at `x`, of all the linearizable factors.
   public func linearizableError(at x: VariableAssignments) -> Double {
+    startTimer("linearizableError")
+    defer { stopTimer("linearizableError") }
     return storage.values.reduce(0) { (result, factors) in
       guard let linearizableFactors = AnyVectorFactorArrayBuffer(factors) else {
         return result
@@ -95,6 +97,8 @@ public struct FactorGraph {
 
   /// Returns the error vectors, at `x`, of all the linearizable factors.
   public func errorVectors(at x: VariableAssignments) -> AllVectors {
+    startTimer("errorVectors")
+    defer { stopTimer("errorVectors") }
     return AllVectors(storage: storage.compactMapValues { factors in
       guard let linearizableFactors = AnyVectorFactorArrayBuffer(factors) else {
         return nil
@@ -116,6 +120,8 @@ public struct FactorGraph {
   ///   `self.linearized(at: x).errorVectors(dx)` ≈ `self.errorVectors(at: x.moved(along: dx))`
   /// where the equality is exact when `dx == x.linearizedZero`.
   public func linearized(at x: VariableAssignments) -> GaussianFactorGraph {
+    startTimer("linearize")
+    defer { stopTimer("linearize") }
     return GaussianFactorGraph(
       storage: storage.compactMapValues { factors in
         AnyVectorFactorArrayBuffer(factors)?.linearized(at: x)

--- a/Sources/SwiftFusion/Inference/PPCA.swift
+++ b/Sources/SwiftFusion/Inference/PPCA.swift
@@ -96,10 +96,4 @@ public struct PPCA {
 
     return matmul(W_inv!, (image - mu).reshaped(to: [H_ * W_ * C_, 1])).reshaped(to: [latent_size])
   }
-
-  /// Generate an image and corresponding Jacobian according to a latent
-  /// Input: [latent_size] or [latent_size, 1]
-  public func decodeWithJacobian(_ latent: Tensor<Double>) -> (Patch, Patch.TangentVector) {
-    return (decode(latent), W)
-  }
 }

--- a/Sources/SwiftFusion/Optimizers/CGLS.swift
+++ b/Sources/SwiftFusion/Optimizers/CGLS.swift
@@ -43,7 +43,7 @@ public struct GenericCGLS {
     var gamma = s.squaredNorm // γ(0) = ||s(0)||^2
 
     while step < max_iteration && gamma > precision {
-      incrementCounter("clgs step")
+      incrementCounter("cgls step")
       // print("[CGLS    ] residual = \(r.squaredNorm), true = \(gfg.errorVectors(at: x).squaredNorm)")
       let q = gfg.errorVectors_linearComponent(at: p) // q(k) = A * p(k)
 

--- a/Sources/SwiftFusion/Optimizers/CGLS.swift
+++ b/Sources/SwiftFusion/Optimizers/CGLS.swift
@@ -33,6 +33,8 @@ public struct GenericCGLS {
   /// Reference: Bjorck96book_numerical-methods-for-least-squares-problems
   /// Page 289, Algorithm 7.4.1
   public mutating func optimize(gfg: GaussianFactorGraph, initial x: inout VariableAssignments) {
+    startTimer("cgls")
+    defer { stopTimer("cgls") }
     step += 1
 
     var r = (-1) * gfg.errorVectors(at: x) // r(0) = b - A * x(0), the residual
@@ -41,6 +43,7 @@ public struct GenericCGLS {
     var gamma = s.squaredNorm // γ(0) = ||s(0)||^2
 
     while step < max_iteration && gamma > precision {
+      incrementCounter("clgs step")
       // print("[CGLS    ] residual = \(r.squaredNorm), true = \(gfg.errorVectors(at: x).squaredNorm)")
       let q = gfg.errorVectors_linearComponent(at: p) // q(k) = A * p(k)
 

--- a/Sources/SwiftFusion/Optimizers/LM.swift
+++ b/Sources/SwiftFusion/Optimizers/LM.swift
@@ -28,6 +28,9 @@ public struct LM {
   
   /// Desired precision, TODO(fan): make this actually work
   public var precision: Double = 1e-10
+
+  /// The precision of the CGLS solver.
+  public var cgls_precision: Double = 1e-10
   
   /// Maximum number of L-M iterations
   public var max_iteration: Int = 50
@@ -105,7 +108,7 @@ public struct LM {
         let old_linear_error = damped.error(at: dx)
         
         var dx_t = dx
-        var optimizer = GenericCGLS(precision: 1e-10, max_iteration: max_inner_iteration)
+        var optimizer = GenericCGLS(precision: cgls_precision, max_iteration: max_inner_iteration)
         optimizer.optimize(gfg: damped, initial: &dx_t)
         if verbosity >= .TRYLAMBDA {
           print("[LM INNER] damped error = \(damped.error(at: dx_t)), lambda = \(lambda)")

--- a/Tests/BeeDatasetTests/BeePPCATests.swift
+++ b/Tests/BeeDatasetTests/BeePPCATests.swift
@@ -43,7 +43,10 @@ final class BeePPCATests: XCTestCase {
     let latentId = v.store(initialLatent)
 
     // Tracking factor on the next frame
-    fg.store(AppearanceTrackingFactor(poseId, latentId, measurement: frames[1].mean(alongAxes: [2]), appearanceModel: ppca.decodeWithJacobian))
+    fg.store(AppearanceTrackingFactor(
+      poseId, latentId,
+      measurement: frames[1].mean(alongAxes: [2]),
+      appearanceModel: ppca.decode, appearanceModelJacobian: { _ in ppca.W }))
 
     // Prior on latent initialized by PPCA decode on the previous frame
     fg.store(PriorFactor(latentId, initialLatent))

--- a/Tests/SwiftFusionTests/Inference/PPCATests.swift
+++ b/Tests/SwiftFusionTests/Inference/PPCATests.swift
@@ -27,7 +27,8 @@ class PPCATests: XCTestCase {
     let ppca = PPCA(W: factor.W, mu: factor.mu.tensor)
     let generic_factor = AppearanceTrackingFactor(
       TypedID<Pose2>(0), TypedID<Vector5>(0),
-      measurement: factor.measurement, appearanceModel: ppca.decodeWithJacobian
+      measurement: factor.measurement,
+      appearanceModel: ppca.decode, appearanceModelJacobian: { _ in ppca.W }
     )
 
     for _ in 0..<2 {
@@ -75,7 +76,8 @@ class PPCATests: XCTestCase {
     let ppca = PPCA(W: factor.W, mu: factor.mu.tensor)
     let generic_factor = AppearanceTrackingFactor(
       TypedID<Pose2>(0), TypedID<Vector5>(0),
-      measurement: factor.measurement, appearanceModel: ppca.decodeWithJacobian
+      measurement: factor.measurement,
+      appearanceModel: ppca.decode, appearanceModelJacobian: { _ in ppca.W }
     )
 
     for _ in 0..<5 {
@@ -123,7 +125,8 @@ class PPCATests: XCTestCase {
     let ppca = PPCA(W: ppca_factor.W.tiled(multiples: [1, 1, 3, 1]), mu: ppca_factor.mu.tensor.tiled(multiples: [1, 1, 3]))
     let generic_factor = AppearanceTrackingFactor(
       TypedID<Pose2>(0), TypedID<Vector5>(0),
-      measurement: ppca_factor.measurement.tiled(multiples: [1, 1, 3]), appearanceModel: ppca.decodeWithJacobian
+      measurement: ppca_factor.measurement.tiled(multiples: [1, 1, 3]),
+      appearanceModel: ppca.decode, appearanceModelJacobian: { _ in ppca.W }
     )
 
     var x = VariableAssignments()


### PR DESCRIPTION
This does a bunch of simple things to make tracking faster. Each LM iteration takes ~1s on my machine now, which is much faster than it used to be.

Specific changes:
* Added some timing code because I couldn't get pprof to give me useful information about what was happening.
* Decreased the CGLS precision because it was spending most of the time in CGLS and it doesn't seem useful to spend tons of time for a tiny bit of precision. This was the biggest speedup.
* Split the appearance model from the appearance model jacobian so that we don't uselessly compute the jacobian when we just need the error.
* Run some embarrassingly parallel things in parallel.