### PR TITLE
clean up and update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
           sudo xcode-select -s /Applications/Xcode_12.2.app
           wget https://storage.googleapis.com/swift-tensorflow-artifacts/macos-toolchains/swift-tensorflow-DEVELOPMENT-2020-08-26-a-osx.pkg
           sudo installer -pkg swift-tensorflow-DEVELOPMENT-2020-08-26-a-osx.pkg -target /
-          echo "::set-env name=PATH::/Library/Developer/Toolchains/swift-latest/usr/bin:${PATH}"
+          echo "PATH=/Library/Developer/Toolchains/swift-latest/usr/bin:${PATH}" >> $GITHUB_ENV
       - name: Build
         run: swift build -v
       - name: Test

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,26 +6,26 @@
         "repositoryURL": "https://github.com/saeta/penguin.git",
         "state": {
           "branch": "master",
-          "revision": "bb3118efc29779b123caa7a83f1694d9b92e9fa7",
+          "revision": "88bc092f4611e6acfa734b2e888880dcb65c0be1",
           "version": null
         }
       },
       {
         "package": "swift-argument-parser",
-        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "3e7d2fe99da091dcc1e4a7dd22fc3cfc2dca7937",
-          "version": "0.2.2"
+          "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
+          "version": "0.3.1"
         }
       },
       {
         "package": "Benchmark",
         "repositoryURL": "https://github.com/google/swift-benchmark.git",
         "state": {
-          "branch": "master",
-          "revision": "34c2f072feb6aa74dcc5f2d8e066fe4f2a0af73c",
-          "version": null
+          "branch": null,
+          "revision": "8e0ef8bb7482ab97dcd2cd1d6855bd38921c345d",
+          "version": "0.1.0"
         }
       },
       {
@@ -33,17 +33,8 @@
         "repositoryURL": "https://github.com/tensorflow/swift-models.git",
         "state": {
           "branch": null,
-          "revision": "99f323e550f7f0c3ed32d31a3c5d11a0f3c51e4b",
+          "revision": "b2fc0325bf9d476bf2d7a4cd0a09d36486c506e4",
           "version": null
-        }
-      },
-      {
-        "package": "SwiftProtobuf",
-        "repositoryURL": "https://github.com/apple/swift-protobuf.git",
-        "state": {
-          "branch": null,
-          "revision": "0279688c9fc5a40028e1b5bb0cb56534a45a6020",
-          "version": "1.12.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -21,13 +21,13 @@ let package = Package(
   dependencies: [
     // Dependencies declare other packages that this package depends on.
     // .package(url: /* package url */, from: "1.0.0"),
-    .package(url: "https://github.com/google/swift-benchmark.git", .branch("master")),
+    .package(url: "https://github.com/google/swift-benchmark.git", from: "0.1.0"),
 
     .package(url: "https://github.com/saeta/penguin.git", .branch("master")),
 
     .package(url: "https://github.com/ProfFan/tensorboardx-s4tf.git", from: "0.1.3"),
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("swift-5.2-branch")),
-    .package(url: "https://github.com/tensorflow/swift-models.git", .branch("99f323e550f7f0c3ed32d31a3c5d11a0f3c51e4b")),
+    .package(url: "https://github.com/tensorflow/swift-models.git", .branch("b2fc0325bf9d476bf2d7a4cd0a09d36486c506e4")),
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,7 @@ let package = Package(
 
     .package(url: "https://github.com/ProfFan/tensorboardx-s4tf.git", from: "0.1.3"),
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("swift-5.2-branch")),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "0.3.0"),
     .package(url: "https://github.com/tensorflow/swift-models.git", .branch("b2fc0325bf9d476bf2d7a4cd0a09d36486c506e4")),
   ],
   targets: [

--- a/Sources/BeeDataset/BeeFrames.swift
+++ b/Sources/BeeDataset/BeeFrames.swift
@@ -59,6 +59,7 @@ public struct BeeFrames: RandomAccessCollection {
   public func index(after i: Int) -> Int { i + 1 }
 
   public subscript(index: Int) -> Tensor<Double> {
-    return Tensor<Double>(Image(jpeg: directory.appendingPathComponent("frame\(index + 1).png")).tensor)
+    return Tensor<Double>(
+      Image(contentsOf: directory.appendingPathComponent("frame\(index + 1).png")).tensor)
   }
 }

--- a/Sources/BeeDataset/BeeVideo.swift
+++ b/Sources/BeeDataset/BeeVideo.swift
@@ -59,7 +59,7 @@ extension BeeVideo {
     func loadFrame(_ index: Int) -> Tensor<Double>? {
       let path = directory.appendingPathComponent("frame\(index).jpeg")
       guard FileManager.default.fileExists(atPath: path.path) else { return nil }
-      return Tensor<Double>(Image(jpeg: path).tensor)
+      return Tensor<Double>(Image(contentsOf: path).tensor)
     }
     while let frame = loadFrame(self.frames.count) {
       self.frames.append(frame)

--- a/Tests/SwiftFusionTests/Image/PatchTests.swift
+++ b/Tests/SwiftFusionTests/Image/PatchTests.swift
@@ -44,7 +44,8 @@ final class PatchTests: XCTestCase {
   /// Test cropping an example image.
   func testExampleImage() {
     let dataDir = URL.sourceFileDirectory().appendingPathComponent("data")
-    let image = Tensor<Double>(Image(jpeg: dataDir.appendingPathComponent("test.png")).tensor)
+    let image = Tensor<Double>(
+      Image(contentsOf: dataDir.appendingPathComponent("test.png")).tensor)
     let obb = OrientedBoundingBox(
       center: Pose2(Rot2(-20 * .pi / 180), Vector2(35, 65)), rows: 20, cols: 40)
     let patch = image.patch(at: obb)
@@ -52,7 +53,7 @@ final class PatchTests: XCTestCase {
     // Created using ImageMagick:
     //   convert -distort SRT 35,65,20 -crop 40x20+15+55 test.png cropped.png
     let expectedPatch =
-      Tensor<Double>(Image(jpeg: dataDir.appendingPathComponent("cropped.png")).tensor)
+      Tensor<Double>(Image(contentsOf: dataDir.appendingPathComponent("cropped.png")).tensor)
 
     // The actual and expected are pretty close, but not precisely the same.
     // TODO: Investigate the difference.


### PR DESCRIPTION
* github actions: stop using set-env because it got deprecated (https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)
* swift-benchmark: use version instead of commit, so that we don't break when dependencies update their version of swift-benchmark
* swift-models: update to newer commit (can't use version because swift-models doesn't have version tags yet)
  * needed to update some calls to a newer signature
* swift-argument-parser: added dependency. we don't directly depend on it but we transitively depend on it, and for some reason swiftpm is getting confused unless I add it to the dependency list.