### PR TITLE
fix bug in eager OISTBeeVideo loading

### DIFF
--- a/Sources/BeeDataset/OISTBeeVideo.swift
+++ b/Sources/BeeDataset/OISTBeeVideo.swift
@@ -124,9 +124,11 @@ fileprivate extension String {
 
 extension OISTBeeVideo {
   /// Creates an instance with auto download.
-  public init?(deferLoadingFrames: Bool = false) {
+  ///
+  /// Parameter frameCount: If specified, truncates the full dataset to this number of frames.
+  public init?(deferLoadingFrames: Bool = false, truncate frameCount: Int? = nil) {
     let dataset = Self.downloadDatasetIfNotPresent()
-    self.init(directory: dataset, deferLoadingFrames: deferLoadingFrames)
+    self.init(directory: dataset, deferLoadingFrames: deferLoadingFrames, truncate: frameCount)
   }
 
   /// Creates an instance from the data in the given `directory`.
@@ -136,7 +138,11 @@ extension OISTBeeVideo {
   ///
   /// The format of a track file is:
   /// - Arbitrarily many lines "offset_x, offset_y, bee_type, x, y, angle".
-  public init?(directory: URL, deferLoadingFrames: Bool = true, fps: Int = 30) {
+  ///
+  /// Parameter frameCount: If specified, truncates the full dataset to this number of frames.
+  public init?(
+    directory: URL, deferLoadingFrames: Bool = true, fps: Int = 30, truncate frameCount: Int? = nil
+  ) {
     self.frames = []
     self.labels = []
     self.frameIds = []
@@ -155,12 +161,16 @@ extension OISTBeeVideo {
       }
     }.sorted()
 
+    if let frameCount = frameCount {
+      self.frameIds = Array(self.frameIds.prefix(frameCount))
+    }
+
     // Lazy loading
     if !deferLoadingFrames {
       self.frames = Array(unsafeUninitializedCapacity: self.frameIds.count) {
         (b, actualCount) -> Void in
         ComputeThreadPools.local.parallelFor(n: self.frameIds.count) { (i, _) in
-          (b.baseAddress! + i).initialize(to: loadFrame(self.frameIds[self.frames.count])!)
+          (b.baseAddress! + i).initialize(to: loadFrame(self.frameIds[i])!)
         }
         actualCount = self.frameIds.count
       }
@@ -191,7 +201,9 @@ extension OISTBeeVideo {
         )
       }
     }
-    while let label = loadFrameLabels(self.frameIds[self.labels.count]) {
+    while self.labels.count < self.frameIds.count,
+      let label = loadFrameLabels(self.frameIds[self.labels.count])
+    {
       self.labels.append(label)
       if self.frameIds.count == self.labels.count {
           break
@@ -202,15 +214,18 @@ extension OISTBeeVideo {
       let track = try! String(contentsOf: path)
       let lines = track.split(separator: "\n")
       let startFrame = Int(lines.first!)!
-      let boxes = lines.dropFirst().map { line -> OrientedBoundingBox in
-        let split = line.split(separator: " ")
-        return OrientedBoundingBox(
-          center: Pose2(
-            Rot2(Double(split[2])!),
-            Vector2(Double(split[0])!, Double(split[1])!)),
-          rows: Int(split[3])!,
-          cols: Int(split[4])!)
-      }
+      let boxes = lines
+        .dropFirst()
+        .prefix(max(0, self.frameIds.count - startFrame))
+        .map { line -> OrientedBoundingBox in
+          let split = line.split(separator: " ")
+          return OrientedBoundingBox(
+            center: Pose2(
+              Rot2(Double(split[2])!),
+              Vector2(Double(split[0])!, Double(split[1])!)),
+            rows: Int(split[3])!,
+            cols: Int(split[4])!)
+        }
       return OISTBeeTrack(startFrameIndex: startFrame, boxes: boxes)
     }
     if let trackDirContents = try? FileManager.default.contentsOfDirectory(
@@ -220,6 +235,7 @@ extension OISTBeeVideo {
       self.tracks = trackDirContents
         .sorted(by: { $0.lastPathComponent < $1.lastPathComponent })
         .map(loadTrack)
+        .filter { $0.boxes.count >= 10 }
     } else {
       print("WARNING: No ground truth tracks found.")
     }

--- a/Tests/BeeDatasetTests/OISTDatasetTests.swift
+++ b/Tests/BeeDatasetTests/OISTDatasetTests.swift
@@ -14,6 +14,7 @@
 
 import BeeDataset
 import Foundation
+import PenguinParallelWithFoundation
 import XCTest
 
 final class OISTDatasetTests: XCTestCase {
@@ -29,5 +30,26 @@ final class OISTDatasetTests: XCTestCase {
     XCTAssertEqual(video.tracks[0].boxes.count, 361)
     XCTAssertEqual(video.tracks[11].startFrameIndex, 28)
     XCTAssertEqual(video.tracks[11].boxes.count, 179)
+  }
+
+  /// Test that eager dataset loading works properly.
+  func testEagerDatasetLoad() throws {
+    if let _ = ProcessInfo.processInfo.environment["CI"] {
+      throw XCTSkip("Test skipped on CI because it downloads a lot of data.")
+    }
+    ComputeThreadPools.local =
+      NonBlockingThreadPool<PosixConcurrencyPlatform>(name: "mypool", threadCount: 5)
+
+    // Truncate the frames so that this test does not take a huge amount of time.
+    let video = OISTBeeVideo(truncate: 15)!
+
+    XCTAssertEqual(video.frames.count, 15)
+    XCTAssertNotEqual(video.frames[1], video.frames[2])
+
+    // There are fewer tracks because we truncated the frames.
+    XCTAssertEqual(video.tracks.count, 13)
+
+    // The tracks are shorter because we truncated the frames.
+    XCTAssertEqual(video.tracks[0].boxes.count, 15)
   }
 }


### PR DESCRIPTION
I found a bug in my recent change to OISTBeeVideo eager loading. It loads the first frame N times instead of loading all N frames.

This PR fixes the bug and adds a test that catches the problem.

I also added a "truncate" option to OISTBeeVideo so that we can load subsets of the video. This makes it possible to run the test quickly, and it should also make it possible to run smaller experiments while we're iterating.