### PR TITLE
Add tensorflow/swift-apis as a SwiftPM dependency.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "LoggerKit",
+        "repositoryURL": "https://github.com/pvieito/LoggerKit.git",
+        "state": {
+          "branch": "master",
+          "revision": "6c0f5ac4d5561086fe6e6381fa35eceb108f1c7a",
+          "version": null
+        }
+      },
+      {
         "package": "Penguin",
         "repositoryURL": "https://github.com/saeta/penguin.git",
         "state": {
@@ -29,12 +38,30 @@
         }
       },
       {
-        "package": "swift-argument-parser",
-        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
+        "package": "PythonKit",
+        "repositoryURL": "https://github.com/pvieito/PythonKit.git",
+        "state": {
+          "branch": "master",
+          "revision": "260ae70cddeadf42a7a0edce0dfc7f00343b5d1a",
+          "version": null
+        }
+      },
+      {
+        "package": "Rainbow",
+        "repositoryURL": "https://github.com/onevcat/Rainbow",
         "state": {
           "branch": null,
-          "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
-          "version": "0.3.1"
+          "revision": "626c3d4b6b55354b4af3aa309f998fae9b31a3d9",
+          "version": "3.2.0"
+        }
+      },
+      {
+        "package": "TensorFlow",
+        "repositoryURL": "https://github.com/tensorflow/swift-apis",
+        "state": {
+          "branch": "main",
+          "revision": "230d48576fdb80955613b3013a84561be0f92e94",
+          "version": null
         }
       },
       {
@@ -47,21 +74,12 @@
         }
       },
       {
-        "package": "swift-models",
-        "repositoryURL": "https://github.com/tensorflow/swift-models.git",
+        "package": "swift-numerics",
+        "repositoryURL": "https://github.com/apple/swift-numerics",
         "state": {
-          "branch": null,
-          "revision": "b2fc0325bf9d476bf2d7a4cd0a09d36486c506e4",
+          "branch": "main",
+          "revision": "4a2cbc186b1f8cbbc1ace12cef43d65784b2559e",
           "version": null
-        }
-      },
-      {
-        "package": "SwiftProtobuf",
-        "repositoryURL": "https://github.com/apple/swift-protobuf.git",
-        "state": {
-          "branch": null,
-          "revision": "da9a52be9cd36c63993291ce3f1b65dafcd1e826",
-          "version": "1.14.0"
         }
       },
       {
@@ -75,11 +93,11 @@
       },
       {
         "package": "TensorBoardX",
-        "repositoryURL": "https://github.com/ProfFan/tensorboardx-s4tf.git",
+        "repositoryURL": "https://github.com/dan-zheng/tensorboardx-s4tf.git",
         "state": {
-          "branch": null,
-          "revision": "02838220694f4236ba84a83856581b76ee9cf1bc",
-          "version": "0.1.3"
+          "branch": "tensorflow-as-swiftpm-dependency",
+          "revision": "22852fff51e32640d4aab2bac1510ab1ebdc25df",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -21,16 +21,15 @@ let package = Package(
       targets: ["Pose3SLAMG2O"])
   ],
   dependencies: [
-    // Dependencies declare other packages that this package depends on.
-    // .package(url: /* package url */, from: "1.0.0"),
     .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark.git", from: "0.1.0"),
 
     .package(name: "Penguin", url: "https://github.com/saeta/penguin.git", .branch("main")),
 
-    .package(name: "TensorBoardX", url: "https://github.com/ProfFan/tensorboardx-s4tf.git", from: "0.1.3"),
+    .package(name: "TensorBoardX", url: "https://github.com/dan-zheng/tensorboardx-s4tf.git", .branch("tensorflow-as-swiftpm-dependency")),
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("swift-5.2-branch")),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "0.3.0"),
     .package(name: "Plotly", url: "https://github.com/vojtamolda/Plotly.swift", from: "0.4.0"),
+    .package(name: "TensorFlow", url: "https://github.com/tensorflow/swift-apis", .branch("main")),
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -40,7 +39,8 @@ let package = Package(
       dependencies: [
         .product(name: "PenguinStructures", package: "Penguin"),
         .product(name: "PenguinTesting", package: "Penguin"),
-        .product(name: "PenguinParallelWithFoundation", package: "Penguin")
+        .product(name: "PenguinParallelWithFoundation", package: "Penguin"),
+        .product(name: "TensorFlow", package: "TensorFlow"),
       ],
       exclude: [
         "Core/VectorN.swift.gyb",
@@ -130,7 +130,7 @@ let package = Package(
       ]),
     .target(
       name: "ModelSupport",
-      dependencies: ["STBImage"]),
+      dependencies: ["TensorFlow", "STBImage"]),
     .target(
       name: "STBImage",
       exclude: 


### PR DESCRIPTION
## Motivation

This enables building SwiftFusion using stock toolchains from [swift.org/download](https://swift.org/download/#snapshots).

`swift build` will clone and build `tensorflow/swift-apis` as a regular SwiftPM dependency. Eventually, we would like to stop releasing custom toolchains bundled with pre-installed `tensorflow/swift-apis`.

## Build instructions

It is possible to build `tensorflow/swift-apis` and dependencies like SwiftFusion using stock toolchains by installing [pre-built X10 libraries](https://github.com/tensorflow/swift-apis/blob/main/Documentation/Development.md#option-2-use-a-prebuilt-version-of-x10-1) (currently available only for macOS and Windows).

After installing (e.g. to `$HOME/Library` on macOS), build with SwiftPM via the following:

```console
$ swift build -Xcc -I$HOME/Library/tensorflow-2.4.0/usr/include -Xlinker -L$HOME/Library/tensorflow-2.4.0/usr/lib -Xswiftc -DTENSORFLOW_USE_STANDARD_TOOLCHAIN
```

`swift test` is known not to work on macOS for `tensorflow/swift-apis` and dependencies due to SR-14008: `Library not loaded: /usr/lib/swift/libswift_Differentiation.dylib`.


## Testing

Before merging, let's verify that `swift build`, `swift run`, and `swift test` works for [swift.org/download](https://swift.org/download/#snapshots) toolchains across platforms, and update GitHub Actions CI so that it passes:

- [x] macOS: [swift-DEVELOPMENT-SNAPSHOT-2021-01-04-a-osx.pkg](https://swift.org/builds/development/xcode/swift-DEVELOPMENT-SNAPSHOT-2021-01-04-a/swift-DEVELOPMENT-SNAPSHOT-2021-01-04-a-osx.pkg)
    - `swift run` and `swift test` currently both fail due to [SR-14008](https://bugs.swift.org/browse/SR-14008):
 
<details>
<p>

```console
$ swift run Pose3SLAMG2O -Xcc -I$HOME/Library/tensorflow-2.4.0/usr/include -Xlinker -L$HOME/Library/tensorflow-2.4.0/usr/lib -Xswiftc -DTENSORFLOW_USE_STANDARD_TOOLCHAIN
...
Everything is already up-to-date
dyld: Library not loaded: /usr/lib/swift/libswift_Differentiation.dylib
  Referenced from: /Users/danielzheng/SwiftFusion/.build/x86_64-apple-macosx/debug/Pose3SLAMG2O
  Reason: image not found
[1]    79788 abort      swift run Pose3SLAMG2O -Xcc -I$HOME/Library/tensorflow-2.4.0/usr/include
```
```console
$ swift test -Xcc -I$HOME/Library/tensorflow-2.4.0/usr/include -Xlinker -L$HOME/Library/tensorflow-2.4.0/usr/lib -Xswiftc -DTENSORFLOW_USE_STANDARD_TOOLCHAIN
...
Everything is already up-to-date
2021-01-08 07:14:48.425 xctest[79757:2116295] The bundle “SwiftFusionPackageTests.xctest” couldn’t be loaded because it is damaged or missing necessary resources. Try reinstalling the bundle.
2021-01-08 07:14:48.425 xctest[79757:2116295] (dlopen_preflight(/Users/danielzheng/SwiftFusion/.build/x86_64-apple-macosx/debug/SwiftFusionPackageTests.xctest/Contents/MacOS/SwiftFusionPackageTests): Library not loaded: /usr/lib/swift/libswift_Differentiation.dylib
  Referenced from: /Users/danielzheng/SwiftFusion/.build/x86_64-apple-macosx/debug/SwiftFusionPackageTests.xctest/Contents/MacOS/SwiftFusionPackageTests
  Reason: image not found)
```
</p>
</details>

- [ ] Ubuntu 18.04: [swift-DEVELOPMENT-SNAPSHOT-2021-01-04-a-ubuntu18.04.tar.gz](https://swift.org/builds/development/ubuntu1804/swift-DEVELOPMENT-SNAPSHOT-2021-01-04-a/swift-DEVELOPMENT-SNAPSHOT-2021-01-04-a-ubuntu18.04.tar.gz)
- [ ] Windows 10: [swift-DEVELOPMENT-SNAPSHOT-2021-01-04-a-windows10.exe](swift-DEVELOPMENT-SNAPSHOT-2021-01-04-a-windows10.exe)