### PR TITLE
~6x tracking speedup by: removing redundant work, switching images to Float, and parallelizing patch

### DIFF
--- a/Examples/BeeTrackingTool/main.swift
+++ b/Examples/BeeTrackingTool/main.swift
@@ -25,7 +25,7 @@ func makeVOTBatch(votBaseDirectory: String, videoName: String, appearanceModelSi
 {
   let data = VOTVideo(votBaseDirectory: votBaseDirectory, videoName: videoName)!
   let images = (0..<data.frames.count).map { (i: Int) -> Tensor<Double> in
-    return data.frames[i].patch(at: data.track[i], outputSize: appearanceModelSize)
+    return Tensor<Double>(data.frames[i].patch(at: data.track[i], outputSize: appearanceModelSize))
   }
   let stacked = Tensor(stacking: images)
   let statistics = FrameStatistics(stacked)
@@ -145,8 +145,8 @@ struct InferTrackRAE: ParsableCommand {
     if verbose { tracker.optimizer.verbosity = .SUMMARY }
 
     let startPose = videoSlice.track[0].center
-    let startPatch = videoSlice.frames[0].patch(
-      at: videoSlice.track[0], outputSize: appearanceModelSize)
+    let startPatch = Tensor<Double>(videoSlice.frames[0].patch(
+      at: videoSlice.track[0], outputSize: appearanceModelSize))
     let startLatent = Vector10(
       flatTensor: model.encode(
         frameStatistics.normalized(startPatch).expandingShape(at: 0)).squeezingShape(at: 0))

--- a/Examples/OISTVisualizationTool/main.swift
+++ b/Examples/OISTVisualizationTool/main.swift
@@ -377,7 +377,7 @@ struct NaiveRae: ParsableCommand {
       $0.filter({ $0.label == .Body })
     }
     // Make batch and do RAE
-    let (batch, _) = makeOISTBatch(dataset: dataset, appearanceModelSize: (40, 70), batchSize: 200)
+    let (batch, _) = dataset.makeBatch(appearanceModelSize: (40, 70), batchSize: 200)
     var statistics = FrameStatistics(batch)
     statistics.mean = Tensor(62.26806976644069)
     statistics.standardDeviation = Tensor(37.44683834503672)

--- a/Sources/BeeDataset/OISTBeeVideo.swift
+++ b/Sources/BeeDataset/OISTBeeVideo.swift
@@ -35,7 +35,7 @@ public struct OISTBeeVideo {
   public var frameIds: [Int]
 
   /// The frames of the video, as tensors of shape `[height, width, channels]`.
-  public var frames: [Tensor<Double>]
+  public var frames: [Tensor<Float>]
 
   /// Labels for this video.
   public var labels: [[OISTBeeLabel]]
@@ -243,11 +243,11 @@ extension OISTBeeVideo {
 
   /// Loads one image frame and downsample by `scale`
   /// Example: frame_30fps_003525.txt
-  public func loadFrame(_ index: Int) -> Tensor<Double>? {
+  public func loadFrame(_ index: Int) -> Tensor<Float>? {
     let path = self.directory!.appendingPathComponent("frames").appendingPathComponent("frame_\(fps)fps_\(index, padding: 6).png")
     guard FileManager.default.fileExists(atPath: path.path) else { return nil }
-    let downsampler = AvgPool2D<Double>(poolSize: (scale, scale), strides: (scale, scale), padding: .same)
-    return downsampler(Tensor<Double>(ModelSupport.Image(contentsOf: path).tensor).expandingShape(at: 0)).squeezingShape(at: 0)
+    let downsampler = AvgPool2D<Float>(poolSize: (scale, scale), strides: (scale, scale), padding: .same)
+    return downsampler(ModelSupport.Image(contentsOf: path).tensor.expandingShape(at: 0)).squeezingShape(at: 0)
   }
   
   private static func downloadDatasetIfNotPresent() -> URL {
@@ -311,7 +311,7 @@ extension OISTBeeTrack {
       }
 
       // Plot the frame.
-      let frame = video.loadFrame(video.frameIds[frameIndex])!.patch(at: surroundingBox)
+      let frame = ArrayImage(video.loadFrame(video.frameIds[frameIndex])!).patch(at: surroundingBox).tensor
       let figure = plt.figure(figsize: [20, 20])
       let subplot = figure.add_subplot(1, 1, 1)
       subplot.imshow(frame.makeNumpyArray() / 255.0)

--- a/Sources/BeeDataset/VOTVideo.swift
+++ b/Sources/BeeDataset/VOTVideo.swift
@@ -20,7 +20,7 @@ import TensorFlow
 /// A video from VOT, with tracking labels.
 public struct VOTVideo {
   /// The frames of the video, as tensors of shape `[height, width, channels]`.
-  public var frames: [Tensor<Double>]
+  public var frames: [Tensor<Float>]
 
   /// The ground truth track of the object in this video.
   public var track: [OrientedBoundingBox]
@@ -88,7 +88,7 @@ extension VOTVideo {
         print("frame \(path.path) not found")
         return nil
       }
-      frames.append(Tensor<Double>(Image(contentsOf: path).tensor))
+      frames.append(Image(contentsOf: path).tensor)
     }
 
     // Load the track points.

--- a/Sources/BeeDataset/Visualization.swift
+++ b/Sources/BeeDataset/Visualization.swift
@@ -20,8 +20,8 @@ import Foundation
 
 /// Creates a Plotly figure that displays `frame`, with optional `boxes` overlaid on
 /// them.
-public func plot(
-  _ frame: Tensor<Double>, boxes: [(name: String, OrientedBoundingBox)] = [],
+public func plot<Scalar: TensorFlowFloatingPoint>(
+  _ frame: Tensor<Scalar>, boxes: [(name: String, OrientedBoundingBox)] = [],
   margin: Double = 30, scale: Double = 1
 ) -> Plotly.Figure {
   let rows = Double(frame.shape[0])

--- a/Sources/BeeTracking/FrameStatistics.swift
+++ b/Sources/BeeTracking/FrameStatistics.swift
@@ -23,4 +23,17 @@ public struct FrameStatistics {
   public func unnormalized(_ n: Tensor<Double>) -> Tensor<Double> {
     return n * standardDeviation + mean
   }
+
+  /// Returns `v`, normalized to have mean `0` and standard deviation `1`.
+  public func normalized(_ v: Tensor<Float>) -> Tensor<Float> {
+    return (v - Tensor<Float>(mean)) / Tensor<Float>(standardDeviation)
+  }
+
+  /// Returns `n` scaled and shifted so that its mean and standard deviation are `self.mean`
+  /// and `self.standardDeviation`.
+  ///
+  /// Requires that `n` has mean `0` and standard deviation `1`.
+  public func unnormalized(_ n: Tensor<Float>) -> Tensor<Float> {
+    return n * Tensor<Float>(standardDeviation) + Tensor<Float>(mean)
+  }
 }

--- a/Sources/BeeTracking/OISTBeeVideo+Batches.swift
+++ b/Sources/BeeTracking/OISTBeeVideo+Batches.swift
@@ -63,8 +63,8 @@ extension OISTBeeVideo {
         for _ in 0..<attemptCount {
           // Sample a point uniformly at random in the frame, away from the edges.
           let location = Vector2(
-            Double.random(in: Double(maxSide)..<Double(frame.shape[1] - maxSide)),
-            Double.random(in: Double(maxSide)..<Double(frame.shape[0] - maxSide)))
+            Double.random(in: Double(maxSide)..<Double(frame.shape[1] - maxSide), using: &deterministicEntropy),
+            Double.random(in: Double(maxSide)..<Double(frame.shape[0] - maxSide), using: &deterministicEntropy))
 
           // Conservatively reject any point that could possibly overlap with any of the labels.
           for label in labels {
@@ -79,7 +79,7 @@ extension OISTBeeVideo {
         fatalError("could not find backround location after \(attemptCount) attempts")
       }
       return locations.map { location -> Tensor<Double> in
-        let theta = Double.random(in: 0..<(2 * .pi))
+        let theta = Double.random(in: 0..<(2 * .pi), using: &deterministicEntropy)
         return frame.patch(
           at: OrientedBoundingBox(
             center: Pose2(Rot2(theta), location),
@@ -105,7 +105,7 @@ extension OISTBeeVideo {
       ComputeThreadPools.local.parallelFor(n: count) { (i, _) -> Void in
         let frameIndex = selectedFrameIndices[i]
         let frameId = self.frameIds[frameIndex]
-        let frame = self.loadFrame(frameId)!
+        let frame = Tensor<Double>(self.loadFrame(frameId)!)
         let labels = self.labels[frameIndex]
         assert(labels.allSatisfy { $0.frameIndex == frameId })
         (b.baseAddress! + i).initialize(to: (frameId, (frame, labels)))

--- a/Sources/BeeTracking/TrackingFactorGraph.swift
+++ b/Sources/BeeTracking/TrackingFactorGraph.swift
@@ -43,7 +43,7 @@ public struct WeightedBetweenFactor<Pose: LieGroup>: LinearizableFactor2 {
 /// A specification for a factor graph that tracks a target in a sequence of frames.
 public struct TrackingConfiguration<FrameVariables: VariableTuple> {
   /// The frames of the video to track.
-  public let frames: [Tensor<Double>]
+  public let frames: [Tensor<Float>]
 
   /// A collection of arbitrary values for the variables in the factor graph.
   public let variableTemplate: VariableAssignments
@@ -58,7 +58,7 @@ public struct TrackingConfiguration<FrameVariables: VariableTuple> {
 
   /// Adds to `graph` a tracking factor on `variables` for tracking in `frame`.
   public let addTrackingFactor: (
-    _ variables: FrameVariables.Indices, _ frame: Tensor<Double>, _ graph: inout FactorGraph
+    _ variables: FrameVariables.Indices, _ frame: Tensor<Float>, _ graph: inout FactorGraph
   ) -> ()
 
   /// Adds to `graph` between factor(s) between the variables at `variables1` and the variables at `variables2`.
@@ -74,14 +74,14 @@ public struct TrackingConfiguration<FrameVariables: VariableTuple> {
   ///
   /// See the field doc comments for argument docs.
   public init(
-    frames: [Tensor<Double>],
+    frames: [Tensor<Float>],
     variableTemplate: VariableAssignments,
     frameVariableIDs: [FrameVariables.Indices],
     addPriorFactor: @escaping (
       _ variables: FrameVariables.Indices, _ values: FrameVariables, _ graph: inout FactorGraph
     ) -> (),
     addTrackingFactor: @escaping (
-      _ variables: FrameVariables.Indices, _ frame: Tensor<Double>, _ graph: inout FactorGraph
+      _ variables: FrameVariables.Indices, _ frame: Tensor<Float>, _ graph: inout FactorGraph
     ) -> (),
     addBetweenFactor: @escaping (
       _ variables1: FrameVariables.Indices, _ variables2: FrameVariables.Indices,
@@ -156,7 +156,7 @@ public struct TrackingConfiguration<FrameVariables: VariableTuple> {
 public func makeRAETracker(
   model: DenseRAE,
   statistics: FrameStatistics,
-  frames: [Tensor<Double>],
+  frames: [Tensor<Float>],
   targetSize: (Int, Int)
 ) -> TrackingConfiguration<Tuple2<Pose2, Vector10>> {
   var variableTemplate = VariableAssignments()
@@ -209,7 +209,7 @@ public func makeRAETracker(
 public func makePPCATracker(
   model: PPCA,
   statistics: FrameStatistics,
-  frames: [Tensor<Double>],
+  frames: [Tensor<Float>],
   targetSize: (Int, Int)
 ) -> TrackingConfiguration<Tuple2<Pose2, Vector10>> {
   var variableTemplate = VariableAssignments()
@@ -259,8 +259,8 @@ public func makePPCATracker(
 /// Parameter frames: The frames of the video where we want to run tracking.
 /// Parameter target: The pixels of the target.
 public func makeRawPixelTracker(
-  frames: [Tensor<Double>],
-  target: Tensor<Double>
+  frames: [Tensor<Float>],
+  target: Tensor<Float>
 ) -> TrackingConfiguration<Tuple1<Pose2>> {
   var variableTemplate = VariableAssignments()
   var frameVariableIDs = [Tuple1<TypedID<Pose2>>]()
@@ -281,7 +281,7 @@ public func makeRawPixelTracker(
     addTrackingFactor: { (variables, frame, graph) -> () in
       let poseID = variables.head
       graph.store(
-        RawPixelTrackingFactor(poseID, measurement: frame, target: target))
+        RawPixelTrackingFactor(poseID, measurement: frame, target: Tensor<Double>(target)))
     },
     addBetweenFactor: { (variables1, variables2, graph) -> () in
       let poseID1 = variables1.head

--- a/Sources/BeeTracking/TrackingMetrics.swift
+++ b/Sources/BeeTracking/TrackingMetrics.swift
@@ -184,7 +184,7 @@ extension TrackerEvaluationDataset {
 /// A single sequence in a `TrackerEvaluationDataset`.
 public struct TrackerEvaluationSequence {
   /// The frames of the sequence.
-  public let frames: [Tensor<Double>]
+  public let frames: [Tensor<Float>]
 
   /// The ground truth labels for the sequence.
   public let groundTruth: [OrientedBoundingBox]
@@ -269,4 +269,4 @@ public struct SequenceEvaluationResults {
 /// Given `frames` and a `start` region containing an object to track, returns predicted regions
 /// for all `frames` (including the first one).
 public typealias Tracker =
-  (_ frames: [Tensor<Double>], _ start: OrientedBoundingBox) -> [OrientedBoundingBox]
+  (_ frames: [Tensor<Float>], _ start: OrientedBoundingBox) -> [OrientedBoundingBox]

--- a/Sources/SwiftFusion/Image/ArrayImage.swift
+++ b/Sources/SwiftFusion/Image/ArrayImage.swift
@@ -19,7 +19,7 @@ import TensorFlow
 /// Useful when doing lots of subscripting because `Array` subscripts are faster than `Tensor`
 /// subscripts.
 public struct ArrayImage: Differentiable {
-  var pixels: [Double]
+  var pixels: [Float]
   @noDerivative let rows: Int
   @noDerivative let cols: Int
   @noDerivative let channels: Int
@@ -42,7 +42,7 @@ public struct ArrayImage: Differentiable {
 
   /// Creates an instance from the given image `tensor`.
   @differentiable
-  public init(_ tensor: Tensor<Double>) {
+  public init(_ tensor: Tensor<Float>) {
     precondition(
       tensor.shape.count == 2 || tensor.shape.count == 3,
       "image must have shape height x width x channelCount"
@@ -56,7 +56,7 @@ public struct ArrayImage: Differentiable {
 
   /// Returns this image as an image `Tensor`.
   @differentiable
-  public var tensor: Tensor<Double> {
+  public var tensor: Tensor<Float> {
     Tensor(shape: [rows, cols, channels], scalars: pixels)
   }
 
@@ -71,7 +71,7 @@ public struct ArrayImage: Differentiable {
   }
 
   /// Accesses the pixel value at `(i, j, channel)`.
-  public subscript(_ i: Int, _ j: Int, _ channel: Int) -> Double {
+  public subscript(_ i: Int, _ j: Int, _ channel: Int) -> Float {
     get {
       guard let idx = index(i, j, channel) else {
         return 0
@@ -89,23 +89,21 @@ public struct ArrayImage: Differentiable {
   ///
   /// Use this instead of the subscript when you need to differentiably modify the image.
   @differentiable
-  public mutating func update(_ i: Int, _ j: Int, _ channel: Int, to value: Double) {
+  public mutating func update(_ i: Int, _ j: Int, _ channel: Int, to value: Float) {
     self[i, j, channel] = value
   }
 
   @derivative(of: update)
   @usableFromInline
-  mutating func vjpUpdate(_ i: Int, _ j: Int, _ channel: Int, to value: Double) -> (
+  mutating func vjpUpdate(_ i: Int, _ j: Int, _ channel: Int, to value: Float) -> (
     value: (),
-    pullback: (inout TangentVector) -> Double
+    pullback: (inout TangentVector) -> Float
   ) {
     update(i, j, channel, to: value)
     let idx = index(i, j, channel).unsafelyUnwrapped
-    func pullback(_ v: inout TangentVector) -> Double {
+    func pullback(_ v: inout TangentVector) -> Float {
       return v.pixels.base[idx]
     }
     return ((), pullback)
   }
 }
-
-

--- a/Sources/SwiftFusion/Image/ArrayImage.swift
+++ b/Sources/SwiftFusion/Image/ArrayImage.swift
@@ -40,6 +40,14 @@ public struct ArrayImage: Differentiable {
     self.channels = template.channels
   }
 
+  /// Creates an instance with the given `pixels`, `rows`, `cols`, and `channels`.
+  public init(pixels: [Float], rows: Int, cols: Int, channels: Int) {
+    self.pixels = pixels
+    self.rows = rows
+    self.cols = cols
+    self.channels = channels
+  }
+
   /// Creates an instance from the given image `tensor`.
   @differentiable
   public init(_ tensor: Tensor<Float>) {

--- a/Sources/SwiftFusion/Image/Patch.swift
+++ b/Sources/SwiftFusion/Image/Patch.swift
@@ -152,7 +152,7 @@ extension ArrayImage {
   }
 }
 
-extension Tensor where Scalar == Double {
+extension Tensor where Scalar: TensorFlowFloatingPoint {
   /// Returns the patch of `self` at `region`.
   ///
   /// - Parameters:
@@ -170,7 +170,7 @@ extension Tensor where Scalar == Double {
       self.shape.count == 2 || self.shape.count == 3,
       "image must have shape [height, width] or [height, width, channelCount]"
     )
-    let result = Tensor<Double>(
+    let result = Tensor<Scalar>(
       ArrayImage(Tensor<Float>(self)).patch(at: region, outputSize: outputSize).tensor)
     return self.shape.count == 2 ? result.reshaped(to: [result.shape[0], result.shape[1]]) : result
   }
@@ -197,8 +197,8 @@ extension Tensor where Scalar == Double {
     precondition(self.shape.count == 3, "image must have shape [height, width, channelCount]")
     let (patch, jacobian) = ArrayImage(Tensor<Float>(self)).patchWithJacobian(at: region, outputSize: outputSize)
     return (
-      patch: Tensor<Double>(patch.tensor),
-      jacobian: Tensor<Double>(Tensor<Float>(stacking: [
+      patch: Tensor<Scalar>(patch.tensor),
+      jacobian: Tensor<Scalar>(Tensor<Float>(stacking: [
         jacobian.dtheta.tensor,
         jacobian.du.tensor,
         jacobian.dv.tensor

--- a/Sources/SwiftFusion/Inference/AppearanceTrackingFactor.swift
+++ b/Sources/SwiftFusion/Inference/AppearanceTrackingFactor.swift
@@ -69,14 +69,14 @@ public struct AppearanceTrackingFactor<LatentCode: FixedSizeVector>: Linearizabl
   public init(
     _ poseId: TypedID<Pose2>,
     _ latentId: TypedID<LatentCode>,
-    measurement: Tensor<Double>,
+    measurement: Tensor<Float>,
     appearanceModel: @escaping GenerativeModel,
     appearanceModelJacobian: @escaping GenerativeModelJacobian,
     weight: Double = 1.0,
     targetSize: (Int, Int)? = nil
   ) {
     self.edges = Tuple2(poseId, latentId)
-    self.measurement = ArrayImage(Tensor<Float>(measurement))
+    self.measurement = ArrayImage(measurement)
     self.appearanceModel = appearanceModel
     self.appearanceModelJacobian = appearanceModelJacobian
     self.weight = weight

--- a/Sources/SwiftFusion/Inference/AppearanceTrackingFactor.swift
+++ b/Sources/SwiftFusion/Inference/AppearanceTrackingFactor.swift
@@ -21,7 +21,7 @@ public struct AppearanceTrackingFactor<LatentCode: FixedSizeVector>: Linearizabl
   public let edges: Variables.Indices
 
   /// The image containing the target.
-  public let measurement: Tensor<Double>
+  public let measurement: ArrayImage
 
   /// Weighting of the error
   public var weight: Double
@@ -76,7 +76,7 @@ public struct AppearanceTrackingFactor<LatentCode: FixedSizeVector>: Linearizabl
     targetSize: (Int, Int)? = nil
   ) {
     self.edges = Tuple2(poseId, latentId)
-    self.measurement = measurement
+    self.measurement = ArrayImage(measurement)
     self.appearanceModel = appearanceModel
     self.appearanceModelJacobian = appearanceModelJacobian
     self.weight = weight
@@ -97,7 +97,7 @@ public struct AppearanceTrackingFactor<LatentCode: FixedSizeVector>: Linearizabl
     let region = OrientedBoundingBox(
       center: pose, rows: targetSize.0, cols: targetSize.1)
     let patch = measurement.patch(at: region, outputSize: (appearance.shape[0], appearance.shape[1]))
-    return Patch(weight * (appearance - patch))
+    return Patch(weight * (appearance - patch.tensor))
   }
 
   @derivative(of: errorVector)
@@ -124,9 +124,14 @@ public struct AppearanceTrackingFactor<LatentCode: FixedSizeVector>: Linearizabl
     let (actualAppearance, actualAppearance_H_pose) = measurement.patchWithJacobian(
       at: region, outputSize: (generatedAppearance.shape[0], generatedAppearance.shape[1]))
     assert(generatedAppearance_H_latent.shape == generatedAppearance.shape + [LatentCode.dimension])
+    let actualAppearance_H_pose_tensor = Tensor(stacking: [
+      actualAppearance_H_pose.dtheta.tensor,
+      actualAppearance_H_pose.du.tensor,
+      actualAppearance_H_pose.dv.tensor,
+    ], alongAxis: -1)
     return LinearizedAppearanceTrackingFactor<LatentCode>(
-      error: Patch(weight * (actualAppearance - generatedAppearance)),
-      errorVector_H_pose: -weight * actualAppearance_H_pose,
+      error: Patch(weight * (actualAppearance.tensor - generatedAppearance)),
+      errorVector_H_pose: -weight * actualAppearance_H_pose_tensor,
       errorVector_H_latent: weight * generatedAppearance_H_latent,
       edges: Variables.linearized(edges))
   }

--- a/Sources/SwiftFusion/Inference/ProbablisticTrackingFactor.swift
+++ b/Sources/SwiftFusion/Inference/ProbablisticTrackingFactor.swift
@@ -30,7 +30,7 @@ public struct ProbablisticTrackingFactor<
   public let edges: Variables.Indices
 
   /// The image containing the target.
-  public let measurement: Tensor<Double>
+  public let measurement: ArrayImage
 
   public let encoder: Encoder
 
@@ -63,7 +63,7 @@ public struct ProbablisticTrackingFactor<
     maxPossibleNegativity: Double = 1e10
   ) {
     self.edges = Tuple1(poseId)
-    self.measurement = measurement
+    self.measurement = ArrayImage(measurement)
     self.encoder = encoder
     self.patchSize = patchSize
     self.appearanceModelSize = appearanceModelSize
@@ -74,7 +74,7 @@ public struct ProbablisticTrackingFactor<
   @differentiable
   public func errorVector(_ pose: Pose2) -> Vector1 {
     let region = OrientedBoundingBox(center: pose, rows: patchSize.0, cols: patchSize.1)
-    let patch = measurement.patch(at: region, outputSize: appearanceModelSize)
+    let patch = measurement.patch(at: region, outputSize: appearanceModelSize).tensor
     let features = encoder.encode(patch.expandingShape(at: 0)).squeezingShape(at: 0)
 
     let result = maxPossibleNegativity + foregroundModel.negativeLogLikelihood(features) - backgroundModel.negativeLogLikelihood(features)

--- a/Sources/SwiftFusion/Inference/ProbablisticTrackingFactor.swift
+++ b/Sources/SwiftFusion/Inference/ProbablisticTrackingFactor.swift
@@ -54,7 +54,7 @@ public struct ProbablisticTrackingFactor<
   ///   - backgroundModel: A generative density on the background
   public init(
     _ poseId: TypedID<Pose2>,
-    measurement: Tensor<Double>,
+    measurement: Tensor<Float>,
     encoder: Encoder,
     patchSize: (Int, Int),
     appearanceModelSize: (Int, Int),
@@ -63,7 +63,7 @@ public struct ProbablisticTrackingFactor<
     maxPossibleNegativity: Double = 1e10
   ) {
     self.edges = Tuple1(poseId)
-    self.measurement = ArrayImage(Tensor<Float>(measurement))
+    self.measurement = ArrayImage(measurement)
     self.encoder = encoder
     self.patchSize = patchSize
     self.appearanceModelSize = appearanceModelSize

--- a/Sources/SwiftFusion/Inference/ProbablisticTrackingFactor.swift
+++ b/Sources/SwiftFusion/Inference/ProbablisticTrackingFactor.swift
@@ -63,7 +63,7 @@ public struct ProbablisticTrackingFactor<
     maxPossibleNegativity: Double = 1e10
   ) {
     self.edges = Tuple1(poseId)
-    self.measurement = ArrayImage(measurement)
+    self.measurement = ArrayImage(Tensor<Float>(measurement))
     self.encoder = encoder
     self.patchSize = patchSize
     self.appearanceModelSize = appearanceModelSize
@@ -74,7 +74,7 @@ public struct ProbablisticTrackingFactor<
   @differentiable
   public func errorVector(_ pose: Pose2) -> Vector1 {
     let region = OrientedBoundingBox(center: pose, rows: patchSize.0, cols: patchSize.1)
-    let patch = measurement.patch(at: region, outputSize: appearanceModelSize).tensor
+    let patch = Tensor<Double>(measurement.patch(at: region, outputSize: appearanceModelSize).tensor)
     let features = encoder.encode(patch.expandingShape(at: 0)).squeezingShape(at: 0)
 
     let result = maxPossibleNegativity + foregroundModel.negativeLogLikelihood(features) - backgroundModel.negativeLogLikelihood(features)

--- a/Sources/SwiftFusion/Inference/RawPixelTrackingFactor.swift
+++ b/Sources/SwiftFusion/Inference/RawPixelTrackingFactor.swift
@@ -31,9 +31,9 @@ public struct RawPixelTrackingFactor: LinearizableFactor1 {
   ///   - poseId: the id of the adjacent pose variable.
   ///   - measurement: the image containing the target.
   ///   - target: the pixels of the target.
-  public init(_ poseID: TypedID<Pose2>, measurement: Tensor<Double>, target: Tensor<Double>) {
+  public init(_ poseID: TypedID<Pose2>, measurement: Tensor<Float>, target: Tensor<Double>) {
     self.edges = Tuple1(poseID)
-    self.measurement = ArrayImage(Tensor<Float>(measurement))
+    self.measurement = ArrayImage(measurement)
     self.target = target
   }
 

--- a/Sources/SwiftFusion/Inference/RawPixelTrackingFactor.swift
+++ b/Sources/SwiftFusion/Inference/RawPixelTrackingFactor.swift
@@ -33,7 +33,7 @@ public struct RawPixelTrackingFactor: LinearizableFactor1 {
   ///   - target: the pixels of the target.
   public init(_ poseID: TypedID<Pose2>, measurement: Tensor<Double>, target: Tensor<Double>) {
     self.edges = Tuple1(poseID)
-    self.measurement = ArrayImage(measurement)
+    self.measurement = ArrayImage(Tensor<Float>(measurement))
     self.target = target
   }
 
@@ -42,7 +42,7 @@ public struct RawPixelTrackingFactor: LinearizableFactor1 {
   public func errorVector(_ pose: Pose2) -> TensorVector {
     let patch = measurement.patch(
       at: OrientedBoundingBox(center: pose, rows: target.shape[0], cols: target.shape[1]))
-    return TensorVector(patch.tensor - target)
+    return TensorVector(Tensor<Double>(patch.tensor) - target)
   }
 
   /// Returns a linear approximation to `self` at `x`.
@@ -50,13 +50,13 @@ public struct RawPixelTrackingFactor: LinearizableFactor1 {
     let pose = x.head
     let region = OrientedBoundingBox(center: pose, rows: target.shape[0], cols: target.shape[1])
     let (actualAppearance, actualAppearance_H_pose) = measurement.patchWithJacobian(at: region)
-    let actualAppearance_H_pose_tensor = Tensor(stacking: [
+    let actualAppearance_H_pose_tensor = Tensor<Double>(Tensor(stacking: [
       actualAppearance_H_pose.dtheta.tensor,
       actualAppearance_H_pose.du.tensor,
       actualAppearance_H_pose.dv.tensor,
-    ], alongAxis: -1)
+    ], alongAxis: -1))
     return LinearizedRawPixelTrackingFactor(
-      error: TensorVector(-(actualAppearance.tensor - target)),
+      error: TensorVector(-(Tensor<Double>(actualAppearance.tensor) - target)),
       errorVector_H_pose: actualAppearance_H_pose_tensor,
       edges: Variables.linearized(edges))
   }

--- a/Tests/BeeDatasetTests/BeePPCATests.swift
+++ b/Tests/BeeDatasetTests/BeePPCATests.swift
@@ -45,7 +45,7 @@ final class BeePPCATests: XCTestCase {
     // Tracking factor on the next frame
     fg.store(AppearanceTrackingFactor(
       poseId, latentId,
-      measurement: frames[1].mean(alongAxes: [2]),
+      measurement: Tensor<Float>(frames[1].mean(alongAxes: [2])),
       appearanceModel: ppca.decode, appearanceModelJacobian: { _ in ppca.W }))
 
     // Prior on latent initialized by PPCA decode on the previous frame
@@ -58,6 +58,6 @@ final class BeePPCATests: XCTestCase {
 
     let expected = Pose2(Rot2(-1.3365823146263909), Vector2(364.59389156740497, 176.17400761774488))
 
-    XCTAssertEqual(expected.localCoordinate(v[poseId]).norm, 0, accuracy: 1e-4)
+    XCTAssertEqual(expected.localCoordinate(v[poseId]).norm, 0, accuracy: 1e-2)
   }
 }

--- a/Tests/SwiftFusionTests/Inference/PPCATests.swift
+++ b/Tests/SwiftFusionTests/Inference/PPCATests.swift
@@ -27,7 +27,7 @@ class PPCATests: XCTestCase {
     let ppca = PPCA(W: factor.W, mu: factor.mu.tensor)
     let generic_factor = AppearanceTrackingFactor(
       TypedID<Pose2>(0), TypedID<Vector5>(0),
-      measurement: factor.measurement,
+      measurement: Tensor<Float>(factor.measurement),
       appearanceModel: ppca.decode, appearanceModelJacobian: { _ in ppca.W }
     )
 
@@ -55,7 +55,7 @@ class PPCATests: XCTestCase {
         assertEqual(
           custom.errorVector_linearComponent(v).tensor,
           autodiff.errorVector_linearComponent(v).tensor,
-          accuracy: 1e-6)
+          accuracy: 1e-4)
       }
 
       // Compare the vector-Jacobian-products (reverse derivative).
@@ -64,7 +64,7 @@ class PPCATests: XCTestCase {
         assertEqual(
           custom.errorVector_linearComponent_adjoint(e).flatTensor,
           autodiff.errorVector_linearComponent_adjoint(e).flatTensor,
-          accuracy: 1e-6)
+          accuracy: 1e-4)
       }
     }
   }
@@ -76,7 +76,7 @@ class PPCATests: XCTestCase {
     let ppca = PPCA(W: factor.W, mu: factor.mu.tensor)
     let generic_factor = AppearanceTrackingFactor(
       TypedID<Pose2>(0), TypedID<Vector5>(0),
-      measurement: factor.measurement,
+      measurement: Tensor<Float>(factor.measurement),
       appearanceModel: ppca.decode, appearanceModelJacobian: { _ in ppca.W }
     )
 
@@ -93,7 +93,7 @@ class PPCATests: XCTestCase {
       assertEqual(
         pbFactor(tangentVector).flatTensor,
         pbGeneric_factor(tangentVector).flatTensor,
-        accuracy: 1e-6)
+        accuracy: 1e-4)
     }
   }
 
@@ -125,7 +125,7 @@ class PPCATests: XCTestCase {
     let ppca = PPCA(W: ppca_factor.W.tiled(multiples: [1, 1, 3, 1]), mu: ppca_factor.mu.tensor.tiled(multiples: [1, 1, 3]))
     let generic_factor = AppearanceTrackingFactor(
       TypedID<Pose2>(0), TypedID<Vector5>(0),
-      measurement: ppca_factor.measurement.tiled(multiples: [1, 1, 3]),
+      measurement: Tensor<Float>(ppca_factor.measurement.tiled(multiples: [1, 1, 3])),
       appearanceModel: ppca.decode, appearanceModelJacobian: { _ in ppca.W }
     )
 

--- a/Tests/SwiftFusionTests/Inference/ProbablisticTrackingFactorTests.swift
+++ b/Tests/SwiftFusionTests/Inference/ProbablisticTrackingFactorTests.swift
@@ -23,7 +23,7 @@ final class ProbablisticTrackingFactorTests: XCTestCase {
     let poseId = v.store(Pose2())
 
     let _ = ProbablisticTrackingFactor(poseId,
-      measurement: Tensor<Double>([[0]]),
+      measurement: Tensor<Float>([[0]]),
       encoder: PPCA(latentSize: 10),
       patchSize: (10, 10),
       appearanceModelSize: (10, 1),
@@ -39,7 +39,7 @@ final class ProbablisticTrackingFactorTests: XCTestCase {
     let poseId = v.store(pose)
 
     /// Make a center one image
-    var image: Tensor<Double> = .init(zeros: [8, 8, 3])
+    var image: Tensor<Float> = .init(zeros: [8, 8, 3])
 
     image[4, 4, 0] = Tensor(1.0)
 
@@ -93,7 +93,7 @@ final class ProbablisticTrackingFactorTests: XCTestCase {
     let poseId = v.store(pose)
 
     /// Make a center one image
-    var image: Tensor<Double> = .init(zeros: [8, 8, 3])
+    var image: Tensor<Float> = .init(zeros: [8, 8, 3])
 
     image[4, 4, 0] = Tensor(1.0)
 


### PR DESCRIPTION
With this PR, `swift run -c release OISTVisualizationTool naive-rae --box-id 8 --verbose` goes from ~6 minutes to ~1 minute for me.

Only like 30s of that is graph inference time.

Main changes:
* Store frames as Float, and do patch in Float, but do all other operations in Double (so that I don't have to change everything to Double, which would be a huge change).
* Store ArrayImage as the measurement in factors instead of Tensor so that we don't have to convert the Tensor to an ArrayImage every time we take a patch.
* Makes `patch` use multithreading.