### PR TITLE
Removed the use of zeroTangentVector from PinholeCamera

### DIFF
--- a/Sources/SwiftFusion/Geometry/Cal3_S2.swift
+++ b/Sources/SwiftFusion/Geometry/Cal3_S2.swift
@@ -39,6 +39,11 @@ extension Cal3_S2: CameraCalibration {
   }
 }
 
+extension Cal3_S2 {
+  public func zeroTangentVector() -> Cal3_S2.TangentVector {
+    return Vector5(0.0, 0.0, 0.0, 0.0, 0.0)
+  }
+}
 
 /// Manifold coordinate for Cal3_S2.
 public struct Cal3_S2Coordinate: Equatable {

--- a/Sources/SwiftFusion/Geometry/CameraCalibration.swift
+++ b/Sources/SwiftFusion/Geometry/CameraCalibration.swift
@@ -12,4 +12,6 @@ public protocol CameraCalibration: Differentiable {
   /// Converts from normalized coordinate to image coordinate.
   @differentiable
   func uncalibrate(_ np: Vector2) -> Vector2
+
+  func zeroTangentVector() -> TangentVector
 }

--- a/Sources/SwiftFusion/Geometry/PinholeCamera.swift
+++ b/Sources/SwiftFusion/Geometry/PinholeCamera.swift
@@ -78,7 +78,7 @@ extension PinholeCamera {
           p.x * (R[0, 2] - u * R[2, 2]) + p.y * (R[1, 2] - v * R[2, 2]))
 
         return (
-          TangentVector(wTc: dpose, calibration: calibration.zeroTangentVector),
+          TangentVector(wTc: dpose, calibration: calibration.zeroTangentVector()),
           dpoint)
       }
     )

--- a/Tests/SwiftFusionTests/Geometry/PinholeCameraTests.swift
+++ b/Tests/SwiftFusionTests/Geometry/PinholeCameraTests.swift
@@ -79,12 +79,12 @@ final class PinholeCameraTests: XCTestCase {
     let dxExpected = (
       PinholeCamera<Cal3_S2>.TangentVector(
         wTc: Vector6(-1.0, -2.0, -1.0, -1.0, 0.0, 1.0), 
-        calibration: K.zeroTangentVector),
+        calibration: K.zeroTangentVector()),
       Vector3(1.0, 0.0, 1.0))
     let dyExpected = (
       PinholeCamera<Cal3_S2>.TangentVector(
         wTc: Vector6(2.0, 1.0, -1.0, 0.0, -1.0, -1.0), 
-        calibration: K.zeroTangentVector),
+        calibration: K.zeroTangentVector()),
       Vector3(0.0, -1.0, -1.0))
 
     assertAllKeyPathEqual(p, Vector2(1.0, -1.0), accuracy: 1e-10)


### PR DESCRIPTION
@dan-zheng I've manually implemented the zeroTangentVector functionality for the CameraCalibration object and Cal3_S2 which inherets it. I've run the suite of tests and it works well.

There is still one instance of zeroTangentVector that is being used in the codebase at https://github.com/borglab/SwiftFusion/blob/9eca609c10cdaeb19e34ca047363c183ddad7c3e/Sources/SwiftFusion/Core/LieGroup.swift#L170 that I've had some trouble replacing, but I'll work on it as well. All other uses in the codebase are not being used as Richard Wei mentioned in his issue.

Let me know your thoughts on the current implementation, as well as if you have suggestions on removing the LieGroup zeroTangentVector.